### PR TITLE
fix: Add support bundle capturing of individual MQ connector stateful sets

### DIFF
--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -138,6 +138,7 @@ class K8sSecretType(Enum):
 
 # MQ runtime attributes
 
+AIO_MQ_RESOURCE_PREFIX = "aio-mq-"
 AIO_MQ_DIAGNOSTICS_SERVICE = "aio-mq-diagnostics-service"
 AIO_MQ_OPERATOR = "aio-mq-operator"
 METRICS_SERVICE_API_PORT = 9600

--- a/azext_edge/edge/providers/check/cloud_connectors.py
+++ b/azext_edge/edge/providers/check/cloud_connectors.py
@@ -5,6 +5,12 @@
 # ----------------------------------------------------------------------------------------------
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from rich.padding import Padding
+
+from ...common import AIO_MQ_RESOURCE_PREFIX, CheckTaskStatus
+from ...providers.edge_api import MQ_ACTIVE_API, MqResourceKinds
+from ..support.mq import MQ_LABEL
 from .base import (
     CheckManager,
     evaluate_pod_health,
@@ -12,15 +18,7 @@ from .base import (
     get_resource_name,
     resources_grouped_by_namespace,
 )
-
-from rich.padding import Padding
-
-from ...common import CheckTaskStatus
-
 from .common import PADDING_SIZE, ResourceOutputDetailLevel
-
-from ...providers.edge_api import MQ_ACTIVE_API, MqResourceKinds
-from ..support.mq import MQ_LABEL
 
 
 def process_cloud_connector(
@@ -190,7 +188,7 @@ def _display_connector_runtime_health(
     namespace: str,
     target: str,
     connectors: Optional[List[Dict[str, Any]]] = None,
-    prefix: str = "aio-mq-",
+    prefix: str = AIO_MQ_RESOURCE_PREFIX,
     padding: int = 8,
 ):
     if connectors:

--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -186,7 +186,8 @@ def process_deployments(
 
 def process_statefulset(
     resource_api: EdgeResourceApi,
-    label_selector: str,
+    label_selector: str = None,
+    field_selector: str = None,
 ):
     from kubernetes.client.models import V1StatefulSet, V1StatefulSetList
 
@@ -194,7 +195,9 @@ def process_statefulset(
 
     processed = []
 
-    statefulsets: V1StatefulSetList = v1_apps.list_stateful_set_for_all_namespaces(label_selector=label_selector)
+    statefulsets: V1StatefulSetList = v1_apps.list_stateful_set_for_all_namespaces(
+        label_selector=label_selector, field_selector=field_selector
+    )
     logger.info(f"Detected {len(statefulsets.items)} statefulsets.")
 
     for statefulset in statefulsets.items:

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -10,19 +10,19 @@ from zipfile import ZipInfo
 
 from knack.log import get_logger
 
-from azext_edge.edge.common import AIO_MQ_OPERATOR
+from azext_edge.edge.common import AIO_MQ_OPERATOR, AIO_MQ_RESOURCE_PREFIX
 from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
 
 from ..edge_api import MQ_ACTIVE_API, EdgeResourceApi
 from ..stats import get_stats, get_traces
 from .base import (
     assemble_crd_work,
+    get_mq_namespaces,
     process_deployments,
     process_replicasets,
     process_services,
     process_statefulset,
     process_v1_pods,
-    get_mq_namespaces,
 )
 
 logger = get_logger(__name__)
@@ -129,7 +129,7 @@ def fetch_statefulsets():
         connector_name = connector.get("metadata", {}).get("name")
         stateful_set = process_statefulset(
             resource_api=MQ_ACTIVE_API,
-            field_selector=f"metadata.name=aio-mq-{connector_name}",
+            field_selector=f"metadata.name={AIO_MQ_RESOURCE_PREFIX}{connector_name}",
         )
         processed.extend(stateful_set)
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -13,7 +13,7 @@ import pytest
 from azure.cli.core.azclierror import ResourceNotFoundError
 
 from azext_edge.edge.commands_edge import support_bundle
-from azext_edge.edge.common import AIO_MQ_OPERATOR
+from azext_edge.edge.common import AIO_MQ_OPERATOR, AIO_MQ_RESOURCE_PREFIX
 from azext_edge.edge.providers.edge_api import (
     AKRI_API_V0,
     DATA_PROCESSOR_API_V1,
@@ -622,7 +622,7 @@ def test_mq_list_stateful_sets(
     # assert secondary connector calls to list stateful sets
     for item in custom_objects["items"]:
         item_name = item["metadata"]["name"]
-        statefulset_name = f"aio-mq-{item_name}"
+        statefulset_name = f"{AIO_MQ_RESOURCE_PREFIX}{item_name}"
         selector = f"metadata.name={statefulset_name}"
         mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(
             label_selector=None, field_selector=selector

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -581,6 +581,7 @@ def test_get_bundle_path(mocked_os_makedirs):
 @pytest.mark.parametrize(
     "custom_objects",
     [
+        # connectors present
         {
             "items": [
                 {
@@ -590,7 +591,9 @@ def test_get_bundle_path(mocked_os_makedirs):
                     "metadata": {"name": "mock-connector2", "namespace": "mock-namespace2"},
                 },
             ]
-        }
+        },
+        # no connectors
+        {"items": []},
     ],
 )
 def test_mq_list_stateful_sets(
@@ -612,6 +615,8 @@ def test_mq_list_stateful_sets(
     )
 
     # TODO - assert zipfile write of generic statefulset
+    if not custom_objects["items"]:
+        mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_called_once()
 
     # assert secondary connector calls to list stateful sets
     for item in custom_objects["items"]:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -126,7 +126,9 @@ def test_create_bundle(
                 since_seconds=since_seconds,
             )
             assert_list_replica_sets(mocked_client, mocked_zipfile, label_selector=MQ_LABEL, resource_api=MQ_API_V1B1)
-            assert_list_stateful_sets(mocked_client, mocked_zipfile, label_selector=MQ_LABEL, resource_api=MQ_API_V1B1)
+            assert_list_stateful_sets(
+                mocked_client, mocked_zipfile, label_selector=MQ_LABEL, field_selector=None, resource_api=MQ_API_V1B1
+            )
             assert_list_services(mocked_client, mocked_zipfile, label_selector=MQ_LABEL, resource_api=MQ_API_V1B1)
             assert_mq_stats(mocked_zipfile)
 
@@ -455,9 +457,16 @@ def assert_list_replica_sets(
         )
 
 
-def assert_list_stateful_sets(mocked_client, mocked_zipfile, label_selector: str, resource_api: EdgeResourceApi):
-    mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(label_selector=label_selector)
-
+def assert_list_stateful_sets(
+    mocked_client,
+    mocked_zipfile,
+    resource_api: EdgeResourceApi,
+    label_selector: Optional[str] = None,
+    field_selector: Optional[str] = None,
+):
+    mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(
+        label_selector=label_selector, field_selector=field_selector
+    )
     assert_zipfile_write(
         mocked_zipfile,
         zinfo=f"mock_namespace/{resource_api.moniker}/statefulset.mock_statefulset.yaml",
@@ -560,6 +569,59 @@ def test_get_bundle_path(mocked_os_makedirs):
     path = get_bundle_path()
     expected = f"{join(abspath('.'), 'support_bundle_')}"
     assert str(path).startswith(expected) and str(path).endswith("_aio.zip")
+
+
+# TODO - test zipfile write for specific resources
+# MQ connector stateful sets need labels based on connector names
+@pytest.mark.parametrize(
+    "mocked_cluster_resources",
+    [[MQ_API_V1B1]],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "custom_objects",
+    [
+        {
+            "items": [
+                {
+                    "metadata": {"name": "mock-connector", "namespace": "mock-namespace"},
+                },
+                {
+                    "metadata": {"name": "mock-connector2", "namespace": "mock-namespace2"},
+                },
+            ]
+        }
+    ],
+)
+def test_mq_list_stateful_sets(
+    mocker,
+    mocked_client,
+    mocked_cluster_resources,
+    custom_objects,
+):
+
+    # mock MQ support bundle to return connectors
+    mocked_mq_support_active_api = mocker.patch("azext_edge.edge.providers.support.mq.MQ_ACTIVE_API")
+    mocked_mq_support_active_api.get_resources.return_value = custom_objects
+    result = support_bundle(None, bundle_dir=a_bundle_dir, ops_service="mq")
+    assert result
+
+    # assert initial call to list stateful sets
+    mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(
+        label_selector=MQ_LABEL, field_selector=None
+    )
+
+    # TODO - assert zipfile write of generic statefulset
+
+    # assert secondary connector calls to list stateful sets
+    for item in custom_objects["items"]:
+        item_name = item["metadata"]["name"]
+        statefulset_name = f"aio-mq-{item_name}"
+        selector = f"metadata.name={statefulset_name}"
+        mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(
+            label_selector=None, field_selector=selector
+        )
+        # TODO - assert zipfile write of individual connector statefulset
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -598,6 +598,7 @@ def test_get_bundle_path(mocked_os_makedirs):
 )
 def test_mq_list_stateful_sets(
     mocker,
+    mocked_config,
     mocked_client,
     mocked_cluster_resources,
     custom_objects,


### PR DESCRIPTION
Tests for individual named connector files in the zip file write are still TODO - but we can at least be sure `list_stateful_set_for_all_namespaces` gets called for each specific connector `field_selector`

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
