### PR TITLE
Restruct lnm core service runtime resource

### DIFF
--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -8,12 +8,16 @@
 CLI parameter definitions.
 """
 
-from azext_edge.edge.providers.edge_api.opcua import OpcuaResourceKinds
 from knack.arguments import CaseInsensitiveList
 from azure.cli.core.commands.parameters import get_three_state_flag, get_enum_type, tags_type
 
 from .common import OpsServiceType
-from .providers.edge_api import DataProcessorResourceKinds, MqResourceKinds
+from .providers.edge_api import (
+    DataProcessorResourceKinds,
+    LnmResourceKinds,
+    MqResourceKinds,
+    OpcuaResourceKinds
+)
 from .providers.check.common import ResourceOutputDetailLevel
 from .providers.orchestration.common import MqMemoryProfile, MqMode, MqServiceType
 
@@ -102,15 +106,16 @@ def load_iotops_arguments(self, _):
             options_list=["--resources"],
             choices=CaseInsensitiveList(
                 [
+                    DataProcessorResourceKinds.DATASET.value,
+                    DataProcessorResourceKinds.PIPELINE.value,
+                    DataProcessorResourceKinds.INSTANCE.value,
+                    LnmResourceKinds.LNM.value,
                     MqResourceKinds.BROKER.value,
                     MqResourceKinds.BROKER_LISTENER.value,
                     MqResourceKinds.DIAGNOSTIC_SERVICE.value,
                     MqResourceKinds.MQTT_BRIDGE_CONNECTOR.value,
                     MqResourceKinds.DATALAKE_CONNECTOR.value,
                     MqResourceKinds.KAFKA_CONNECTOR.value,
-                    DataProcessorResourceKinds.DATASET.value,
-                    DataProcessorResourceKinds.PIPELINE.value,
-                    DataProcessorResourceKinds.INSTANCE.value,
                     OpcuaResourceKinds.ASSET_TYPE.value,
                 ]
             ),

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+from itertools import groupby
 from typing import Any, Dict, List, Tuple
 
 from azext_edge.edge.providers.base import get_namespaced_pods_by_prefix
@@ -25,6 +26,7 @@ from ...common import CheckTaskStatus
 
 from .common import (
     AIO_LNM_PREFIX,
+    CORE_SERVICE_RUNTIME_RESOURCE,
     LNM_ALLOWLIST_PROPERTIES,
     LNM_EXCLUDED_SUBRESOURCE,
     LNM_IMAGE_PROPERTIES,
@@ -48,6 +50,7 @@ def check_lnm_deployment(
     resource_kinds: List[str] = None
 ) -> None:
     evaluate_funcs = {
+        CORE_SERVICE_RUNTIME_RESOURCE: evaluate_core_service_runtime,
         LnmResourceKinds.LNM: evaluate_lnms,
     }
 
@@ -65,6 +68,27 @@ def check_lnm_deployment(
     )
 
 
+def evaluate_core_service_runtime(
+    as_list: bool = False,
+    detail_level: int = ResourceOutputDetailLevel.summary.value,
+) -> Dict[str, Any]:
+    check_manager = CheckManager(check_name="evalCoreServiceRuntime", check_desc="Evaluate LNM core service")
+
+    lnm_operator_label = f"app in ({','.join(LNM_APP_LABELS)})"
+    _process_lnm_pods(
+        check_manager=check_manager,
+        description="LNM runtime resources in namespace {{[purple]{}[/purple]}}",
+        target=CORE_SERVICE_RUNTIME_RESOURCE,
+        prefix=AIO_LNM_PREFIX,
+        label_selector=lnm_operator_label,
+        conditions=[],
+        namespace="",
+        padding=6,
+        detail_level=detail_level,
+    )
+
+    return check_manager.as_dict(as_list)
+
 def evaluate_lnms(
     as_list: bool = False,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
@@ -80,6 +104,12 @@ def evaluate_lnms(
         fetch_lnms_error_text = "Unable to fetch LNM instances in any namespaces."
         check_manager.add_target(target_name=target_lnms)
         check_manager.add_display(target_name=target_lnms, display=Padding(fetch_lnms_error_text, (0, 0, 0, 8)))
+        check_manager.add_target_eval(
+            target_name=target_lnms,
+            status=CheckTaskStatus.skipped.value,
+            value={"lnms": None}
+        )
+        return check_manager.as_dict(as_list)
 
     for (namespace, lnms) in resources_grouped_by_namespace(all_lnms):
         lnm_names = []
@@ -236,80 +266,72 @@ def evaluate_lnms(
             for lnm_name in lnm_names:
                 lnm_app_labels.append(f"{LNM_LABEL_PREFIX}-{lnm_name}")
 
-            lnm_label = f"app in ({','.join(lnm_app_labels + LNM_APP_LABELS)})"
-            _evaluate_lnm_pod_health(
-                check_manager=check_manager,
-                target=target_lnms,
-                pod=AIO_LNM_PREFIX,
-                display_padding=12,
-                service_label=lnm_label,
-                namespace=namespace,
-                detail_level=detail_level,
-            )
+            lnm_label = f"app in ({','.join(lnm_app_labels)})"
+            pods = get_namespaced_pods_by_prefix(prefix=AIO_LNM_PREFIX, namespace="", label_selector=lnm_label)
 
-    # evaluate lnm operator pod no matter if there is lnm instance
-    pods = _evaluate_pod_for_other_namespace(
+            for pod in pods:
+                _evaluate_lnm_pod_health(
+                    check_manager=check_manager,
+                    target=target_lnms,
+                    pod=pod,
+                    display_padding=12,
+                    namespace=namespace,
+                    detail_level=detail_level,
+                )
+
+    # evaluate lnm svclb pod in other namespace
+    _process_lnm_pods(
         check_manager=check_manager,
-        conditions=lnm_namespace_conditions,
+        description="LNM resource health for namespace {{[purple]{}[/purple]}}",
         target=target_lnms,
+        prefix=f"svclb-{AIO_LNM_PREFIX}",
+        label_selector=None,
+        conditions=lnm_namespace_conditions,
+        namespace="",
+        padding=6,
         detail_level=detail_level,
     )
-
-    if not all_lnms and not pods:
-        check_manager.add_target_eval(
-            target_name=target_lnms,
-            status=CheckTaskStatus.skipped.value,
-            value={"lnms": None}
-        )
 
     return check_manager.as_dict(as_list)
 
 
-def _evaluate_pod_for_other_namespace(
+def _get_lnm_pods_namespace(pod: V1Pod) -> str:
+    return pod.metadata.namespace
+
+def _process_lnm_pods(
     check_manager: CheckManager,
-    conditions: List[str],
+    description: str,
     target: str,
+    prefix: str,
+    label_selector: str,
+    conditions: List[str],
+    namespace: str,
+    padding: int,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
-) -> List[dict]:
-    from itertools import groupby
+) -> None:
+    pods = get_namespaced_pods_by_prefix(prefix=prefix, namespace=namespace, label_selector=label_selector)
 
-    lnm_operator_label = f"app in ({','.join(LNM_APP_LABELS)})"
-    pods = get_namespaced_pods_by_prefix(prefix=AIO_LNM_PREFIX, namespace="", label_selector=lnm_operator_label)
-    pods.extend(
-        get_namespaced_pods_by_prefix(prefix=f"svclb-{AIO_LNM_PREFIX}", namespace="", label_selector=None)
-    )
-
-    def get_namespace(pod: V1Pod) -> str:
-        return pod.metadata.namespace
-
-    pods.sort(key=get_namespace)
-
-    for (namespace, pods) in groupby(pods, get_namespace):
-        # only evaluate operator pod if there is no target for the namespace operator pod is in
-        if not check_manager.targets[target].get(namespace, ""):
-            check_manager.add_target(target_name=target, namespace=namespace, conditions=conditions)
-            check_manager.add_display(
-                target_name=target,
-                namespace=namespace,
-                display=Padding(
-                    f"LNM resource health for namespace {{[purple]{namespace}[/purple]}}",
-                    (0, 0, 0, 6)
-                )
+    pods.sort(key=_get_lnm_pods_namespace)
+    for (namespace, pods) in groupby(pods, _get_lnm_pods_namespace):
+        check_manager.add_target(target_name=target, namespace=namespace, conditions=conditions)
+        check_manager.add_display(
+            target_name=target,
+            namespace=namespace,
+            display=Padding(
+                description.format(namespace),
+                (0, 0, 0, padding)
             )
+        )
 
-            for pod in pods:
-                pod_name = pod.metadata.name
-                service_label = None if pod_name.startswith("svclb-") else lnm_operator_label
-
-                _evaluate_lnm_pod_health(
-                    check_manager=check_manager,
-                    target=target,
-                    pod=pod.metadata.name,
-                    display_padding=12,
-                    service_label=service_label,
-                    namespace=namespace,
-                    detail_level=detail_level,
-                )
+        for pod in pods:
+            _evaluate_lnm_pod_health(
+                check_manager=check_manager,
+                target=target,
+                pod=pod,
+                display_padding=padding + 4,
+                namespace=namespace,
+                detail_level=detail_level,
+            )
 
     return pods
 
@@ -317,9 +339,8 @@ def _evaluate_pod_for_other_namespace(
 def _evaluate_lnm_pod_health(
     check_manager: CheckManager,
     target: str,
-    pod: str,
+    pod: V1Pod,
     display_padding: int,
-    service_label: str,
     namespace: str,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
 ) -> None:
@@ -329,7 +350,7 @@ def _evaluate_lnm_pod_health(
             return f"[green]{condition}[/green]", CheckTaskStatus.success.value
         return f"[red]{condition}[/red]", CheckTaskStatus.error.value
 
-    target_service_pod = f"pod/{pod}"
+    target_service_pod = f"pod/{pod.metadata.name}"
 
     pod_conditions = [
         f"{target_service_pod}.status.phase",
@@ -339,11 +360,12 @@ def _evaluate_lnm_pod_health(
         f"{target_service_pod}.status.conditions.podscheduled",
     ]
 
-    diagnostics_pods = get_namespaced_pods_by_prefix(prefix=pod, namespace=namespace, label_selector=service_label)
+    if check_manager.targets.get(target, {}).get(namespace, {}).get("conditions", None):
+        check_manager.add_target_conditions(target_name=target, namespace=namespace, conditions=pod_conditions)
+    else:
+        check_manager.set_target_conditions(target_name=target, namespace=namespace, conditions=pod_conditions)
 
-    check_manager.add_target_conditions(target_name=target, namespace=namespace, conditions=pod_conditions)
-
-    if not diagnostics_pods:
+    if not pod:
         add_display_and_eval(
             check_manager=check_manager,
             target_name=target,
@@ -355,62 +377,61 @@ def _evaluate_lnm_pod_health(
             padding=(0, 0, 0, display_padding)
         )
     else:
-        for pod in diagnostics_pods:
-            pod_dict = pod.to_dict()
-            pod_name = pod_dict["metadata"]["name"]
-            pod_phase = pod_dict.get("status", {}).get("phase")
-            pod_conditions = pod_dict.get("status", {}).get("conditions", {})
-            pod_phase_deco, status = decorate_pod_phase(pod_phase)
+        pod_dict = pod.to_dict()
+        pod_name = pod_dict["metadata"]["name"]
+        pod_phase = pod_dict.get("status", {}).get("phase")
+        pod_conditions = pod_dict.get("status", {}).get("conditions", {})
+        pod_phase_deco, status = decorate_pod_phase(pod_phase)
 
-            check_manager.add_target_eval(
+        check_manager.add_target_eval(
+            target_name=target,
+            namespace=namespace,
+            status=status,
+            resource_name=target_service_pod,
+            value={"name": pod_name, "status.phase": pod_phase},
+        )
+
+        for text in [
+            f"\nPod {{[bright_blue]{pod_name}[/bright_blue]}}",
+            f"- Phase: {pod_phase_deco}",
+            "- Conditions:"
+        ]:
+            padding = 2 if "\nPod" not in text else 0
+            padding += display_padding
+            check_manager.add_display(
                 target_name=target,
                 namespace=namespace,
-                status=status,
-                resource_name=target_service_pod,
-                value={"name": pod_name, "status.phase": pod_phase},
+                display=Padding(text, (0, 0, 0, padding)),
             )
 
-            for text in [
-                f"\nPod {{[bright_blue]{pod_name}[/bright_blue]}}",
-                f"- Phase: {pod_phase_deco}",
-                "- Conditions:"
-            ]:
-                padding = 2 if "\nPod" not in text else 0
-                padding += display_padding
-                check_manager.add_display(
-                    target_name=target,
-                    namespace=namespace,
-                    display=Padding(text, (0, 0, 0, padding)),
-                )
+        for condition in pod_conditions:
+            condition_type = LNM_POD_CONDITION_TEXT_MAP[condition.get("type")]
+            condition_status = True if condition.get("status") == "True" else False
+            pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
 
-            for condition in pod_conditions:
-                condition_type = LNM_POD_CONDITION_TEXT_MAP[condition.get("type")]
-                condition_status = True if condition.get("status") == "True" else False
-                pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
+            add_display_and_eval(
+                check_manager=check_manager,
+                target_name=target,
+                display_text=f"{condition_type}: {pod_condition_deco}",
+                eval_status=status,
+                eval_value={"name": pod_name, f"status.conditions.{condition_type.lower()}": condition_status},
+                resource_name=target_service_pod,
+                namespace=namespace,
+                padding=(0, 0, 0, display_padding + 8)
+            )
 
-                add_display_and_eval(
-                    check_manager=check_manager,
-                    target_name=target,
-                    display_text=f"{condition_type}: {pod_condition_deco}",
-                    eval_status=status,
-                    eval_value={"name": pod_name, f"status.conditions.{condition_type.lower()}": condition_status},
-                    resource_name=target_service_pod,
-                    namespace=namespace,
-                    padding=(0, 0, 0, display_padding + 8)
-                )
+            if detail_level > ResourceOutputDetailLevel.summary.value:
+                condition_reason = condition.get("message")
+                condition_reason_text = f"{condition_reason}" if condition_reason else ""
 
-                if detail_level > ResourceOutputDetailLevel.summary.value:
-                    condition_reason = condition.get("message")
-                    condition_reason_text = f"{condition_reason}" if condition_reason else ""
-
-                    if condition_reason_text:
-                        # remove the [ and ] to prevent console not printing the text
-                        condition_reason_text = condition_reason_text.replace("[", "\\[")
-                        check_manager.add_display(
-                            target_name=target,
-                            namespace=namespace,
-                            display=Padding(
-                                f"[red]Reason: {condition_reason_text}[/red]",
-                                (0, 0, 0, display_padding + 8),
-                            ),
-                        )
+                if condition_reason_text:
+                    # remove the [ and ] to prevent console not printing the text
+                    condition_reason_text = condition_reason_text.replace("[", "\\[")
+                    check_manager.add_display(
+                        target_name=target,
+                        namespace=namespace,
+                        display=Padding(
+                            f"[red]Reason: {condition_reason_text}[/red]",
+                            (0, 0, 0, display_padding + 8),
+                        ),
+                    )


### PR DESCRIPTION
Since lnm only have one resource type lnmz(instance), now only showing lnmz related pod under lnmz check, rest of the pod moved to a new check section called "core service runtime", similar to opcua check. **Note**: when there is lnm instance, the instance related pod will not only exist in the namespace stated in the deploy manifest, it will also have a svclb pod in kube-system namespace

no instance output:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/a20560d3-88f6-4c2a-921c-5ddb7a170871)

with instance output:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/396a7179-65c3-4ea1-ad17-bb581462871a)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
