### PR TITLE
feat: --mq-traces in support bundle operation

### DIFF
--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -15,6 +15,7 @@ from .providers.base import DEFAULT_NAMESPACE, load_config_context
 from .providers.check.common import ResourceOutputDetailLevel
 from .providers.orchestration.common import MqMemoryProfile, MqMode, MqServiceType
 from .providers.support.base import get_bundle_path
+from .common import OpsServiceType
 
 logger = get_logger(__name__)
 
@@ -22,15 +23,21 @@ logger = get_logger(__name__)
 def support_bundle(
     cmd,
     log_age_seconds: int = 60 * 60 * 24,
-    ops_service: str = "auto",
+    ops_service: str = OpsServiceType.auto.value,
     bundle_dir: Optional[str] = None,
+    include_mq_traces: Optional[bool] = None,
     context_name: Optional[str] = None,
 ) -> Union[Dict[str, Any], None]:
     load_config_context(context_name=context_name)
     from .providers.support_bundle import build_bundle
 
     bundle_path: PurePath = get_bundle_path(bundle_dir=bundle_dir)
-    return build_bundle(ops_service=ops_service, bundle_path=str(bundle_path), log_age_seconds=log_age_seconds)
+    return build_bundle(
+        ops_service=ops_service,
+        bundle_path=str(bundle_path),
+        log_age_seconds=log_age_seconds,
+        include_mq_traces=include_mq_traces,
+    )
 
 
 def check(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -66,6 +66,7 @@ def load_iotops_arguments(self, _):
             options_list=["--mq-traces"],
             arg_type=get_three_state_flag(),
             help="Include mq traces in the support bundle.",
+            deprecate_info=context.deprecate(hide=True),
         )
 
     with self.argument_context("iot ops check") as context:

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -61,6 +61,12 @@ def load_iotops_arguments(self, _):
             help="The local directory the produced bundle will be saved to. "
             "If no directory is provided the current directory is used.",
         )
+        context.argument(
+            "include_mq_traces",
+            options_list=["--mq-traces"],
+            arg_type=get_three_state_flag(),
+            help="Include mq traces in the support bundle.",
+        )
 
     with self.argument_context("iot ops check") as context:
         context.argument(

--- a/azext_edge/edge/providers/stats.py
+++ b/azext_edge/edge/providers/stats.py
@@ -371,10 +371,16 @@ def _convert_otlp_to_tempo(message_dict: dict) -> dict:
 
 def _fetch_bytes(socket: "socket", size: int) -> bytes:
     result_bytes = socket.recv(size)
+    if result_bytes == b"":
+        return result_bytes
+
     result_bytes_len = len(result_bytes)
     while result_bytes_len < size:
-        remaining_bytes = size - result_bytes_len
-        result_bytes += socket.recv(remaining_bytes)
-        result_bytes_len = len(result_bytes)
+        remaining_bytes_size = size - result_bytes_len
+        interm_bytes = socket.recv(remaining_bytes_size)
+        if interm_bytes == b"":
+            break
+        result_bytes += interm_bytes
+        result_bytes_len += len(interm_bytes)
 
     return result_bytes

--- a/azext_edge/edge/providers/stats.py
+++ b/azext_edge/edge/providers/stats.py
@@ -231,16 +231,19 @@ def get_traces(
     namespace, diagnostic_pod = _preprocess_stats(namespace=namespace, diag_service_pod_prefix=diag_service_pod_prefix)
 
     for_support_bundle = False
-    if not trace_ids:
-        trace_ids = []
-    else:
+    trace_ids = trace_ids or []
+
+    if trace_ids:
         if trace_ids[0] == "!support_bundle!":
             trace_ids.pop()
             for_support_bundle = True
         trace_ids = [binascii.unhexlify(t) for t in trace_ids]
 
     with Progress(
-        *Progress.get_default_columns(), MofNCompleteColumn(), transient=False, disable=bool(trace_ids) or for_support_bundle
+        *Progress.get_default_columns(),
+        MofNCompleteColumn(),
+        transient=False,
+        disable=bool(trace_ids) or for_support_bundle,
     ) as progress:
         with portforward_socket(
             namespace=namespace, pod_name=diagnostic_pod.metadata.name, pod_port=pod_protobuf_port

--- a/azext_edge/edge/providers/stats.py
+++ b/azext_edge/edge/providers/stats.py
@@ -212,7 +212,7 @@ def get_traces(
     pod_protobuf_port: int = PROTOBUF_SERVICE_API_PORT,
     trace_ids: Optional[List[str]] = None,
     trace_dir: Optional[str] = None,
-) -> Union[List["TracesData"], None]:
+) -> Union[List["TracesData"], List[Tuple[str, str]], None]:
     """
     trace_ids: List[str] hex representation of trace Ids.
     """

--- a/azext_edge/edge/providers/stats.py
+++ b/azext_edge/edge/providers/stats.py
@@ -314,21 +314,21 @@ def get_traces(
                         pb_suffix = ".otlp.pb"
                         tempo_suffix = ".tempo.json"
 
-                        oltp_format_pair = (f"{archive}{pb_suffix}", response.retrieved_trace.trace.SerializeToString())
+                        otlp_format_pair = (f"{archive}{pb_suffix}", response.retrieved_trace.trace.SerializeToString())
                         tempo_format_pair = (
                             f"{archive}{tempo_suffix}",
                             json.dumps(_convert_otlp_to_tempo(msg_dict), sort_keys=True),
                         )
 
                         if for_support_bundle:
-                            traces.append(oltp_format_pair)
+                            traces.append(otlp_format_pair)
                             traces.append(tempo_format_pair)
                             continue
 
-                        # Original OLTP
+                        # Original OTLP
                         myzip.writestr(
-                            zinfo_or_arcname=oltp_format_pair[0],
-                            data=oltp_format_pair[1],
+                            zinfo_or_arcname=otlp_format_pair[0],
+                            data=otlp_format_pair[1],
                         )
                         # Tempo
                         myzip.writestr(

--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -337,14 +337,20 @@ def process_nodes():
     }
 
 
-def process_events():
+def get_mq_namespaces() -> List[str]:
     from ..edge_api import MQ_ACTIVE_API, MqResourceKinds
 
     namespaces = []
-    event_content = []
     cluster_brokers = MQ_ACTIVE_API.get_resources(MqResourceKinds.BROKER)
     if cluster_brokers and cluster_brokers["items"]:
         namespaces.extend([b["metadata"]["namespace"] for b in cluster_brokers["items"]])
+
+    return namespaces
+
+
+def process_events():
+    event_content = []
+    namespaces = get_mq_namespaces()
 
     for namespace in namespaces:
         event_content.append(

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -66,10 +66,7 @@ def fetch_diagnostic_traces():
                         }
                     )
 
-        except Exception as e:
-            import pdb
-
-            pdb.set_trace()
+        except Exception:
             logger.debug(f"Unable to process diagnostics pod traces against namespace {namespace}.")
 
     return result

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -5,14 +5,14 @@
 # ----------------------------------------------------------------------------------------------
 
 from functools import partial
-from typing import Iterable
+from typing import Iterable, Optional
 
 from knack.log import get_logger
 
 from azext_edge.edge.common import AIO_MQ_OPERATOR
 
 from ..edge_api import MQ_ACTIVE_API, EdgeResourceApi
-from ..stats import get_stats
+from ..stats import get_stats, get_traces
 from .base import (
     assemble_crd_work,
     process_deployments,
@@ -20,19 +20,20 @@ from .base import (
     process_services,
     process_statefulset,
     process_v1_pods,
+    get_mq_namespaces,
 )
 
 logger = get_logger(__name__)
 
 MQ_APP_LABELS = [
-    'broker',  # aio-mq-dmqtt-frontend, aio-mq-dmqtt-backend, aio-mq-dmqtt-authentication
-    'diagnostics',  # aio-mq-diagnostics-service
-    'health-manager',  # aio-mq-dmqtt-health-manager
-    'aio-mq-operator',
-    'aio-mq-mqttbridge',
-    'aio-mq-datalake',
-    'aio-mq-kafka-connector',
-    'aio-mq-iothub-connector'
+    "broker",  # aio-mq-dmqtt-frontend, aio-mq-dmqtt-backend, aio-mq-dmqtt-authentication
+    "diagnostics",  # aio-mq-diagnostics-service
+    "health-manager",  # aio-mq-dmqtt-health-manager
+    "aio-mq-operator",
+    "aio-mq-mqttbridge",
+    "aio-mq-datalake",
+    "aio-mq-kafka-connector",
+    "aio-mq-iothub-connector",
 ]
 
 MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
@@ -47,7 +48,31 @@ def fetch_diagnostic_metrics(namespace: str):
             "zinfo": f"{namespace}/{MQ_ACTIVE_API.moniker}/diagnostic_metrics.txt",
         }
     except Exception:
-        logger.debug(f"Unable to call stats pod metrics against namespace {namespace}.")
+        logger.debug(f"Unable to process diagnostics pod metrics against namespace {namespace}.")
+
+
+def fetch_diagnostic_traces():
+    namespaces = get_mq_namespaces()
+    result = []
+    for namespace in namespaces:
+        try:
+            traces = get_traces(namespace=namespace, trace_ids=["!support_bundle!"])
+            if traces:
+                for trace in traces:
+                    result.append(
+                        {
+                            "data": trace[1],
+                            "zinfo": f"{namespace}/{MQ_ACTIVE_API.moniker}/traces/{trace[0]}",
+                        }
+                    )
+
+        except Exception as e:
+            import pdb
+
+            pdb.set_trace()
+            logger.debug(f"Unable to process diagnostics pod traces against namespace {namespace}.")
+
+    return result
 
 
 def fetch_deployments():
@@ -114,11 +139,16 @@ support_runtime_elements = {
 }
 
 
-def prepare_bundle(apis: Iterable[EdgeResourceApi], log_age_seconds: int = 60 * 60 * 24) -> dict:
+def prepare_bundle(
+    apis: Iterable[EdgeResourceApi], log_age_seconds: int = 60 * 60 * 24, include_mq_traces: Optional[bool] = None
+) -> dict:
     mq_to_run = {}
     mq_to_run.update(assemble_crd_work(apis))
 
     support_runtime_elements["pods"] = partial(fetch_pods, since_seconds=log_age_seconds)
+    if include_mq_traces:
+        support_runtime_elements["traces"] = fetch_diagnostic_traces
+
     mq_to_run.update(support_runtime_elements)
 
     return mq_to_run

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -91,7 +91,7 @@ def build_bundle(
                 # TODO: Change to kwargs based pattern
                 if service_moniker == OpsServiceType.deviceregistry.value:
                     bundle = bundle_method(deployed_apis)
-                if service_moniker == OpsServiceType.mq.value:
+                elif service_moniker == OpsServiceType.mq.value:
                     bundle = bundle_method(deployed_apis, log_age_seconds, include_mq_traces)
                 else:
                     bundle = bundle_method(deployed_apis, log_age_seconds)

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -36,7 +36,9 @@ COMPAT_LNM_APIS = EdgeApiManager(resource_apis=[LNM_API_V1B1])
 COMPAT_DEVICEREGISTRY_APIS = EdgeApiManager(resource_apis=[DEVICEREGISTRY_API_V1])
 
 
-def build_bundle(ops_service: str, bundle_path: str, log_age_seconds: Optional[int] = None):
+def build_bundle(
+    ops_service: str, bundle_path: str, log_age_seconds: Optional[int] = None, include_mq_traces: Optional[bool] = None
+):
     from rich.live import Live
     from rich.progress import Progress
     from rich.table import Table
@@ -86,8 +88,11 @@ def build_bundle(ops_service: str, bundle_path: str, log_age_seconds: Optional[i
             if deployed_apis:
                 bundle_method = api_info["prepare_bundle"]
                 # Check if the function takes a second argument
+                # TODO: Change to kwargs based pattern
                 if service_moniker == OpsServiceType.deviceregistry.value:
                     bundle = bundle_method(deployed_apis)
+                if service_moniker == OpsServiceType.mq.value:
+                    bundle = bundle_method(deployed_apis, log_age_seconds, include_mq_traces)
                 else:
                     bundle = bundle_method(deployed_apis, log_age_seconds)
 

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -218,14 +218,16 @@ def mocked_list_deployments(mocked_client):
         # @jiacju - currently no unique label for lnm
         # @vilit - also akri
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            names.extend([
-                "aio-lnm-operator",
-                "aio-akri-otel-collector",
-                "aio-opc-admission-controller",
-                "aio-opc-supervisor",
-                "aio-opc-opc",
-                "opcplc-0000000"
-            ])
+            names.extend(
+                [
+                    "aio-lnm-operator",
+                    "aio-akri-otel-collector",
+                    "aio-opc-admission-controller",
+                    "aio-opc-supervisor",
+                    "aio-opc-opc",
+                    "opcplc-0000000",
+                ]
+            )
 
         deployment_list = []
         for name in names:
@@ -247,9 +249,7 @@ def mocked_list_replicasets(mocked_client):
         names = ["mock_replicaset"]
         # @vilit - also akri
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            names.extend([
-                "aio-akri-otel-collector"
-            ])
+            names.extend(["aio-akri-otel-collector"])
 
         replicaset_list = []
         for name in names:
@@ -285,9 +285,11 @@ def mocked_list_services(mocked_client):
     def _handle_list_services(*args, **kwargs):
         service_names = ["mock_service"]
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            service_names.extend([
-                "opcplc-0000000",
-            ])
+            service_names.extend(
+                [
+                    "opcplc-0000000",
+                ]
+            )
 
         service_list = []
         for name in service_names:
@@ -342,11 +344,9 @@ def mocked_list_daemonsets(mocked_client):
         # @vilit - also akri
         daemonset_names = ["mock_daemonset"]
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            daemonset_names.extend([
-                "aio-akri-agent-daemonset",
-                "akri-opcua-asset-discovery-daemonset",
-                "svclb-aio-lnm-operator"
-            ])
+            daemonset_names.extend(
+                ["aio-akri-agent-daemonset", "akri-opcua-asset-discovery-daemonset", "svclb-aio-lnm-operator"]
+            )
 
         daemonset_list = []
         for name in daemonset_names:
@@ -366,3 +366,11 @@ def mocked_mq_active_api(mocker):
     patched_active_mq_api = mocker.patch("azext_edge.edge.providers.edge_api.MQ_ACTIVE_API")
     patched_active_mq_api.get_resources.return_value = {"items": [{"metadata": {"namespace": "mock_namespace"}}]}
     yield patched_active_mq_api
+
+
+@pytest.fixture
+def mocked_mq_get_traces(mocker):
+    # Supports --mq-traces
+    patched_get_traces = mocker.patch("azext_edge.edge.providers.support.mq.get_traces")
+    patched_get_traces.return_value = [("trace_key", "trace_data")]
+    yield patched_get_traces

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -606,8 +606,11 @@ def test_create_bundle_mq_traces(
     mocked_mq_get_traces,
 ):
     result = support_bundle(None, bundle_dir=a_bundle_dir, include_mq_traces=True)
+
     assert result["bundlePath"]
     mocked_mq_get_traces.assert_called_once()
     get_trace_kwargs = mocked_mq_get_traces.call_args.kwargs
+
     assert get_trace_kwargs["namespace"] == "mock_namespace"  # TODO: Not my favorite
     assert get_trace_kwargs["trace_ids"] == ["!support_bundle!"]  # TODO: Magic string
+    assert_zipfile_write(mocked_zipfile, zinfo="mock_namespace/mq/traces/trace_key", data="trace_data")


### PR DESCRIPTION
* This PR introduces the optional `--mq-traces` flag to `az iot ops support create-bundle`.
* This is a convenience/shortcut, as the `stats` command supports both fetching traces by `--trace-ids` or `--trace-dir`. 
* Also smooths out some tcp socket byte handling.