### PR TITLE
refactor: SB capture cluster wide events

### DIFF
--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -360,17 +360,14 @@ def get_mq_namespaces() -> List[str]:
 
 def process_events():
     event_content = []
-    namespaces = get_mq_namespaces()
 
-    for namespace in namespaces:
-        event_content.append(
-            {
-                "data": generic.sanitize_for_serialization(
-                    obj=client.CoreV1Api().list_namespaced_event(namespace=namespace)
-                ),
-                "zinfo": f"{namespace}/events.yaml",
-            }
-        )
+    core_v1_api = client.CoreV1Api()
+    event_content.append(
+        {
+            "data": generic.sanitize_for_serialization(obj=core_v1_api.list_event_for_all_namespaces()),
+            "zinfo": "events.yaml",
+        }
+    )
 
     return event_content
 

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -318,10 +318,10 @@ def mocked_list_nodes(mocked_client):
 
 
 @pytest.fixture
-def mocked_list_namespaced_events(mocked_client):
+def mocked_list_cluster_events(mocked_client):
     from kubernetes.client.models import CoreV1EventList, CoreV1Event, V1ObjectMeta
 
-    def _handle_list_namespaced_events(*args, **kwargs):
+    def _handle_list_cluster_events(*args, **kwargs):
         event = CoreV1Event(
             action="mock_action", involved_object="mock_object", metadata=V1ObjectMeta(name="mock_event")
         )
@@ -329,7 +329,7 @@ def mocked_list_namespaced_events(mocked_client):
 
         return event_list
 
-    mocked_client.CoreV1Api().list_namespaced_event.side_effect = _handle_list_namespaced_events
+    mocked_client.CoreV1Api().list_event_for_all_namespaces.side_effect = _handle_list_cluster_events
 
     yield mocked_client
 
@@ -343,9 +343,7 @@ def mocked_list_daemonsets(mocked_client):
         # @vilit - also akri
         daemonset_names = ["mock_daemonset"]
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            daemonset_names.extend(
-                ["aio-akri-agent-daemonset", "svclb-aio-lnm-operator"]
-            )
+            daemonset_names.extend(["aio-akri-agent-daemonset", "svclb-aio-lnm-operator"])
 
         daemonset_list = []
         for name in daemonset_names:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -84,7 +84,7 @@ def test_create_bundle(
     mocked_list_daemonsets,
     mocked_list_services,
     mocked_list_nodes,
-    mocked_list_namespaced_events,
+    mocked_list_cluster_events,
     mocked_get_stats,
     mocked_root_logger,
     mocked_mq_active_api,
@@ -554,10 +554,10 @@ def assert_mq_stats(mocked_zipfile):
 def assert_shared_kpis(mocked_client, mocked_zipfile):
     mocked_client.CoreV1Api().list_node.assert_called_once()
     assert_zipfile_write(mocked_zipfile, zinfo="nodes.yaml", data="items:\n- metadata:\n    name: mock_node\n")
-    mocked_client.CoreV1Api().list_namespaced_event.assert_called_once()
+    mocked_client.CoreV1Api().list_event_for_all_namespaces.assert_called_once()
     assert_zipfile_write(
         mocked_zipfile,
-        zinfo="mock_namespace/events.yaml",
+        zinfo="events.yaml",
         data="items:\n- action: mock_action\n  involvedObject: mock_object\n  metadata:\n    name: mock_event\n",
     )
 
@@ -623,7 +623,7 @@ def test_create_bundle_mq_traces(
     mocked_list_daemonsets,
     mocked_list_services,
     mocked_list_nodes,
-    mocked_list_namespaced_events,
+    mocked_list_cluster_events,
     mocked_get_stats,
     mocked_root_logger,
     mocked_mq_active_api,


### PR DESCRIPTION
* Rather than namespaced events capture cluster wide events. Main driver is deployment failures where using the existing support bundle has likelihood of not capturing events due to dependence of mq broker instances to determine which namespaces to pull events from.