### PR TITLE
feat: add missing daemon to akri bundle

### DIFF
--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 
 AKRI_NAME_LABEL = "name in (aio-akri-agent, akri-opcua-asset-discovery)"
 AKRI_SERVICE_LABEL = "service in (aio-akri-metrics)"
-AKRI_PREFIXES = ["aio-akri-"]
+AKRI_PREFIXES = ["aio-akri-", "akri-"]
 
 
 def fetch_pods(since_seconds: int = 60 * 60 * 24):

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -342,7 +342,11 @@ def mocked_list_daemonsets(mocked_client):
         # @vilit - also akri
         daemonset_names = ["mock_daemonset"]
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            daemonset_names.extend(["aio-akri-agent-daemonset", "svclb-aio-lnm-operator"])
+            daemonset_names.extend([
+                "aio-akri-agent-daemonset",
+                "akri-opcua-asset-discovery-daemonset",
+                "svclb-aio-lnm-operator"
+            ])
 
         daemonset_list = []
         for name in daemonset_names:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -336,7 +336,7 @@ def test_create_bundle(
                 mocked_zipfile,
                 label_selector=None,
                 resource_api=AKRI_API_V0,
-                mock_names=["aio-akri-agent-daemonset"],
+                mock_names=["aio-akri-agent-daemonset", "akri-opcua-asset-discovery-daemonset"],
             )
 
         if api in [LNM_API_V1B1]:


### PR DESCRIPTION
Add the lost child to akri

![image](https://github.com/Azure/azure-edge-cli-extension/assets/73560279/5bcd0ca4-429c-4f3c-b213-929189db53f1)

note that the only differences between init runs is that if you have simulate plc, an akri instance is created. Otherwise adding assets, etc does not affect this.

![image](https://github.com/Azure/azure-edge-cli-extension/assets/73560279/3391e6d4-c3d3-4149-a6f3-fee4f5445961)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
