### PR TITLE
Added linter to python3.8 unit tests

### DIFF
--- a/azext_edge/edge/providers/checks.py
+++ b/azext_edge/edge/providers/checks.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------------------------
 
 from functools import partial
-from time import sleep
 from typing import Any, Dict, List, Optional, Tuple
 
 from knack.log import get_logger
@@ -50,6 +49,7 @@ def run_checks(
     result = {}
 
     # with console.status("Analyzing cluster...") as status:
+    #    from time import sleep
     #    sleep(0.25)
 
     if pre_deployment:

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ description =
 # tox-gh matrix (github action -> tox python environment)
 [gh]
 python =
-    3.8 = py38
+    3.8 = py38, lint
     3.9 = py39
     3.10 = py310
     3.11 = py311


### PR DESCRIPTION
Also fixed one minor linter error

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
