### PR TITLE
fix: support multiple datalake connector target endpoints

### DIFF
--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -229,9 +229,9 @@ class DataLakeConnectorTargetType(ListableEnum):
     Data Lake Connector Target type:
     """
 
-    datalake = "datalakeStorage"
-    fabric = "fabricOneLake"
-    local = "localStorage"
+    data_lake_storage = "datalakeStorage"
+    fabric_onelake = "fabricOneLake"
+    local_storage = "localStorage"
 
 
 # Data processor runtime attributes

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -224,6 +224,16 @@ class KafkaTopicMapRouteType(Enum):
     mqtt_to_kafka = "mqttToKafka"
 
 
+class DataLakeConnectorTargetType(ListableEnum):
+    """
+    Data Lake Connector Target type:
+    """
+
+    datalake = "datalakeStorage"
+    fabric = "fabricOneLake"
+    local = "localStorage"
+
+
 # Data processor runtime attributes
 
 DATA_PROCESSOR_READER_WORKER_PREFIX = "aio-dp-reader-worker"

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -32,6 +32,7 @@ from .common import (
     AIO_MQ_BACKEND_PREFIX,
     AIO_MQ_AUTH_PREFIX,
     PADDING_SIZE,
+    DataLakeConnectorTargetType,
     KafkaTopicMapRouteType,
     ResourceOutputDetailLevel,
 )
@@ -1070,11 +1071,19 @@ def evaluate_datalake_connectors(
         )
         detail_padding = (0, 0, 0, padding[3] + PADDING_SIZE)
         spec = connector.get("spec", {})
+        datalake_target = spec.get("target", {})
+        datalake_target_type = None
+        for _target, target_type in [(datalake_target.get(target_type), target_type) for target_type in DataLakeConnectorTargetType.list()]:
+            if _target:
+                datalake_target = _target
+                datalake_target_type = target_type
+
         connector_eval_status = connector_eval_status = (
             CheckTaskStatus.error.value
             if not all(
                 [
-                    spec.get("target", {}).get("datalakeStorage", {}).get("endpoint"),
+                    datalake_target_type is not None,
+                    datalake_target is not None,
                     spec.get("instances"),
                 ]
             )
@@ -1088,10 +1097,8 @@ def evaluate_datalake_connectors(
             resource_name=connector_name,
             resource_kind=MqResourceKinds.DATALAKE_CONNECTOR.value,
         )
-        connector_instances = spec.get("instances")
 
-        datalake_target = spec.get("target", {}).get("datalakeStorage", {})
-        datalake_endpoint = datalake_target.get("endpoint")
+        connector_instances = spec.get("instances")
         check_manager.add_display(
             target_name=target,
             namespace=namespace,
@@ -1104,7 +1111,24 @@ def evaluate_datalake_connectors(
             target_name=target,
             namespace=namespace,
             display=Padding(
-                f"Target endpoint: [bright_blue]{datalake_endpoint}[/bright_blue]",
+                f"Target: [bright_blue]{datalake_target_type}[/bright_blue]",
+                detail_padding,
+            ),
+        )
+
+        target_endpoint_display = "Endpoint"
+        datalake_endpoint = ""
+        if datalake_target_type == DataLakeConnectorTargetType.local.value:
+            datalake_endpoint = datalake_target.get("volumeName")
+            target_endpoint_display = "Volume"
+        else:
+            datalake_endpoint = datalake_target.get("endpoint")
+
+        check_manager.add_display(
+            target_name=target,
+            namespace=namespace,
+            display=Padding(
+                f"{target_endpoint_display}: [bright_blue]{datalake_endpoint}[/bright_blue]",
                 detail_padding,
             ),
         )

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -1118,7 +1118,7 @@ def evaluate_datalake_connectors(
 
         target_endpoint_display = "Endpoint"
         datalake_endpoint = ""
-        if datalake_target_type == DataLakeConnectorTargetType.local.value:
+        if datalake_target_type == DataLakeConnectorTargetType.local_storage.value:
             datalake_endpoint = datalake_target.get("volumeName")
             target_endpoint_display = "Volume"
         else:

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -493,7 +493,31 @@ def test_mqtt_checks(
     "connector, topic_map, conditions, evaluations",
     [
         (
-            # datalake connector
+            # localstorage target
+            generate_resource_stub(
+                metadata={"name": "test_connector"},
+                spec={
+                    "instances": 2,
+                    "target": {"localStorage": {"volumeName": "sample_volume"}},
+                },
+                status={"configStatusLevel": ResourceState.running.value},
+            ),
+            # topic map
+            generate_resource_stub(spec={"dataLakeConnectorRef": "test_connector"}),
+            # conditions str
+            ["status", "valid(spec)"],
+            # evaluations
+            [
+                [("status", "success"), ("kind", "datalakeconnector")],
+                [
+                    ("status", "success"),
+                    ("value/spec/instances", 2),
+                    ("value/spec/target/localStorage/volumeName", "sample_volume"),
+                ],
+            ],
+        ),
+        (
+            # datalakestorage target
             generate_resource_stub(
                 metadata={"name": "test_connector"},
                 spec={
@@ -513,6 +537,30 @@ def test_mqtt_checks(
                     ("status", "success"),
                     ("value/spec/instances", 2),
                     ("value/spec/target/datalakeStorage/endpoint", "test_endpoint"),
+                ],
+            ],
+        ),
+        (
+            # fabriconelake target
+            generate_resource_stub(
+                metadata={"name": "test_connector"},
+                spec={
+                    "instances": 2,
+                    "target": {"fabricOneLake": {"endpoint": "test_endpoint"}},
+                },
+                status={"configStatusLevel": ResourceState.running.value},
+            ),
+            # topic map
+            generate_resource_stub(spec={"dataLakeConnectorRef": "test_connector"}),
+            # conditions str
+            ["status", "valid(spec)"],
+            # evaluations
+            [
+                [("status", "success"), ("kind", "datalakeconnector")],
+                [
+                    ("status", "success"),
+                    ("value/spec/instances", 2),
+                    ("value/spec/target/fabricOneLake/endpoint", "test_endpoint"),
                 ],
             ],
         ),


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
