### PR TITLE
feat: Use ensure_azure_namespace_path() + add placeholder SPC. 

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.2.0b1"
+VERSION = "0.2.0b2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/providers/orchestration/base.py
+++ b/azext_edge/edge/providers/orchestration/base.py
@@ -118,6 +118,7 @@ def configure_cluster_secrets(
         "aio-opc-ua-broker-client-certificate",
         "aio-opc-ua-broker-user-authentication",
         "aio-opc-ua-broker-trust-list",
+        "aio-opc-ua-broker-issuer-list",
     ]:
         yaml_configs.append(
             get_kv_secret_store_yaml(

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -4,10 +4,14 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+from .common import ensure_azure_namespace_path
+from ...constants import USER_AGENT
+
+ensure_azure_namespace_path()
+
 from azure.identity import AzureCliCredential
 from azure.mgmt.resource import ResourceManagementClient
 from azure.core.pipeline.policies import UserAgentPolicy
-from ...constants import USER_AGENT
 
 AZURE_CLI_CREDENTIAL = AzureCliCredential()
 

--- a/azext_edge/edge/util/common.py
+++ b/azext_edge/edge/util/common.py
@@ -142,13 +142,14 @@ def url_safe_hash_phrase(phrase: str):
 
 
 def ensure_azure_namespace_path():
-    import os
-    import sys
-
     """
     Run prior to importing azure namespace packages (azure.*) to ensure the
     extension root path is configured for package import.
     """
+
+    import os
+    import sys
+
     from azure.cli.core.extension import get_extension_path
     from ...constants import EXTENSION_NAME
 
@@ -168,5 +169,3 @@ def ensure_azure_namespace_path():
 
     if sys.path and sys.path[0] != ext_path:
         sys.path.insert(0, ext_path)
-
-    return

--- a/azext_edge/edge/util/common.py
+++ b/azext_edge/edge/util/common.py
@@ -43,7 +43,7 @@ def assemble_nargs_to_dict(hash_list: List[str]) -> Dict[str, str]:
 
 
 def build_query(cmd, subscription_id: Optional[str] = None, custom_query: Optional[str] = None, **kwargs):
-    url = '/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01'
+    url = "/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
     subscriptions = [subscription_id] if subscription_id else []
     payload = {"subscriptions": subscriptions, "query": "Resources ", "options": {}}
 
@@ -139,3 +139,34 @@ def url_safe_hash_phrase(phrase: str):
     from hashlib import sha256
 
     return sha256(phrase.encode("utf8")).hexdigest()
+
+
+def ensure_azure_namespace_path():
+    import os
+    import sys
+
+    """
+    Run prior to importing azure namespace packages (azure.*) to ensure the
+    extension root path is configured for package import.
+    """
+    from azure.cli.core.extension import get_extension_path
+    from ...constants import EXTENSION_NAME
+
+    ext_path = get_extension_path(EXTENSION_NAME)
+    if not ext_path:
+        return
+
+    ext_azure_dir = os.path.join(ext_path, "azure")
+    if os.path.isdir(ext_azure_dir):
+        import azure
+
+        if getattr(azure, "__path__", None) and ext_azure_dir not in azure.__path__:  # _NamespacePath /w PEP420
+            if isinstance(azure.__path__, list):
+                azure.__path__.insert(0, ext_azure_dir)
+            else:
+                azure.__path__.append(ext_azure_dir)
+
+    if sys.path and sys.path[0] != ext_path:
+        sys.path.insert(0, ext_path)
+
+    return

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ per-file-ignores =
     azext_edge/edge/providers/check/*.py:E501
     # ignore line length for template content
     azext_edge/edge/providers/orchestration/template.py:E501
+    # ignore module level import not at top of file
+    azext_edge/edge/util/az_client.py:E402
 exclude =
     # protobuf generated
     diagnostics_service_pb2.py


### PR DESCRIPTION
- When importing azure namespace packages, ensures extension packages are first on namespace pkg path and sys.path.
- Add placeholder SPC for `aio-opc-ua-broker-issuer-list`.