### PR TITLE
fix(ci): Int tests - remove continue-on-fail and add second az login to update token

### DIFF
--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: "Az CLI login"
-      uses: azure/login@v1
+      uses: azure/login@v1.6.1
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -138,7 +138,7 @@ jobs:
           wheel=$(find ./dist/*.whl)
           az extension add --source $wheel -y
       - name: "Az CLI login"
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -210,6 +210,12 @@ jobs:
       - name: "Allow cluster to finish provisioning"
         run: |
           sleep 1m
+      - name: "Az CLI login refresh"
+        uses: azure/login@v1.6.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: "Run smoke tests"
         run: |
           az iot ops support create-bundle --svc auto

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -77,6 +77,7 @@ jobs:
       EXTENSION_SOURCE_DIRECTORY: "./azure-iot-ops-cli-extension"
       K3S_VERSION: "v1.28.5+k3s1"
     strategy:
+      fail-fast: false
       matrix:
         feature: [default, mq-insecure, no-syncrules, ca-certs]
         include:
@@ -97,7 +98,6 @@ jobs:
             ca-key-file: 'test-ca-key.pem'
     name: "Run cluster tests"
     runs-on: ubuntu-22.04
-    continue-on-error: true
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v5
@@ -223,7 +223,7 @@ jobs:
           az iot ops mq stats
           az iot ops mq stats --raw
           az iot ops mq get-password-hash -p test
-          az iot ops asset query -g ${{ env.RESOURCE_GROUP }}
+          az iot ops asset query -g ${{ env.RESOURCE_GROUP }} --location westus -o table
           az iot ops verify-host
 
   # Optional cleanup job


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
