### PR TITLE
chore: Add conventional commit check to PR titles

### DIFF
--- a/.github/workflows/conventional_pr.yml
+++ b/.github/workflows/conventional_pr.yml
@@ -1,0 +1,22 @@
+name: "[auto] Check PR title format"
+on:
+  pull_request:
+    types: [
+        opened,
+        edited,
+        ready_for_review,
+        reopened,
+    ]
+jobs:
+  verify_title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Verify PR title matches conventional commits specification"
+        run: |
+            conventional_regex='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?: .*$'
+            if [[ "${{ github.event.pull_request.title }}" =~ $conventional_regex ]]; then
+                echo "Success!"
+            else
+                echo "Incorrect PR title format" >> $GITHUB_STEP_SUMMARY
+                exit 1
+            fi

--- a/.github/workflows/conventional_pr.yml
+++ b/.github/workflows/conventional_pr.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Verify PR title matches conventional commits specification"
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
             conventional_regex='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?: .*$'
-            if [[ "${{ github.event.pull_request.title }}" =~ $conventional_regex ]]; then
+            if [[ "$TITLE" =~ $conventional_regex ]]; then
                 echo "Success!"
             else
                 echo "Incorrect PR title format" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds the following regex check to PR titles:
`^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?: .*$`

We have a few commits that don't meet this spec, but this check will ensure all of our merged commits match (most of) the [conventional spec](https://www.conventionalcommits.org/en/v1.0.0/#specification)
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/13545962/1a12fe04-1ef0-406f-8082-3294d5aeeeed)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
