### PR TITLE
refactor: remove `az iot ops asset list`

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -284,22 +284,6 @@ def load_iotops_help():
     """
 
     helps[
-        "iot ops asset list"
-    ] = """
-        type: command
-        short-summary: List assets.
-
-        examples:
-        - name: List all assets in the current subscription.
-          text: >
-            az iot ops asset list
-
-        - name: List all assets in a resource group.
-          text: >
-            az iot ops asset list -g {resource_group}
-    """
-
-    helps[
         "iot ops asset query"
     ] = """
         type: command

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -46,7 +46,6 @@ def load_iotops_commands(self, _):
     ) as cmd_group:
         cmd_group.command("create", "create_asset")
         cmd_group.command("delete", "delete_asset")
-        cmd_group.command("list", "list_assets")
         cmd_group.command("query", "query_assets")
         cmd_group.show_command("show", "show_asset")
         cmd_group.command("update", "update_asset")

--- a/azext_edge/edge/commands_assets.py
+++ b/azext_edge/edge/commands_assets.py
@@ -100,14 +100,6 @@ def delete_asset(
     )
 
 
-def list_assets(
-    cmd,
-    resource_group_name: Optional[str] = None,
-) -> dict:
-    asset_provider = AssetProvider(cmd)
-    return asset_provider.list(resource_group_name=resource_group_name)
-
-
 def query_assets(
     cmd,
     asset_type: Optional[str] = None,


### PR DESCRIPTION
Fixing the polling for asset lists exposes an issue with RPSaaS object versioning and breaks list overall. Thus, this command will just be removed and we will point users at the query.

Issue with versioning:
The subscriptions have assets created with a previous API version, that have been created with a different schema (i.e., connectivityProfileUri vs assetEndpointProfileUri) and this fails the swagger validation when returning the resources

![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/cbf24fa5-b99f-45bb-9799-4d86b42010a9)

Also note that query will just return everything in resource graph - even if it was created with older API's 👯 

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
