### PR TITLE
ci: Auto pull request from release branch into main after release publish

### DIFF
--- a/.github/workflows/conventional_pr.yml
+++ b/.github/workflows/conventional_pr.yml
@@ -7,6 +7,7 @@ on:
         ready_for_review,
         reopened,
     ]
+    branches-ignore: [main]
 jobs:
   verify_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,27 @@
+name: "[auto] PR to main on release"
+run-name: Create Release PR for ${{github.event.release.name}}
+on:
+  release:
+    types: [published]
+permissions:
+  pull-requests: write
+
+jobs:
+  create-pr:
+    env:
+      tag: ${{ github.event.release.tag_name }}
+      body: ${{ github.event.release.body }}
+      branch: ${{ github.event.release.target_commitish }}
+      reviewer: ${{ github.event.sender.login }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: "Create pull Request to main"
+        continue-on-error: true
+        env:
+            GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh pr create --base main --head $branch --title "Release $tag" --body "$body" --reviewer $reviewer)
+          echo "Created pull request to main: $PR_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Once a new release is `published` (from `dev`), this workflow will run to create a PR from that branch to `main` using the title and tag of the release.

This also updates our conventional PR title check to exclude PRs to the `main` branch

Example workflow:
- Release created: https://github.com/c-ryan-k/azure-iot-ops-cli-extension/releases/tag/v1.2.3b45
- Action Run: https://github.com/c-ryan-k/azure-iot-ops-cli-extension/actions/runs/8024344609
- PR created: https://github.com/c-ryan-k/azure-iot-ops-cli-extension/pull/5

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
