### PR TITLE
fix: opcua support bundle to include connector pod collateral.

### DIFF
--- a/azext_edge/edge/providers/orchestration/base.py
+++ b/azext_edge/edge/providers/orchestration/base.py
@@ -48,7 +48,7 @@ class ManifestBuilder:
         self.version_def = version_def
 
         self.last_sync_priority: int = 0
-        self.target_name = f"{self.cluster_name}-azedge-init-target"
+        self.target_name = f"{self.cluster_name.lower()}-azedge-init-target"
         self.symphony_components: List[dict] = []
         self.resources: List[dict] = []
         self.extension_ids: List[str] = []


### PR DESCRIPTION
* Existing support bundle did not capture connector pod definitions or logs since a consistent label for them does not exist. Instead apollo deployments should be used to determine applicable pod labels. 