### PR TITLE
fix: Add exclude subresource list and exclude subresources showing from lnm check

### DIFF
--- a/azext_edge/edge/providers/check/base.py
+++ b/azext_edge/edge/providers/check/base.py
@@ -59,13 +59,13 @@ def check_post_deployment(
     as_list: bool = False,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
     resource_kinds: List[str] = None,
-    exclude_subresources: bool = False,
+    excluded_subresources: List[str] = None,
 ) -> None:
     check_resources = {}
     for resource in resource_kinds_enum:
         check_resources[resource] = not resource_kinds or resource.value in resource_kinds
 
-    resource_enumeration, api_resources = enumerate_ops_service_resources(api_info, check_name, check_desc, as_list, exclude_subresources)
+    resource_enumeration, api_resources = enumerate_ops_service_resources(api_info, check_name, check_desc, as_list, excluded_subresources)
     result["postDeployment"].append(resource_enumeration)
     lowercase_api_resources = {k.lower(): v for k, v in api_resources.items()}
 
@@ -176,7 +176,7 @@ def enumerate_ops_service_resources(
     check_name: str,
     check_desc: str,
     as_list: bool = False,
-    exclude_subresources: bool = False,
+    excluded_subresources: List[str] = None,
 ) -> Tuple[dict, dict]:
 
     resource_kind_map = {}
@@ -202,8 +202,7 @@ def enumerate_ops_service_resources(
 
     for resource in api_resources.resources:
         r: V1APIResource = resource
-        is_subresource = "/" in r.name
-        if is_subresource and exclude_subresources:
+        if excluded_subresources and r.name in excluded_subresources:
             continue
         if r.kind not in resource_kind_map:
             resource_kind_map[r.kind] = True

--- a/azext_edge/edge/providers/check/base.py
+++ b/azext_edge/edge/providers/check/base.py
@@ -58,8 +58,8 @@ def check_post_deployment(
     evaluate_funcs: Dict[ListableEnum, Callable],
     as_list: bool = False,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
-    resource_kinds: List[str] = None,
-    excluded_subresources: List[str] = None,
+    resource_kinds: Optional[List[str]] = None,
+    excluded_subresources: Optional[List[str]] = None,
 ) -> None:
     check_resources = {}
     for resource in resource_kinds_enum:
@@ -176,7 +176,7 @@ def enumerate_ops_service_resources(
     check_name: str,
     check_desc: str,
     as_list: bool = False,
-    excluded_subresources: List[str] = None,
+    excluded_subresources: Optional[List[str]] = None,
 ) -> Tuple[dict, dict]:
 
     resource_kind_map = {}

--- a/azext_edge/edge/providers/check/base.py
+++ b/azext_edge/edge/providers/check/base.py
@@ -59,7 +59,7 @@ def check_post_deployment(
     as_list: bool = False,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
     resource_kinds: Optional[List[str]] = None,
-    excluded_subresources: Optional[List[str]] = None,
+    excluded_resources: Optional[List[str]] = None,
 ) -> None:
     check_resources = {}
     for resource in resource_kinds_enum:
@@ -176,7 +176,7 @@ def enumerate_ops_service_resources(
     check_name: str,
     check_desc: str,
     as_list: bool = False,
-    excluded_subresources: Optional[List[str]] = None,
+    excluded_resources: Optional[List[str]] = None,
 ) -> Tuple[dict, dict]:
 
     resource_kind_map = {}
@@ -202,7 +202,7 @@ def enumerate_ops_service_resources(
 
     for resource in api_resources.resources:
         r: V1APIResource = resource
-        if excluded_subresources and r.name in excluded_subresources:
+        if excluded_resources and r.name in excluded_resources:
             continue
         if r.kind not in resource_kind_map:
             resource_kind_map[r.kind] = True

--- a/azext_edge/edge/providers/check/base.py
+++ b/azext_edge/edge/providers/check/base.py
@@ -65,7 +65,7 @@ def check_post_deployment(
     for resource in resource_kinds_enum:
         check_resources[resource] = not resource_kinds or resource.value in resource_kinds
 
-    resource_enumeration, api_resources = enumerate_ops_service_resources(api_info, check_name, check_desc, as_list, excluded_subresources)
+    resource_enumeration, api_resources = enumerate_ops_service_resources(api_info, check_name, check_desc, as_list, excluded_resources)
     result["postDeployment"].append(resource_enumeration)
     lowercase_api_resources = {k.lower(): v for k, v in api_resources.items()}
 

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -156,6 +156,11 @@ LNM_POD_CONDITION_TEXT_MAP = {
     "PodScheduled": "Pod Scheduled",
 }
 
+LNM_EXCLUDED_SUBRESOURCE = [
+    "lnmz/scale",
+    "lnmz/status",
+]
+
 # Check constants
 ALL_NAMESPACES_TARGET = '_all_'
 

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -59,7 +59,7 @@ def check_lnm_deployment(
         as_list=as_list,
         detail_level=detail_level,
         resource_kinds=resource_kinds,
-        no_subresources=True,
+        exclude_subresources=True,
     )
 
 

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -25,6 +25,7 @@ from ...common import CheckTaskStatus
 from .common import (
     AIO_LNM_PREFIX,
     LNM_ALLOWLIST_PROPERTIES,
+    LNM_EXCLUDED_SUBRESOURCE,
     LNM_IMAGE_PROPERTIES,
     LNM_POD_CONDITION_TEXT_MAP,
     LNM_REST_PROPERTIES,
@@ -59,7 +60,7 @@ def check_lnm_deployment(
         as_list=as_list,
         detail_level=detail_level,
         resource_kinds=resource_kinds,
-        exclude_subresources=True,
+        excluded_subresources=LNM_EXCLUDED_SUBRESOURCE,
     )
 
 

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -60,7 +60,7 @@ def check_lnm_deployment(
         as_list=as_list,
         detail_level=detail_level,
         resource_kinds=resource_kinds,
-        excluded_subresources=LNM_EXCLUDED_SUBRESOURCE,
+        excluded_resources=LNM_EXCLUDED_SUBRESOURCE,
     )
 
 

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -58,7 +58,8 @@ def check_lnm_deployment(
         evaluate_funcs=evaluate_funcs,
         as_list=as_list,
         detail_level=detail_level,
-        resource_kinds=resource_kinds
+        resource_kinds=resource_kinds,
+        no_subresources=True,
     )
 
 

--- a/azext_edge/edge/providers/edge_api/lnm.py
+++ b/azext_edge/edge/providers/edge_api/lnm.py
@@ -10,7 +10,6 @@ from ...common import ListableEnum
 
 class LnmResourceKinds(ListableEnum):
     LNM = "lnm"
-    SCALE = "scale"
 
 
 LNM_API_V1B1 = EdgeResourceApi(group="layerednetworkmgmt.iotoperations.azure.com", version="v1beta1", moniker="lnm")

--- a/azext_edge/tests/edge/checks/conftest.py
+++ b/azext_edge/tests/edge/checks/conftest.py
@@ -67,8 +67,7 @@ def mock_resource_types(mocker, ops_service):
         patched.return_value = (
             {},
             {
-                "Lnm": [{}],
-                "Scale": [{}]
+                "Lnm": [{}]
             }
         )
 

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -141,7 +141,6 @@ def mocked_cluster_resources(request, mocker):
 
         if r == LNM_API_V1B1:
             v1_resources.append(_get_api_resource("Lnm"))
-            v1_resources.append(_get_api_resource("Scale"))
 
         if r == DEVICEREGISTRY_API_V1:
             v1_resources.append(_get_api_resource("Asset"))


### PR DESCRIPTION
1. add exclude subresource flag to enumerate_ops_service_resources so individual service can decide to exclude enumerate subresource or not
2. as discussion we will hide all subresources from showing under lnm service check (current behaviour -- only scale is showing but status is not)

After fix:
<img width="691" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/28534ae9-0b34-47a3-8488-0b36fcf16586">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
