### PR TITLE
refactor: update dp support bundle and checks for new 0.4.0 template

### DIFF
--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -192,7 +192,6 @@ DATA_PROCESSOR_RUNNER_WORKER_PREFIX = "aio-dp-runner-worker"
 DATA_PROCESSOR_REFDATA_STORE_PREFIX = "aio-dp-refdata-store"
 DATA_PROCESSOR_NATS_PREFIX = "aio-dp-msg-store"
 DATA_PROCESSOR_OPERATOR = "aio-dp-operator"
-DATA_PROCESSOR_NFS_SERVER_PROVISIONER = "aio-dp-nfs-server-provisioner"
 
 # MQ runtime attributes
 

--- a/azext_edge/edge/providers/check/dataprocessor.py
+++ b/azext_edge/edge/providers/check/dataprocessor.py
@@ -29,7 +29,6 @@ from .common import (
     DATA_PROCESSOR_INTERMEDIATE_STAGE_PROPERTIES,
     DATA_PROCESSOR_NATS_PREFIX,
     DATA_PROCESSOR_OPERATOR,
-    DATA_PROCESSOR_NFS_SERVER_PROVISIONER,
     DATA_PROCESSOR_READER_WORKER_PREFIX,
     DATA_PROCESSOR_REFDATA_STORE_PREFIX,
     DATA_PROCESSOR_RUNNER_WORKER_PREFIX,
@@ -193,7 +192,6 @@ def evaluate_instances(
                 DATA_PROCESSOR_REFDATA_STORE_PREFIX,
                 DATA_PROCESSOR_NATS_PREFIX,
                 DATA_PROCESSOR_OPERATOR,
-                DATA_PROCESSOR_NFS_SERVER_PROVISIONER,
             ]:
                 evaluate_pod_health(
                     check_manager=check_manager,

--- a/azext_edge/edge/providers/support/dataprocessor.py
+++ b/azext_edge/edge/providers/support/dataprocessor.py
@@ -29,13 +29,8 @@ DATA_PROCESSOR_APP_LABELS = [
     'aio-dp-operator',
 ]
 
-DATA_PROCESSOR_PREFIX = "aio-dp-"
 DATA_PROCESSOR_LABEL = f"app in ({','.join(DATA_PROCESSOR_APP_LABELS)})"
-DATA_PROCESSOR_RELEASE_LABEL = "release in (processor)"
-DATA_PROCESSOR_INSTANCE_LABEL = "app.kubernetes.io/instance in (processor)"
-DATA_PROCESSOR_PART_OF_LABEL = "app.kubernetes.io/part-of in (aio-dp-operator)"
 DATA_PROCESSOR_NAME_LABEL = "app.kubernetes.io/name in (dataprocessor)"
-DATA_PROCESSOR_ONEOFF_LABEL = "control-plane in (controller-manager)"
 
 
 def fetch_pods(since_seconds: int = 60 * 60 * 24):

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -28,12 +28,8 @@ from azext_edge.edge.providers.edge_api import (
 from azext_edge.edge.providers.support.akri import AKRI_NAME_LABEL, AKRI_SERVICE_LABEL
 from azext_edge.edge.providers.support.base import get_bundle_path
 from azext_edge.edge.providers.support.dataprocessor import (
-    DATA_PROCESSOR_INSTANCE_LABEL,
     DATA_PROCESSOR_LABEL,
     DATA_PROCESSOR_NAME_LABEL,
-    DATA_PROCESSOR_ONEOFF_LABEL,
-    DATA_PROCESSOR_PART_OF_LABEL,
-    DATA_PROCESSOR_RELEASE_LABEL,
 )
 from azext_edge.edge.providers.support.lnm import LNM_APP_LABELS
 from azext_edge.edge.providers.support.mq import MQ_LABEL
@@ -197,12 +193,6 @@ def test_create_bundle(
             assert_list_deployments(
                 mocked_client, mocked_zipfile, label_selector=DATA_PROCESSOR_LABEL, resource_api=DATA_PROCESSOR_API_V1
             )
-            assert_list_deployments(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=DATA_PROCESSOR_PART_OF_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-            )
 
             assert_list_pods(
                 mocked_client,
@@ -212,51 +202,15 @@ def test_create_bundle(
                 resource_api=DATA_PROCESSOR_API_V1,
                 since_seconds=since_seconds,
             )
-            assert_list_pods(
-                mocked_client,
-                mocked_zipfile,
-                mocked_list_pods,
-                label_selector=DATA_PROCESSOR_INSTANCE_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-                since_seconds=since_seconds,
-            )
-            assert_list_pods(
-                mocked_client,
-                mocked_zipfile,
-                mocked_list_pods,
-                label_selector=DATA_PROCESSOR_RELEASE_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-                since_seconds=since_seconds,
-            )
-            assert_list_pods(
-                mocked_client,
-                mocked_zipfile,
-                mocked_list_pods,
-                label_selector=DATA_PROCESSOR_ONEOFF_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-                since_seconds=since_seconds,
-            )
 
             assert_list_replica_sets(
                 mocked_client, mocked_zipfile, label_selector=DATA_PROCESSOR_LABEL, resource_api=DATA_PROCESSOR_API_V1
             )
-            assert_list_replica_sets(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=DATA_PROCESSOR_ONEOFF_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-            )
 
             assert_list_stateful_sets(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=DATA_PROCESSOR_RELEASE_LABEL,
-                resource_api=DATA_PROCESSOR_API_V1,
-            )
-            assert_list_stateful_sets(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=DATA_PROCESSOR_INSTANCE_LABEL,
+                label_selector=DATA_PROCESSOR_LABEL,
                 resource_api=DATA_PROCESSOR_API_V1,
             )
 


### PR DESCRIPTION
for support bundle: remove the label for no longer existed pod, and remove some code that seems to get repetitive resource
for check: remove the label for no longer existed pod
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
