### PR TITLE
ci: Add matrix strategy / feature set for init integration tests

### DIFF
--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -37,7 +37,7 @@ on:
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}
   CLUSTER_PREFIX: ${{ inputs.cluster_prefix || 'az-iot-ops-test-cluster' }}
-  KEYVAULT_PREFIX: ${{ inputs.keyvault_prefix || 'opstestkv' }}
+  KEYVAULT_PREFIX: ${{ inputs.keyvault_prefix || 'opskv' }}
 
 permissions:
   # required for OpenID federation

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         required: false
         default: false
+      custom-locations-oid:
+        description: Object ID of Custom Locations RP
+        type: string
+        required: false
+        default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -35,7 +40,11 @@ on:
         type: boolean
         required: false
         default: false
-
+      custom-locations-oid:
+        description: Object ID of Custom Locations RP
+        type: string
+        required: false
+        default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
 permissions:
   # required for OpenID federation
   contents: 'read'
@@ -62,7 +71,7 @@ jobs:
     needs: [create_kv]
     env:
       CLUSTER_NAME: "az-iot-ops-test-cluster${{ github.run_number }}${{ matrix.feature }}"
-      CUSTOM_LOCATIONS_OID: "51dfe1e8-70c6-4de5-a08e-e18aff23d815"
+      CUSTOM_LOCATIONS_OID: ${{ inputs.custom-locations-oid }}
       EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"
       K3S_VERSION: "v1.28.5+k3s1"
     strategy:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -56,8 +56,7 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: "Create Key Vault for clusters"
-      run: |
-        az keyvault create -n ${{ env.KV_NAME }} -g ${{ env.RESOURCE_GROUP }}
+      run: az keyvault create -n ${{ env.KV_NAME }} -g ${{ env.RESOURCE_GROUP }} --enable-rbac-authorization false
     
   test:
     needs: [create_kv]

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -173,10 +173,10 @@ jobs:
           ca-file: ${{ matrix.ca-file && format('--ca-file {0}', matrix.ca-file) || '' }}
           ca-key-file: ${{ matrix.ca-key-file && format('--ca-key-file {0}', matrix.ca-key-file) || '' }}
           ca-valid-days: ${{ matrix.ca-valid-days && format('--ca-valid-days {0}', matrix.ca-valid-days) || '' }}
-          disable-rsync-rules: ${{ matrix.disable-rsync-rules == 'true' && '--disable-rsync-rules' || '' }}
+          disable-rsync-rules: ${{ matrix.disable-rsync-rules && '--disable-rsync-rules' || '' }}
           kv-sat-secret-name: ${{ matrix.kv-sat-secret-name && format('--kv-sat-secret-name {0}', matrix.kv-sat-secret-name) || '' }}
-          mq-insecure: ${{ matrix.mq-insecure == 'true' && '--mq-insecure' || '' }}
-          no-preflight: ${{ matrix.no-preflight == 'true' && '--no-preflight' || '' }}
+          mq-insecure: ${{ matrix.mq-insecure && '--mq-insecure' || '' }}
+          no-preflight: ${{ matrix.no-preflight && '--no-preflight' || '' }}
         run: >-
           az iot ops init
           -g ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -44,8 +44,9 @@ permissions:
 jobs:
   integration_test:
     env:
-      CLUSTER_NAME: "az-iot-ops-test-cluster-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.feature }}"
-      KV_NAME: "opstestkv-${{ github.run_id }}-${{ github.run_attempt }}"
+      CLUSTER_NAME: "az-iot-ops-test-cluster${{ github.run_id }}${{ matrix.feature }}"
+      # TODO - KV Name has a hard limit of 24 chars
+      KV_NAME: "opstestkv${{ github.run_id }}${{ matrix.feature }}"
       CLUSTER_RG: ${{ inputs.resource_group }}
       CUSTOM_LOCATIONS_OID: "51dfe1e8-70c6-4de5-a08e-e18aff23d815"
       EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -41,38 +41,58 @@ permissions:
   contents: 'read'
   id-token: 'write'
 
+env:
+  KV_NAME: "opskv${{ github.run_number }}"
+  RESOURCE_GROUP: "${{ inputs.resource_group }}"
+
 jobs:
-  integration_test:
+  create_kv:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: "Az CLI login"
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: "Create Key Vault for clusters"
+      run: |
+        az keyvault create -n ${{ env.KV_NAME }} -g ${{ env.RESOURCE_GROUP }}
+    
+  test:
+    needs: [create_kv]
     env:
-      CLUSTER_NAME: "az-iot-ops-test-cluster${{ github.run_id }}${{ matrix.feature }}"
-      # TODO - KV Name has a hard limit of 24 chars
-      KV_NAME: "opstestkv${{ github.run_id }}${{ matrix.feature }}"
-      CLUSTER_RG: ${{ inputs.resource_group }}
+      CLUSTER_NAME: "az-iot-ops-test-cluster${{ github.run_number }}${{ matrix.feature }}"
       CUSTOM_LOCATIONS_OID: "51dfe1e8-70c6-4de5-a08e-e18aff23d815"
       EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"
       K3S_VERSION: "v1.28.5+k3s1"
     strategy:
       matrix:
-        feature: [std, mq]
+        feature: [default, mq-ins, syncrules, ca-certs]
         include:
-          - feature: mq
+          # default / limited options
+          - feature: default
+            ca-valid-days: 3
+            kv-sat-secret-name: test-kv-secret
+          # test --mq-insecure deployment
+          - feature: mq-ins
             mq-insecure: true
             no-preflight: true
-          - feature: std
-            ca-valid-days: 3
-    name: Integration test
+          # test disabling custom sync rules
+          - feature: syncrules
+            disable-rsync-rules: true
+          # test custom ca files
+          - feature: ca-certs
+            ca-file: 'test-ca.pem'
+            ca-key-file: 'test-ca-key.pem'
+    name: "Run cluster tests"
     runs-on: ubuntu-22.04
+    continue-on-error: true
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: "Checkout extension source"
-        uses: actions/checkout@v4
-        with:
-          # ensure source checkout uses our repo instead of calling workflow
-          repository: azure/azure-iot-ops-cli-extension
-          path: ${{ env.EXTENSION_SOURCE_DIRECTORY }}
       - name: "Create k3s cluster"
         run: |
           # vars
@@ -94,46 +114,85 @@ jobs:
           mkdir ~/.kube 2> /dev/null
           sudo k3s kubectl config view --raw > ~/.kube/config
           chmod 600 ~/.kube/config
-      - name: "Az CLI login"
-        uses: azure/login@v1
+      - name: "Checkout extension source for build"
+        uses: actions/checkout@v4
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: "Build and install IoT Ops extension"
+          # ensure source checkout uses our repo instead of calling workflow
+          repository: azure/azure-iot-ops-cli-extension
+          path: ${{ env.EXTENSION_SOURCE_DIRECTORY }}
+      - name: "Build and install local IoT Ops extension from source"
         run: |
           pip install wheel==0.30.0
           cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
           python -m setup bdist_wheel -d dist
           wheel=$(find ./dist/*.whl)
           az extension add --source $wheel -y
+      - name: "Az CLI login"
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: "ARC connect cluster"
         run: >-
           az extension add --name connectedk8s -y
 
-          az connectedk8s connect -n ${{ env.CLUSTER_NAME }} -g ${{ env.CLUSTER_RG }}
+          az connectedk8s connect -n ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }}
 
           az connectedk8s enable-features
           -n ${{ env.CLUSTER_NAME }}
-          -g ${{ env.CLUSTER_RG }}
+          -g ${{ env.RESOURCE_GROUP }}
           --features custom-locations cluster-connect
           --custom-locations-oid ${{ env.CUSTOM_LOCATIONS_OID }}
+      - name: "Get Keyvault ID"
+        run: |
+          KV_ID=$(az keyvault show -n ${{env.KV_NAME}} -g ${{ env.RESOURCE_GROUP }} -o tsv --query id)
+          echo "KV_ID=$KV_ID" >> $GITHUB_ENV
+      - name: "Create CA certificates"
+        if: ${{matrix.feature == 'ca-certs'}}
+        run: |
+          >ca.conf cat <<-EOF
+          [ req ]
+          distinguished_name = req_distinguished_name
+          prompt = no
+          x509_extensions = v3_ca
+
+          [ req_distinguished_name ]
+          CN=Azure IoT Operations CLI IT non-prod
+
+          [ v3_ca ]
+          basicConstraints = critical, CA:TRUE
+          keyUsage = keyCertSign
+          subjectKeyIdentifier = hash
+          authorityKeyIdentifier = keyid
+          EOF
+          openssl ecparam -name prime256v1 -genkey -noout -out ${{ matrix.ca-key-file }}
+          openssl req -new -x509 -key ${{ matrix.ca-key-file }} -days 30 -config ca.conf -out ${{ matrix.ca-file }}
+          rm ca.conf
       - name: "AIO Deployment"
         env:
-          preflight: ${{ matrix.no-preflight && '--no-preflight'}}
-          mq-insecure: ${{ matrix.mq-insecure && '--mq-insecure'}}
-          ca-valid-days: ${{ matrix.ca-valid-days && format('--ca-valid-days {0}', matrix.ca-valid-days)}}
+          ca-file: ${{ matrix.ca-file && format('--ca-file {0}', matrix.ca-file) || '' }}
+          ca-key-file: ${{ matrix.ca-key-file && format('--ca-key-file {0}', matrix.ca-key-file) || '' }}
+          ca-valid-days: ${{ matrix.ca-valid-days && format('--ca-valid-days {0}', matrix.ca-valid-days) || '' }}
+          disable-rsync-rules: ${{ matrix.disable-rsync-rules == 'true' && '--disable-rsync-rules' || '' }}
+          kv-sat-secret-name: ${{ matrix.kv-sat-secret-name && format('--kv-sat-secret-name {0}', matrix.kv-sat-secret-name) || '' }}
+          mq-insecure: ${{ matrix.mq-insecure == 'true' && '--mq-insecure' || '' }}
+          no-preflight: ${{ matrix.no-preflight == 'true' && '--no-preflight' || '' }}
         run: >-
           az iot ops init
-          -g ${{ env.CLUSTER_RG }}
+          -g ${{ env.RESOURCE_GROUP }}
           --cluster ${{ env.CLUSTER_NAME }}
-          --kv-id $(az keyvault create -n ${{ env.KV_NAME }} -g ${{ env.CLUSTER_RG }} -o tsv --query id)
+          --kv-id ${{ env.KV_ID }}
           --sp-app-id ${{ secrets.AZURE_CLIENT_ID }}
           --sp-object-id ${{ secrets.AZURE_OBJECT_ID }}
           --sp-secret ${{ secrets.AZURE_CLIENT_SECRET }}
-          ${{ env.preflight || '' }}
-          ${{ env.mq-insecure || '' }}
-          ${{ env.ca-valid-days || '' }}
+          ${{ env.ca-file }}
+          ${{ env.ca-key-file }}
+          ${{ env.ca-valid-days }}
+          ${{ env.disable-rsync-rules }}
+          ${{ env.kv-sat-secret-name }}
+          ${{ env.mq-insecure }}
+          ${{ env.no-preflight }}
           --no-progress
       - name: "Allow cluster to finish provisioning"
         run: |
@@ -156,15 +215,16 @@ jobs:
           az iot ops mq stats
           az iot ops mq stats --raw
           az iot ops mq get-password-hash -p test
-          az iot ops asset query -g ${{ env.CLUSTER_RG }}
+          az iot ops asset query -g ${{ env.RESOURCE_GROUP }}
           az iot ops verify-host
+
   # Optional cleanup job
   cleanup:
-    needs: [integration_test]
+    needs: [test]
     if: ${{ github.event.inputs.cleanup == 'true' }}
     uses: './.github/workflows/cluster_cleanup.yml'
     with:
-      cluster_prefix: az-iot-ops-test-cluster${{ github.run_id }}
-      resource_group: ${{ inputs.resource_group }}
-      keyvault_prefix: opstestkv${{ github.run_id }}
+      cluster_prefix: "az-iot-ops-test-cluster${{ github.run_number }}"
+      resource_group: "${{ inputs.resource_group }}"
+      keyvault_prefix: "opskv${{ github.run_number }}"
     secrets: inherit

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -196,11 +196,6 @@ jobs:
       - name: "Allow cluster to finish provisioning"
         run: |
           sleep 1m
-      - name: "Run 'az iot ops check'"
-        run: |
-          echo "### Run checks" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          az iot ops check >> $GITHUB_STEP_SUMMARY
       - name: "Run smoke tests"
         run: |
           az iot ops support create-bundle --svc auto

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -36,14 +36,6 @@ on:
         required: false
         default: false
 
-env:
-  CLUSTER_NAME: "az-iot-ops-test-cluster-${{ github.run_id }}-${{ github.run_attempt }}"
-  KV_NAME: "opstestkv-${{ github.run_id }}-${{ github.run_attempt }}"
-  CLUSTER_RG: ${{ inputs.resource_group }}
-  CUSTOM_LOCATIONS_OID: "51dfe1e8-70c6-4de5-a08e-e18aff23d815"
-  EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"
-  K3S_VERSION: "v1.28.5+k3s1"
-
 permissions:
   # required for OpenID federation
   contents: 'read'
@@ -51,6 +43,20 @@ permissions:
 
 jobs:
   integration_test:
+    env:
+      CLUSTER_NAME: "az-iot-ops-test-cluster-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.feature }}"
+      KV_NAME: "opstestkv-${{ github.run_id }}-${{ github.run_attempt }}"
+      CLUSTER_RG: ${{ inputs.resource_group }}
+      CUSTOM_LOCATIONS_OID: "51dfe1e8-70c6-4de5-a08e-e18aff23d815"
+      EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"
+      K3S_VERSION: "v1.28.5+k3s1"
+    strategy:
+      matrix:
+        feature: [std, mq]
+        include:
+          - feature: mq
+            mq-insecure: true
+            no-preflight: true
     name: Integration test
     runs-on: ubuntu-22.04
     outputs:
@@ -114,7 +120,7 @@ jobs:
           --features custom-locations cluster-connect
           --custom-locations-oid ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "AIO Deployment"
-        run: >-
+        run: |-
           az iot ops init
           -g ${{ env.CLUSTER_RG }}
           --cluster ${{ env.CLUSTER_NAME }}
@@ -122,6 +128,8 @@ jobs:
           --sp-app-id ${{ secrets.AZURE_CLIENT_ID }}
           --sp-object-id ${{ secrets.AZURE_OBJECT_ID }}
           --sp-secret ${{ secrets.AZURE_CLIENT_SECRET }}
+          ${{ matrix.no-preflight == 'true' && '--no-preflight' || ''}}
+          ${{ matrix.mq-insecure == 'true' && '--mq-insecure' || ''}}
           --no-progress
       - name: "Allow cluster to finish provisioning"
         run: |

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -7,16 +7,16 @@ on:
         type: string
         required: true
         default: ops-cli-int-test-rg
+      custom-locations-oid:
+        description: Custom Locations OID
+        type: string
+        required: false
+        default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
       cleanup:
         description: Attempt to cleanup resources after testing
         type: boolean
         required: false
         default: false
-      custom-locations-oid:
-        description: Object ID of Custom Locations RP
-        type: string
-        required: false
-        default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
     secrets:
       # required for az login
       AZURE_CLIENT_ID:
@@ -28,7 +28,7 @@ on:
       # optional --sp-* init params
       AIO_SP_APP_ID:
       AIO_SP_OBJECT_ID:
-      AIO_SP_APP_SECRET:
+      AIO_SP_SECRET:
   workflow_dispatch:
     inputs:
       resource_group:
@@ -36,16 +36,17 @@ on:
         type: string
         required: true
         default: ops-cli-int-test-rg
-      cleanup:
-        description: Attempt to cleanup resources after testing
-        type: boolean
-        required: false
-        default: false
       custom-locations-oid:
         description: Object ID of Custom Locations RP
         type: string
         required: false
         default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
+      cleanup:
+        description: Attempt to cleanup resources after testing
+        type: boolean
+        required: false
+        default: false
+
 permissions:
   # required for OpenID federation
   contents: 'read'
@@ -77,18 +78,18 @@ jobs:
       K3S_VERSION: "v1.28.5+k3s1"
     strategy:
       matrix:
-        feature: [default, mq-ins, syncrules, ca-certs]
+        feature: [default, mq-insecure, no-syncrules, ca-certs]
         include:
           # default / limited options
           - feature: default
             ca-valid-days: 3
             kv-sat-secret-name: test-kv-secret
           # test --mq-insecure deployment
-          - feature: mq-ins
+          - feature: mq-insecure
             mq-insecure: true
             no-preflight: true
           # test disabling custom sync rules
-          - feature: syncrules
+          - feature: no-syncrules
             disable-rsync-rules: true
           # test custom ca files
           - feature: ca-certs
@@ -189,7 +190,7 @@ jobs:
           no-preflight: ${{ matrix.no-preflight && '--no-preflight' || '' }}
           SP_APP_ID: ${{ secrets.AIO_SP_APP_ID && format('--sp-app-id {0}', secrets.AIO_SP_APP_ID) || '' }}
           SP_OBJECT_ID: ${{ secrets.AIO_SP_OBJECT_ID && format('--sp-object-id {0}', secrets.AIO_SP_OBJECT_ID) || '' }}
-          SP_APP_SECRET: ${{ secrets.AIO_SP_APP_SECRET && format('--sp-secret {0}', secrets.AIO_SP_APP_SECRET) || '' }}
+          SP_APP_SECRET: ${{ secrets.AIO_SP_SECRET && format('--sp-secret {0}', secrets.AIO_SP_SECRET) || '' }}
         run: >-
           az iot ops init
           -g ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -18,16 +18,17 @@ on:
         required: false
         default: '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
     secrets:
+      # required for az login
       AZURE_CLIENT_ID:
         required: true
       AZURE_TENANT_ID:
         required: true
       AZURE_SUBSCRIPTION_ID:
         required: true
-      AZURE_OBJECT_ID:
-        required: true
-      AZURE_CLIENT_SECRET:
-        required: true
+      # optional --sp-* init params
+      AIO_SP_APP_ID:
+      AIO_SP_OBJECT_ID:
+      AIO_SP_APP_SECRET:
   workflow_dispatch:
     inputs:
       resource_group:
@@ -186,14 +187,17 @@ jobs:
           kv-sat-secret-name: ${{ matrix.kv-sat-secret-name && format('--kv-sat-secret-name {0}', matrix.kv-sat-secret-name) || '' }}
           mq-insecure: ${{ matrix.mq-insecure && '--mq-insecure' || '' }}
           no-preflight: ${{ matrix.no-preflight && '--no-preflight' || '' }}
+          SP_APP_ID: ${{ secrets.AIO_SP_APP_ID && format('--sp-app-id {0}', secrets.AIO_SP_APP_ID) || '' }}
+          SP_OBJECT_ID: ${{ secrets.AIO_SP_OBJECT_ID && format('--sp-object-id {0}', secrets.AIO_SP_OBJECT_ID) || '' }}
+          SP_APP_SECRET: ${{ secrets.AIO_SP_APP_SECRET && format('--sp-secret {0}', secrets.AIO_SP_APP_SECRET) || '' }}
         run: >-
           az iot ops init
           -g ${{ env.RESOURCE_GROUP }}
           --cluster ${{ env.CLUSTER_NAME }}
           --kv-id ${{ env.KV_ID }}
-          --sp-app-id ${{ secrets.AZURE_CLIENT_ID }}
-          --sp-object-id ${{ secrets.AZURE_OBJECT_ID }}
-          --sp-secret ${{ secrets.AZURE_CLIENT_SECRET }}
+          ${{ env.SP_APP_ID }}
+          ${{ env.SP_OBJECT_ID }}
+          ${{ env.SP_APP_SECRET }}
           ${{ env.ca-file }}
           ${{ env.ca-key-file }}
           ${{ env.ca-valid-days }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -161,7 +161,7 @@ jobs:
     if: ${{ github.event.inputs.cleanup == 'true' }}
     uses: './.github/workflows/cluster_cleanup.yml'
     with:
-      cluster_prefix: ${{ needs.integration_test.outputs.cluster_name }}
-      resource_group: ${{ needs.integration_test.outputs.resource_group }}
-      keyvault_prefix: ${{ needs.integration_test.outputs.keyvault_name }}
+      cluster_prefix: az-iot-ops-test-cluster${{ github.run_id }}
+      resource_group: ${{ inputs.resource_group }}
+      keyvault_prefix: opstestkv${{ github.run_id }}
     secrets: inherit

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -58,6 +58,8 @@ jobs:
           - feature: mq
             mq-insecure: true
             no-preflight: true
+          - feature: std
+            ca-valid-days: 3
     name: Integration test
     runs-on: ubuntu-22.04
     outputs:
@@ -121,6 +123,10 @@ jobs:
           --features custom-locations cluster-connect
           --custom-locations-oid ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "AIO Deployment"
+        env:
+          preflight: ${{ matrix.no-preflight && '--no-preflight'}}
+          mq-insecure: ${{ matrix.mq-insecure && '--mq-insecure'}}
+          ca-valid-days: ${{ matrix.ca-valid-days && format('--ca-valid-days {0}', matrix.ca-valid-days)}}
         run: >-
           az iot ops init
           -g ${{ env.CLUSTER_RG }}
@@ -129,8 +135,9 @@ jobs:
           --sp-app-id ${{ secrets.AZURE_CLIENT_ID }}
           --sp-object-id ${{ secrets.AZURE_OBJECT_ID }}
           --sp-secret ${{ secrets.AZURE_CLIENT_SECRET }}
-          ${{ matrix.no-preflight && '--no-preflight' || ''}}
-          ${{ matrix.mq-insecure && '--mq-insecure' || ''}}
+          ${{ env.preflight || '' }}
+          ${{ env.mq-insecure || '' }}
+          ${{ env.ca-valid-days || '' }}
           --no-progress
       - name: "Allow cluster to finish provisioning"
         run: |

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -62,10 +62,6 @@ jobs:
             ca-valid-days: 3
     name: Integration test
     runs-on: ubuntu-22.04
-    outputs:
-      cluster_name: ${{ env.CLUSTER_NAME }}
-      resource_group: ${{ env.CLUSTER_RG }}
-      keyvault_name: ${{ env.KV_NAME }}
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v5

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -129,8 +129,8 @@ jobs:
           --sp-app-id ${{ secrets.AZURE_CLIENT_ID }}
           --sp-object-id ${{ secrets.AZURE_OBJECT_ID }}
           --sp-secret ${{ secrets.AZURE_CLIENT_SECRET }}
-          ${{ matrix.no-preflight == 'true' && '--no-preflight' || ''}}
-          ${{ matrix.mq-insecure == 'true' && '--mq-insecure' || ''}}
+          ${{ matrix.no-preflight && '--no-preflight' || ''}}
+          ${{ matrix.mq-insecure && '--mq-insecure' || ''}}
           --no-progress
       - name: "Allow cluster to finish provisioning"
         run: |

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -121,7 +121,7 @@ jobs:
           --features custom-locations cluster-connect
           --custom-locations-oid ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "AIO Deployment"
-        run: |-
+        run: >-
           az iot ops init
           -g ${{ env.CLUSTER_RG }}
           --cluster ${{ env.CLUSTER_NAME }}


### PR DESCRIPTION
Adds the following matrix strategy to our integration test workflow to configure AIO init feature sets:
```yaml
strategy:
  matrix:
    feature: [default, mq-ins, syncrules, ca-certs]
    include:
      # default / limited options
      - feature: default
        ca-valid-days: 3
        kv-sat-secret-name: test-kv-secret
      # test --mq-insecure deployment
      - feature: mq-ins
        mq-insecure: true
        no-preflight: true
      # test disabling custom sync rules
      - feature: syncrules
        disable-rsync-rules: true
      # test custom ca files
      - feature: ca-certs
        ca-file: 'test-ca.pem'
        ca-key-file: 'test-ca-key.pem'
```
This allows us to spin up multiple clusters to test various init configurations.

In this example, each string in `feature: [default...]` are the feature sets, and any extra options under `include` for that feature are matrix options added to that `feature`.

The resulting test matrix looks like this:
```
[
    { feature: 'mq-ins', mq-insecure: true, no-preflight: true },
    { feature: 'default', ca-valid-days: 3 }
]
```

Variables are then expanded (if they exist) into arguments in environment vars for the job:
```yaml
env:
  preflight: ${{ matrix.no-preflight && '--no-preflight'}}
  mq-insecure: ${{ matrix.mq-insecure && '--mq-insecure'}}
  ca-valid-days: ${{ matrix.ca-valid-days && format('--ca-valid-days {0}', matrix.ca-valid-days)}}
```

And then conditionally added to the `az iot ops init` command string like so:

```sh
az iot ops init
-g ${{ env.CLUSTER_RG }}
--cluster ${{ env.CLUSTER_NAME }}
...
${{ env.preflight || '' }}
${{ env.mq-insecure || '' }}
${{ env.ca-valid-days || '' }}
```

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
