### PR TITLE
fix: Add check for opcua-asset-discovery pod

### DIFF
--- a/azext_edge/edge/providers/check/opcua.py
+++ b/azext_edge/edge/providers/check/opcua.py
@@ -31,7 +31,7 @@ from ..edge_api import (
     OpcuaResourceKinds,
 )
 
-from ..support.opcua import OPC_APP_LABEL, OPC_NAME_LABEL
+from ..support.opcua import OPC_APP_LABEL, OPC_NAME_LABEL, OPC_NAME_VAR_LABEL
 
 
 def check_opcua_deployment(
@@ -65,7 +65,7 @@ def evaluate_core_service_runtime(
     check_manager = CheckManager(check_name="evalCoreServiceRuntime", check_desc="Evaluate OPC UA broker core service")
 
     opcua_runtime_resources: List[dict] = []
-    for label_selector in [OPC_APP_LABEL, OPC_NAME_LABEL]:
+    for label_selector in [OPC_APP_LABEL, OPC_NAME_LABEL, OPC_NAME_VAR_LABEL]:
         opcua_runtime_resources.extend(
             get_namespaced_pods_by_prefix(
                 prefix="",


### PR DESCRIPTION
Add check for opcua-asset-discovery pod
<img width="483" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/d201531e-d52b-4249-b512-491b04777f6a">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
