### PR TITLE
fix: tweak akri for `az iot ops check`

### DIFF
--- a/azext_edge/edge/providers/check/akri.py
+++ b/azext_edge/edge/providers/check/akri.py
@@ -15,7 +15,7 @@ from ..edge_api import (
     AkriResourceKinds,
 )
 
-from ..support.akri import AKRI_PREFIXES
+from ..support.akri import AKRI_PREFIX
 
 from .base import (
     CheckManager,
@@ -67,15 +67,11 @@ def evaluate_core_service_runtime(
     check_manager = CheckManager(check_name="evalCoreServiceRuntime", check_desc="Evaluate Akri core service")
 
     padding = 6
-    akri_runtime_resources: List[dict] = []
-    for prefix in AKRI_PREFIXES:
-        akri_runtime_resources.extend(
-            get_namespaced_pods_by_prefix(
-                prefix=prefix,
-                namespace="",
-                label_selector="",
-            )
-        )
+    akri_runtime_resources = get_namespaced_pods_by_prefix(
+        prefix=AKRI_PREFIX,
+        namespace="",
+        label_selector="",
+    )
 
     for (namespace, pods) in pods_grouped_by_namespace(akri_runtime_resources):
         check_manager.add_target(target_name=CoreServiceResourceKinds.RUNTIME_RESOURCE.value, namespace=namespace)

--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 AKRI_INSTANCE_LABEL = "app.kubernetes.io/instance in (akri)"
 AKRI_APP_LABEL = "app in (otel-collector)"
 AKRI_SERVICE_LABEL = "service in (aio-akri-metrics)"
-AKRI_PREFIXES = ["aio-akri-"]
+AKRI_PREFIX = "aio-akri-"
 
 
 def fetch_pods(since_seconds: int = 60 * 60 * 24):


### PR DESCRIPTION
Now I feel like I could have slipped this in the other pr...

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
