### PR TITLE
fix: improve docs + modify copy of template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on.
 ## Pre-requisites
 
 - An Azure Arc-enabled CNCF K8s cluster.
-- Azure CLI `2.42.0` or higher. If you don't have az cli installed, follow [these instructions](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
+- Azure CLI `2.46.0` or higher. If you don't have az cli installed, follow [these instructions](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 ## Install az iot ops extension
 
@@ -20,7 +20,7 @@ on.
 The IoT Ops CLI is part of the Azure CLI extension index. Installation is as simple as:
 
 ```
-az extension add --name azure-iot-ops
+az extension add --upgrade --name azure-iot-ops
 ```
 
 After install, the root command group `az iot ops` should be available and ready for use.

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.3.0b1"
+VERSION = "0.3.0b2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -167,9 +167,9 @@ def load_iotops_help():
         short-summary: Runs a set of cluster host verifications for IoT Operations deployment compatibility.
         long-summary: Intended to be run directly on a target cluster host.
           The command may prompt to apply a set of privileged actions such as installing a dependency.
-          In this case the CLI must be run with elevated permissions. For example
+          In this case the CLI must be run with elevated permissions. For example:
 
-            `sudo AZURE_EXTENSION_DIR=/home/me/.azure/cliextensions az iot ops verify-host`.
+            `sudo AZURE_EXTENSION_DIR=~/.azure/cliextensions az iot ops verify-host`.
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -167,7 +167,7 @@ def load_iotops_help():
         short-summary: Runs a set of cluster host verifications for IoT Operations deployment compatibility.
         long-summary: Intended to be run directly on a target cluster host.
           The command may prompt to apply a set of privileged actions such as installing a dependency.
-          In this case the CLI must be run with elevated permissions. For example:
+          In this case the CLI must be run with elevated permissions. For example
 
             `sudo AZURE_EXTENSION_DIR=~/.azure/cliextensions az iot ops verify-host`.
     """

--- a/azext_edge/edge/providers/orchestration/permissions.py
+++ b/azext_edge/edge/providers/orchestration/permissions.py
@@ -40,7 +40,7 @@ def verify_write_permission_against_rg(subscription_id: str, resource_group_name
 
     raise ValidationError(
         "This IoT Operations deployment config includes resource sync rules which require the logged-in principal\n"
-        "to have permission to write role assignments against the resource group.\n\n"
+        "to have permission to write role assignments (Microsoft.Authorization/roleAssignments/write) against the resource group.\n\n"
         "Use --disable-rsync-rules to not include resource sync rules in the deployment.\n"
         "Use --no-preflight to skip pre-flight checks.\n"
     )

--- a/azext_edge/edge/providers/orchestration/permissions.py
+++ b/azext_edge/edge/providers/orchestration/permissions.py
@@ -11,7 +11,9 @@ from ...util.az_client import get_authz_client
 
 logger = get_logger(__name__)
 
-VALID_PERM_FORMS = frozenset(["*", "microsoft.authorization/roleassignments/write", "microsoft.authorization/*/write"])
+VALID_PERM_FORMS = frozenset(
+    ["*", "*/write", "microsoft.authorization/roleassignments/write", "microsoft.authorization/*/write"]
+)
 
 
 # TODO: one-off for time, make generic
@@ -37,8 +39,10 @@ def verify_write_permission_against_rg(subscription_id: str, resource_group_name
             return
 
     raise ValidationError(
-        "This IoT Operations deployment configuration requires "
-        "the permission to write role assignments against the resource group."
+        "This IoT Operations deployment config includes resource sync rules which require the logged-in principal\n"
+        "to have permission to write role assignments against the resource group.\n\n"
+        "Use --disable-rsync-rules to not include resource sync rules in the deployment.\n"
+        "Use --no-preflight to skip pre-flight checks.\n"
     )
 
 

--- a/azext_edge/edge/providers/orchestration/permissions.py
+++ b/azext_edge/edge/providers/orchestration/permissions.py
@@ -40,7 +40,8 @@ def verify_write_permission_against_rg(subscription_id: str, resource_group_name
 
     raise ValidationError(
         "This IoT Operations deployment config includes resource sync rules which require the logged-in principal\n"
-        "to have permission to write role assignments (Microsoft.Authorization/roleAssignments/write) against the resource group.\n\n"
+        "to have permission to write role assignments (Microsoft.Authorization/roleAssignments/write) "
+        "against the resource group.\n\n"
         "Use --disable-rsync-rules to not include resource sync rules in the deployment.\n"
         "Use --no-preflight to skip pre-flight checks.\n"
     )

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -812,3 +812,9 @@ def get_insecure_mq_listener():
 
 
 CURRENT_TEMPLATE = V1_TEMPLATE
+
+
+def get_current_template_copy() -> TemplateVer:
+    from copy import deepcopy
+
+    return TemplateVer(commit_id=CURRENT_TEMPLATE.commit_id, content=deepcopy(CURRENT_TEMPLATE.content))

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -22,7 +22,7 @@ from rich.table import Table
 
 from ...util import get_timestamp_now_utc
 from ...util.x509 import DEFAULT_EC_ALGO, DEFAULT_VALID_DAYS
-from .template import CURRENT_TEMPLATE, TemplateVer
+from .template import get_current_template_copy, CURRENT_TEMPLATE, TemplateVer
 
 logger = get_logger(__name__)
 
@@ -466,7 +466,7 @@ class WorkManager:
 
     def build_template(self, work_kpis: dict) -> Tuple[TemplateVer, dict]:
         # TODO refactor, move out of work
-        template = CURRENT_TEMPLATE
+        template = get_current_template_copy()
         parameters = {}
 
         for template_pair in [

--- a/azext_edge/tests/edge/init/conftest.py
+++ b/azext_edge/tests/edge/init/conftest.py
@@ -183,3 +183,12 @@ def mocked_connected_cluster_location(mocker):
         new_callable=mocker.PropertyMock,
     )
     yield patched
+
+
+@pytest.fixture
+def spy_get_current_template_copy(mocker):
+    import azext_edge.edge.providers.orchestration.work as work
+
+    spy = mocker.spy(work, "get_current_template_copy")
+
+    yield spy

--- a/azext_edge/tests/edge/init/conftest.py
+++ b/azext_edge/tests/edge/init/conftest.py
@@ -187,7 +187,7 @@ def mocked_connected_cluster_location(mocker):
 
 @pytest.fixture
 def spy_get_current_template_copy(mocker):
-    import azext_edge.edge.providers.orchestration.work as work
+    from azext_edge.edge.providers.orchestration import work
 
     spy = mocker.spy(work, "get_current_template_copy")
 

--- a/azext_edge/tests/edge/init/test_permissions_unit.py
+++ b/azext_edge/tests/edge/init/test_permissions_unit.py
@@ -1,0 +1,113 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import pytest
+
+from azext_edge.edge.providers.orchestration.permissions import verify_write_permission_against_rg
+from azure.cli.core.azclierror import ValidationError
+
+from ...generators import get_zeroed_subscription, generate_generic_id
+
+MOCK_SUBSCRIPTION_ID = get_zeroed_subscription()
+MOCK_RG = f"rg_{generate_generic_id()}"
+
+
+class IntermObj:
+    def __init__(self, return_dict: dict):
+        self._return_dict = return_dict
+
+    def as_dict(self):
+        return self._return_dict
+
+
+@pytest.fixture
+def mocked_get_principal_permissions_for_group(mocker, request):
+    return_payload = []
+    for p in request.param["permissions"]:
+        return_payload.append(IntermObj(p))
+
+    patched = mocker.patch(
+        "azext_edge.edge.providers.orchestration.permissions.get_principal_permissions_for_group",
+        return_value=return_payload,
+    )
+    setattr(patched, "expected_success", request.param.get("expected_success", True))
+    yield patched
+
+
+@pytest.mark.parametrize(
+    "mocked_get_principal_permissions_for_group",
+    [
+        {
+            "permissions": [
+                {"actions": [], "not_actions": []},
+            ],
+            "expected_success": False,
+        },
+        {
+            "permissions": [
+                {"actions": ["*"], "not_actions": ["*/write"]},
+            ],
+            "expected_success": False,
+        },
+        {
+            "permissions": [
+                {"actions": ["*"], "not_actions": ["Microsoft.Authorization/*/write"]},
+            ],
+            "expected_success": False,
+        },
+        {
+            "permissions": [
+                {
+                    "actions": ["Microsoft.Authorization/*/write"],
+                    "not_actions": ["Microsoft.Authorization/roleAssignments/write"],
+                },
+            ],
+            "expected_success": False,
+        },
+        {
+            "permissions": [
+                {"actions": ["*"], "not_actions": []},
+            ],
+        },
+        {
+            "permissions": [
+                {"actions": ["*"], "not_actions": ["Microsoft.Authorization/*/write"]},
+                {"actions": ["*"], "not_actions": []},
+            ],
+        },
+        {
+            "permissions": [
+                {"actions": [], "not_actions": []},
+                {"actions": ["*/write"], "not_actions": ["Microsoft.Test/subject/action"]},
+            ],
+        },
+        {
+            "permissions": [
+                {
+                    "actions": ["Microsoft.Authorization/roleAssignments/write", "Microsoft.Test/subject/action"],
+                    "not_actions": [],
+                },
+            ],
+        },
+        {
+            "permissions": [
+                {"actions": [], "not_actions": []},
+                {"actions": ["Microsoft.Authorization/*/write"], "not_actions": []},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_verify_write_permission_against_rg(mocked_get_principal_permissions_for_group):
+    if not mocked_get_principal_permissions_for_group.expected_success:
+        with pytest.raises(ValidationError):
+            verify_write_permission_against_rg(subscription_id=MOCK_SUBSCRIPTION_ID, resource_group_name=MOCK_RG)
+        return
+
+    verify_write_permission_against_rg(subscription_id=MOCK_SUBSCRIPTION_ID, resource_group_name=MOCK_RG)
+    call_kwargs = mocked_get_principal_permissions_for_group.call_args.kwargs
+    assert call_kwargs["subscription_id"] == MOCK_SUBSCRIPTION_ID
+    assert call_kwargs["resource_group_name"] == MOCK_RG

--- a/azext_edge/tests/edge/init/test_template_unit.py
+++ b/azext_edge/tests/edge/init/test_template_unit.py
@@ -6,6 +6,7 @@
 
 from unittest import TestCase
 
+
 def test_current_template():
     from azext_edge.edge.providers.orchestration.template import CURRENT_TEMPLATE, get_current_template_copy
 

--- a/azext_edge/tests/edge/init/test_template_unit.py
+++ b/azext_edge/tests/edge/init/test_template_unit.py
@@ -4,11 +4,20 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+from unittest import TestCase
 
 def test_current_template():
-    from azext_edge.edge.providers.orchestration.template import CURRENT_TEMPLATE
+    from azext_edge.edge.providers.orchestration.template import CURRENT_TEMPLATE, get_current_template_copy
 
     assert CURRENT_TEMPLATE.commit_id
     assert CURRENT_TEMPLATE.content_vers
     assert CURRENT_TEMPLATE.content
     assert CURRENT_TEMPLATE.parameters
+
+    deep_copy_template = get_current_template_copy()
+
+    assert deep_copy_template.commit_id == CURRENT_TEMPLATE.commit_id
+    assert deep_copy_template.content_vers == CURRENT_TEMPLATE.content_vers
+    assert deep_copy_template.parameters == CURRENT_TEMPLATE.parameters
+    assert deep_copy_template.content == CURRENT_TEMPLATE.content
+    TestCase().assertDictEqual(CURRENT_TEMPLATE.content, deep_copy_template.content)


### PR DESCRIPTION
* Doc improvements for readme, verify-host example and clearer error for RSR permission check.
* +Permission check unit test content and addition of one more valid form of permission `*/write`.
*  WorkManager.build_template() gets and modifies deep copy of base template.
* Increment version.