### PR TITLE
chore(ci): Change action reference to public repo dev branch

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -2,7 +2,7 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
-      resource_group:
+      resource-group:
         description: Resource group for cluster creation
         type: string
         required: true
@@ -31,7 +31,7 @@ on:
       AIO_SP_SECRET:
   workflow_dispatch:
     inputs:
-      resource_group:
+      resource-group:
         description: Resource group for cluster creation
         type: string
         required: true
@@ -54,7 +54,7 @@ permissions:
 
 env:
   KV_NAME: "opskv${{ github.run_number }}"
-  RESOURCE_GROUP: "${{ inputs.resource_group }}"
+  RESOURCE_GROUP: "${{ inputs.resource-group }}"
 
 jobs:
   create_kv:
@@ -222,6 +222,6 @@ jobs:
     uses: './.github/workflows/cluster_cleanup.yml'
     with:
       cluster_prefix: "az-iot-ops-test-cluster${{ github.run_number }}"
-      resource_group: "${{ inputs.resource_group }}"
+      resource_group: "${{ inputs.resource-group }}"
       keyvault_prefix: "opskv${{ github.run_number }}"
     secrets: inherit

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -143,12 +143,8 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        # TODO: not needed when actions are in default branch
-      - name: "Checkout source for actions"
-        uses: actions/checkout@v4
-        # TODO: update action path to azure/azure-iot-ops/.github/actions/connect-arc
       - name: "ARC connect cluster"
-        uses: ./.github/actions/connect-arc
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/connect-arc@dev
         with:
           cluster-name: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -178,9 +174,8 @@ jobs:
           openssl ecparam -name prime256v1 -genkey -noout -out ${{ matrix.ca-key-file }}
           openssl req -new -x509 -key ${{ matrix.ca-key-file }} -days 30 -config ca.conf -out ${{ matrix.ca-file }}
           rm ca.conf
-      # TODO: update action path to azure/azure-iot-ops/.github/actions/deploy-aio
       - name: "AIO Deployment"
-        uses: ./.github/actions/deploy-aio
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -36,13 +36,14 @@ In order to run these tests, you must provide the following service principal va
 The following values are also required in order to run the `az iot ops init` command, using the same service principal in order to deploy AIO to a cluster:
 | Secret | Description |
 |---|---|
-**AZURE_OBJECT_ID** | *Entra Application Object ID*
-**AZURE_CLIENT_SECRET** | *Entra Application Client Secret*
+**AIO_SP_APP_ID** | *Entra Application client ID*
+**AIO_SP_OBJECT_ID** | *Entra Application Object ID*
+**AIO_SP_SECRET** | *Entra Application Client Secret*
 
 The final set of inputs are more traditional workflow inputs:
 | Input | Description |
 |---|---|
-**resource_group** | *The resource group to run tests in*
+**resource-group** | *The resource group to run tests in*
 **cleanup** | *An optional boolean switch that decides whether to attempt post-test cleanup rather than waiting for a scheduled cleanup job*
 
 ## Outputs


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
