### PR TITLE
fix(ci): pipeline approval logic fix

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -37,7 +37,8 @@ jobs:
   #   uses: ./.github/workflows/smoke_test.yml
   approval:
     needs: [security, build, test, linter]
-    if: ${{ (success() || inputs.continue-on-fail == 'true') && inputs.release_strategy != 'none' }}
+    # as long as build worked, our break-glass can skip other checks
+    if: github.event.inputs.release_strategy != 'none' && (success() || (needs.build.result == 'success' && github.event.inputs.continue-on-fail == 'true'))
     environment: production
     runs-on: ubuntu-latest
     steps:
@@ -45,20 +46,20 @@ jobs:
         run: |
           echo "Approved"
           echo "Release Strategy: ${{ inputs.release_strategy }}"
-          if [ "${{ inputs.release_strategy }}" == "upload-wheel"]; then
+          if [ "${{ inputs.release_strategy }}" == "upload-wheel" ]; then
             echo "Wheel will be uploaded to storage account."
-          elif [ "${{ inputs.release_strategy }}" == "prod-release"]; then
+          elif [ "${{ inputs.release_strategy }}" == "prod-release" ]; then
             echo "Wheel will be uploaded to storage account after drafting a github release"
           fi
   # occurs when release_strategy is prod-release
   draft_github_release:
     needs: [approval]
-    if: needs.approval.result == 'success' && inputs.release_strategy == 'prod-release'
+    if: success() || (needs.approval.result == 'success' && github.event.inputs.release_strategy == 'prod-release')
     uses: ./.github/workflows/stage_release.yml
     secrets: inherit
   # occurs when release_strategy is not 'none'
   upload_wheel:
     needs: [approval]
-    if: needs.approval.result == 'success' && inputs.release_strategy != 'none'
+    if: success() || (needs.approval.result == 'success' && github.event.inputs.release_strategy != 'none')
     uses: ./.github/workflows/upload_wheel.yml
     secrets: inherit


### PR DESCRIPTION
Will finally fix the `continue-on-fail` and `approval` fiasco.

`inputs.continue-on-fail` was being processed in the conditional `if` step as `false`, while `github.event.inputs.continue-on-fail` was the truthy value.

This ensures (from the release workflow level) that inputs are processed as the values that they are set to in the "event" - in this case, a release workflow trigger.

It also attempts to short-circuit the approval job logic as:
- `github.event.inputs.release_strategy` is not `none` AND
  - all needs have succeeded (`success()`) OR 
  - at least the build has succeeded (`needs.build.result == 'success'`) AND break-glass is enabled (`github.event.inputs.continue-on-fail == 'true'`)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
