### PR TITLE
fix: update akri labels for `az iot ops support create-bundle`

### DIFF
--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -25,6 +25,7 @@ logger = get_logger(__name__)
 AKRI_INSTANCE_LABEL = "app.kubernetes.io/instance in (akri)"
 AKRI_APP_LABEL = "app in (otel-collector)"
 AKRI_SERVICE_LABEL = "service in (aio-akri-metrics)"
+AKRI_PREFIXES = ["aio-akri-"]
 
 
 def fetch_pods(since_seconds: int = 60 * 60 * 24):

--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -22,47 +22,61 @@ from .base import (
 logger = get_logger(__name__)
 
 
-AKRI_NAME_LABEL = "name in (aio-akri-agent)"
+AKRI_INSTANCE_LABEL = "app.kubernetes.io/instance in (akri)"
+AKRI_APP_LABEL = "app in (otel-collector)"
 AKRI_SERVICE_LABEL = "service in (aio-akri-metrics)"
-AKRI_PREFIXES = ["aio-akri-", "akri-"]
 
 
 def fetch_pods(since_seconds: int = 60 * 60 * 24):
     processed = process_v1_pods(
         resource_api=AKRI_API_V0,
-        prefix_names=AKRI_PREFIXES,
+        label_selector=AKRI_INSTANCE_LABEL,
         since_seconds=since_seconds,
         capture_previous_logs=True,
     )
     processed.extend(
         process_v1_pods(
             resource_api=AKRI_API_V0,
-            label_selector=AKRI_NAME_LABEL,
+            label_selector=AKRI_APP_LABEL,
             since_seconds=since_seconds,
             capture_previous_logs=True,
         )
     )
-
     return processed
 
 
 def fetch_deployments():
-    return process_deployments(
+    processed = process_deployments(
         resource_api=AKRI_API_V0,
-        prefix_names=AKRI_PREFIXES,
+        label_selector=AKRI_INSTANCE_LABEL,
     )
+    processed.extend(
+        process_deployments(
+            resource_api=AKRI_API_V0,
+            label_selector=AKRI_APP_LABEL,
+        )
+    )
+    return processed
 
 
 def fetch_daemonsets():
-    return process_daemonsets(resource_api=AKRI_API_V0, prefix_names=AKRI_PREFIXES)
+    return process_daemonsets(resource_api=AKRI_API_V0, label_selector=AKRI_INSTANCE_LABEL)
 
 
 def fetch_services():
-    return process_services(resource_api=AKRI_API_V0, label_selector=AKRI_SERVICE_LABEL)
+    processed = process_services(resource_api=AKRI_API_V0, label_selector=AKRI_SERVICE_LABEL)
+    processed.extend(
+        process_services(resource_api=AKRI_API_V0, label_selector=AKRI_INSTANCE_LABEL)
+    )
+    return processed
 
 
 def fetch_replicasets():
-    return process_replicasets(resource_api=AKRI_API_V0, prefix_names=AKRI_PREFIXES)
+    processed = process_replicasets(resource_api=AKRI_API_V0, label_selector=AKRI_INSTANCE_LABEL)
+    processed.extend(
+        process_replicasets(resource_api=AKRI_API_V0, label_selector=AKRI_APP_LABEL)
+    )
+    return processed
 
 
 support_runtime_elements = {

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -215,12 +215,10 @@ def mocked_list_deployments(mocked_client):
     def _handle_list_deployments(*args, **kwargs):
         names = ["mock_deployment"]
         # @jiacju - currently no unique label for lnm
-        # @vilit - also akri
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
             names.extend(
                 [
                     "aio-lnm-operator",
-                    "aio-akri-otel-collector",
                     "aio-opc-admission-controller",
                     "aio-opc-supervisor",
                     "aio-opc-opc",
@@ -246,10 +244,6 @@ def mocked_list_replicasets(mocked_client):
 
     def _handle_list_replicasets(*args, **kwargs):
         names = ["mock_replicaset"]
-        # @vilit - also akri
-        if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            names.extend(["aio-akri-otel-collector"])
-
         replicaset_list = []
         for name in names:
             replicaset_list.append(V1ReplicaSet(metadata=V1ObjectMeta(namespace="mock_namespace", name=name)))
@@ -340,10 +334,9 @@ def mocked_list_daemonsets(mocked_client):
 
     def _handle_list_daemonsets(*args, **kwargs):
         # @jiacju - currently no unique label for lnm
-        # @vilit - also akri
         daemonset_names = ["mock_daemonset"]
         if "label_selector" in kwargs and kwargs["label_selector"] is None:
-            daemonset_names.extend(["aio-akri-agent-daemonset", "svclb-aio-lnm-operator"])
+            daemonset_names.extend(["svclb-aio-lnm-operator"])
 
         daemonset_list = []
         for name in daemonset_names:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -49,7 +49,6 @@ from azext_edge.edge.providers.support.orc import (
 from azext_edge.edge.providers.support_bundle import COMPAT_MQ_APIS
 
 from ...generators import generate_generic_id
-from .conftest import add_pod_to_mocked_pods
 
 a_bundle_dir = f"support_test_{generate_generic_id()}"
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -25,7 +25,7 @@ from azext_edge.edge.providers.edge_api import (
     ORC_API_V1,
     EdgeResourceApi,
 )
-from azext_edge.edge.providers.support.akri import AKRI_NAME_LABEL, AKRI_SERVICE_LABEL
+from azext_edge.edge.providers.support.akri import AKRI_APP_LABEL, AKRI_INSTANCE_LABEL, AKRI_SERVICE_LABEL
 from azext_edge.edge.providers.support.base import get_bundle_path
 from azext_edge.edge.providers.support.dataprocessor import (
     DATA_PROCESSOR_INSTANCE_LABEL,
@@ -96,10 +96,6 @@ def test_create_bundle(
         mocked_root_logger.warning.assert_called_once_with("No known IoT Operations services discovered on cluster.")
         assert auto_result_no_resources is None
         return
-
-    # @vilit - AKRI pod with ambigious label
-    if AKRI_API_V0 in mocked_cluster_resources["param"]:
-        add_pod_to_mocked_pods(mocked_client, mocked_list_pods, ["aio-akri-otel-collector"])
 
     since_seconds = random.randint(86400, 172800)
     result = support_bundle(None, bundle_dir=a_bundle_dir, log_age_seconds=since_seconds)
@@ -293,7 +289,7 @@ def test_create_bundle(
                 mocked_client,
                 mocked_zipfile,
                 mocked_list_pods,
-                label_selector=AKRI_NAME_LABEL,
+                label_selector=AKRI_INSTANCE_LABEL,
                 resource_api=AKRI_API_V0,
                 since_seconds=since_seconds,
             )
@@ -301,34 +297,45 @@ def test_create_bundle(
                 mocked_client,
                 mocked_zipfile,
                 mocked_list_pods,
-                label_selector=None,
+                label_selector=AKRI_APP_LABEL,
                 resource_api=AKRI_API_V0,
                 since_seconds=since_seconds,
-                mock_names=["aio-akri-otel-collector"],
             )
             assert_list_deployments(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=None,
+                label_selector=AKRI_INSTANCE_LABEL,
                 resource_api=AKRI_API_V0,
-                mock_names=["aio-akri-otel-collector"],
+            )
+            assert_list_deployments(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=AKRI_APP_LABEL,
+                resource_api=AKRI_API_V0,
             )
             assert_list_replica_sets(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=None,
+                label_selector=AKRI_INSTANCE_LABEL,
                 resource_api=AKRI_API_V0,
-                mock_names=["aio-akri-otel-collector"],
+            )
+            assert_list_replica_sets(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=AKRI_APP_LABEL,
+                resource_api=AKRI_API_V0,
             )
             assert_list_services(
                 mocked_client, mocked_zipfile, label_selector=AKRI_SERVICE_LABEL, resource_api=AKRI_API_V0
             )
+            assert_list_services(
+                mocked_client, mocked_zipfile, label_selector=AKRI_INSTANCE_LABEL, resource_api=AKRI_API_V0
+            )
             assert_list_daemon_sets(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=None,
+                label_selector=AKRI_INSTANCE_LABEL,
                 resource_api=AKRI_API_V0,
-                mock_names=["aio-akri-agent-daemonset"],
             )
 
         if api in [LNM_API_V1B1]:


### PR DESCRIPTION

![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/6c35a18f-0fa8-4063-9c64-8f82188dbcd1)


Finally labels for everything

example bundle:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/b9d8e463-b2cb-4e0f-ada4-9934b257c144)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
