### PR TITLE
feat: Add scale check to lnm

### DIFF
--- a/azext_edge/edge/providers/check/base.py
+++ b/azext_edge/edge/providers/check/base.py
@@ -1,8 +1,8 @@
 # coding=utf-8
-# --------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Private distribution for NDA customers only. Governed by license terms at https://preview.e4k.dev/docs/use-terms/
-# --------------------------------------------------------------------------------------------
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
 
 from functools import partial
 from itertools import groupby

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -1,8 +1,8 @@
 # coding=utf-8
-# --------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Private distribution for NDA customers only. Governed by license terms at https://preview.e4k.dev/docs/use-terms/
-# --------------------------------------------------------------------------------------------
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
 
 from typing import Any, Dict, List, Tuple
 
@@ -48,7 +48,7 @@ def check_lnm_deployment(
 ) -> None:
     evaluate_funcs = {
         LnmResourceKinds.LNM: evaluate_lnms,
-        # LnmResourceKinds.SCALE: evaluate_scales,
+        LnmResourceKinds.SCALE: evaluate_scales,
     }
 
     check_post_deployment(

--- a/azext_edge/tests/edge/checks/test_lnm_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_lnm_checks_unit.py
@@ -1,8 +1,8 @@
 # coding=utf-8
-# --------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Private distribution for NDA customers only. Governed by license terms at https://preview.e4k.dev/docs/use-terms/
-# --------------------------------------------------------------------------------------------
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
 
 
 from azext_edge.edge.providers.check.common import ResourceOutputDetailLevel


### PR DESCRIPTION
Scale is a Kubernetes specific subresource that is enabled in lnmz resource kind, therefore the way of getting the resource is a little different
<img width="418" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/c0c876ef-90a7-4d69-847c-ad5ace44ff9f">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
