### PR TITLE
fix: check for asset property existance

### DIFF
--- a/azext_edge/edge/providers/assets.py
+++ b/azext_edge/edge/providers/assets.py
@@ -368,7 +368,7 @@ class AssetProvider():
             resource_group_name=resource_group_name
         )
 
-        return asset["properties"][sub_point_type]
+        return asset["properties"].get(sub_point_type, [])
 
     def remove_sub_point(
         self,

--- a/azext_edge/tests/edge/asset/conftest.py
+++ b/azext_edge/tests/edge/asset/conftest.py
@@ -44,13 +44,11 @@ MINIMUM_ASSET = {
     "name": "props-test-min",
     "properties": {
         "assetEndpointProfileUri": generate_generic_id(),
-        "dataPoints": [],
         "defaultDataPointsConfiguration": "{\"publishingInterval\": 1000, \"samplingInterval\": 500, "
         "\"queueSize\": 1}",
         "defaultEventsConfiguration": "{\"publishingInterval\": 1000, \"samplingInterval\": 500, \"queueSize\": 1}",
         "displayName": "props-test-min",
         "enabled": True,
-        "events": [],
         "externalAssetId": generate_generic_id(),
         "provisioningState": "Accepted",
         "uuid": generate_generic_id(),

--- a/azext_edge/tests/edge/asset/test_data_points_unit.py
+++ b/azext_edge/tests/edge/asset/test_data_points_unit.py
@@ -82,7 +82,7 @@ def test_add_asset_data_point(
     # Check update request
     request_data_points = call_kwargs["parameters"]["properties"]["dataPoints"]
 
-    assert request_data_points[:-1] == original_asset["properties"]["dataPoints"]
+    assert request_data_points[:-1] == original_asset["properties"].get("dataPoints", [])
     added_event = request_data_points[-1]
     assert added_event["capabilityId"] == (capability_id or name)
     assert added_event["name"] == name
@@ -112,7 +112,7 @@ def test_list_asset_data_points(mocked_cmd, mocked_resource_management_client):
     )
     mocked_resource_management_client.resources.get.assert_called_once()
     original_asset = mocked_resource_management_client.resources.get.return_value.as_dict.return_value
-    assert result_events == original_asset["properties"]["dataPoints"]
+    assert result_events == original_asset["properties"].get("dataPoints", [])
 
 
 @pytest.mark.parametrize("mocked_resource_management_client", [

--- a/azext_edge/tests/edge/asset/test_events_unit.py
+++ b/azext_edge/tests/edge/asset/test_events_unit.py
@@ -82,7 +82,7 @@ def test_add_asset_event(
     # Check update request
     request_events = call_kwargs["parameters"]["properties"]["events"]
 
-    assert request_events[:-1] == original_asset["properties"]["events"]
+    assert request_events[:-1] == original_asset["properties"].get("events", [])
     added_event = request_events[-1]
     assert added_event["capabilityId"] == (capability_id or name)
     assert added_event["name"] == name
@@ -112,7 +112,7 @@ def test_list_asset_events(mocked_cmd, mocked_resource_management_client):
     )
     mocked_resource_management_client.resources.get.assert_called_once()
     original_asset = mocked_resource_management_client.resources.get.return_value.as_dict.return_value
-    assert result_events == original_asset["properties"]["events"]
+    assert result_events == original_asset["properties"].get("events", [])
 
 
 @pytest.mark.parametrize("mocked_resource_management_client", [


### PR DESCRIPTION
Life is hard these days
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/b08fb14e-10e4-417f-a424-39fec40cfb53)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
