### PR TITLE
fix: Add support for dataprocessor stage type

### DIFF
--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -101,92 +101,85 @@ DATA_PROCESSOR_SOURCE_DISPLAY_PROPERTIES = {
     ],
 }
 
+DATA_PROCESSOR_INTERMEDIATE_REQUIRED_PROPERTIES = {
+    DataProcessorStageType.aggregate.value: ["window", "properties"],
+    DataProcessorStageType.enrich.value: ["dataset", "outputPath"],
+    DataProcessorStageType.filter.value: ["expression"],
+    DataProcessorStageType.grpc.value: ["serverAddress", "rpcName", "descriptor"],
+    DataProcessorStageType.http.value: ["url", "method"],
+    DataProcessorStageType.lkv.value: ["properties"],
+    DataProcessorStageType.transform.value: ["expression"],
+}
+
 DATA_PROCESSOR_INTERMEDIATE_STAGE_PROPERTIES = {
-    DataProcessorStageType.aggregate.value: [
-        ("window.type", "Aggregate window type", False),
-        ("window.size", "Aggregate window duration", False),
-        ("properties", "Aggregate property", True)
-    ],
+    DataProcessorStageType.aggregate.value: [],
     DataProcessorStageType.enrich.value: [
-        ("dataset", "Enrich dataset ID", False),
-        ("outputPath", "Enrich output path", False),
         ("conditions", "Enrich condition", True),
         ("alwaysArray", "Enrich always array", True),
         ("limit", "Enrich limit", True)
     ],
-    DataProcessorStageType.filter.value: [("expression", "Filter expression", True)],
+    DataProcessorStageType.filter.value: [],
     DataProcessorStageType.grpc.value: [
-        ("serverAddress", "gRPC server address", False),
-        ("rpcName", "gRPC RPC name", False),
-        ("descriptor", "gRPC descriptor", False),
         ("request", "gRPC request", True),
         ("response", "gRPC response", True),
         ("retry", "gRPC retry mechanism", True),
         ("tls", "gRPC TLS", True),
     ],
     DataProcessorStageType.http.value: [
-        ("url", "Request URL", False),
-        ("method", "Request method", False),
         ("request", "gRPC request", True),
         ("response", "gRPC response", True),
         ("retry", "gRPC retry mechanism", True)
     ],
-    DataProcessorStageType.lkv.value: [("properties", "LKV property", True)],
-    DataProcessorStageType.transform.value: [("expression", "Transform expression", True)]
+    DataProcessorStageType.transform.value: []
+}
+
+DATA_PROCESSOR_DESTINATION_REQUIRED_PROPERTIES = {
+    DataprocessorDestinationStageType.blob_storage.value: ["accountName", "containerName"],
+    DataprocessorDestinationStageType.data_explorer.value: ["clusterUrl", "database", "table"],
+    DataprocessorDestinationStageType.fabric.value: ["workspace", "lakehouse", "table"],
+    DataprocessorDestinationStageType.file.value: ["rootDirectory"],
+    DataprocessorDestinationStageType.grpc.value: ["serverAddress", "rpcName", "descriptor"],
+    DataprocessorDestinationStageType.http.value: ["url", "method"],
+    DataprocessorDestinationStageType.mqtt.value: ["broker", "topic"],
+    DataprocessorDestinationStageType.reference_data.value: ["dataset"]
 }
 
 DATA_PROCESSOR_DESTINATION_STAGE_PROPERTIES = {
     DataprocessorDestinationStageType.blob_storage.value: [
-        ("accountName", "Account name", False),
-        ("containerName", "Container name", False),
         ("blobPath", "Blob path", True),
         ("batch", "Batch method", True),
         ("retry", "Retry mechanism", True),
     ],
     DataprocessorDestinationStageType.fabric.value: [
-        ("workspace", "Fabric workspace ID", False),
-        ("lakehouse", "Fabric lakehouse ID", False),
-        ("table", "Fabric lakehouse table", False),
-        ("filePath", "Fabric template file path", True),
-        ("batch", "Fabric batch method", True),
-        ("columns", "Fabric table column", True),
-        ("retry", "Fabric retry mechanism", True)
+        ("filePath", "Template file path", True),
+        ("batch", "Batch method", True),
+        ("columns", "Table column", True),
+        ("retry", "Retry mechanism", True)
     ],
     DataprocessorDestinationStageType.file.value: [
-        ("rootDirectory", "Root directory", False),
         ("filePath", "File path", False),
-        ("batch", "File batch method", True),
+        ("batch", "Batch method", True),
         ("filePermissions", "File permissions", True),
     ],
     DataprocessorDestinationStageType.grpc.value: [
-        ("serverAddress", "gRPC server address", False),
-        ("rpcName", "gRPC RPC name", False),
-        ("descriptor", "gRPC descriptor", False),
         ("request", "gRPC request", True),
-        ("retry", "gRPC retry mechanism", True),
+        ("retry", "Retry mechanism", True),
     ],
     DataprocessorDestinationStageType.http.value: [
-        ("url", "Request URL", False),
-        ("method", "Request method", False),
         ("request", "HTTP request", True),
-        ("retry", "HTTP retry mechanism", True),
+        ("retry", "Retry mechanism", True),
     ],
     DataprocessorDestinationStageType.data_explorer.value: [
-        ("clusterUrl", "Data Explorer cluster URL", False),
-        ("database", "Data Explorer database", False),
-        ("table", "Data Explorer table", False),
-        ("batch", "Data Explorer batch method", True),
-        ("columns", "Data Explorer table column", True),
-        ("retry", "Data Explorer retry mechanism", True)
+        ("batch", "Batch method", True),
+        ("columns", "Table column", True),
+        ("retry", "Retry mechanism", True)
     ],
     DataprocessorDestinationStageType.mqtt.value: [
-        ("broker", "MQTT broker URL", False),
-        ("qos", "MQTT QoS", False),
-        ("topic", "MQTT topic", False),
+        ("qos", "QoS", False),
         ("userProperties", "MQTT user property", True),
         ("retry", "MQTT retry mechanism", True)
     ],
-    DataprocessorDestinationStageType.reference_data.value: [("dataset", "Dataset ID", False)]
+    DataprocessorDestinationStageType.reference_data.value: []
 }
 
 DATA_PROCESSOR_AUTHENTICATION_REQUIRED_PROPERTIES = {

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -50,6 +50,7 @@ class DataprocessorDestinationStageType(ListableEnum):
     """
     Data processor destination stage type.
     """
+    blob_storage = "output/blobstorage"
     data_explorer = "output/dataexplorer"
     fabric = "output/fabric"
     file = "output/file"
@@ -108,7 +109,10 @@ DATA_PROCESSOR_INTERMEDIATE_STAGE_PROPERTIES = {
     ],
     DataProcessorStageType.enrich.value: [
         ("dataset", "Enrich dataset ID", False),
-        ("conditions", "Enrich condition", True)
+        ("outputPath", "Enrich output path", False),
+        ("conditions", "Enrich condition", True),
+        ("alwaysArray", "Enrich always array", True),
+        ("limit", "Enrich limit", True)
     ],
     DataProcessorStageType.filter.value: [("expression", "Filter expression", True)],
     DataProcessorStageType.grpc.value: [
@@ -117,7 +121,8 @@ DATA_PROCESSOR_INTERMEDIATE_STAGE_PROPERTIES = {
         ("descriptor", "gRPC descriptor", False),
         ("request", "gRPC request", True),
         ("response", "gRPC response", True),
-        ("retry", "gRPC retry mechanism", True)
+        ("retry", "gRPC retry mechanism", True),
+        ("tls", "gRPC TLS", True),
     ],
     DataProcessorStageType.http.value: [
         ("url", "Request URL", False),
@@ -131,44 +136,53 @@ DATA_PROCESSOR_INTERMEDIATE_STAGE_PROPERTIES = {
 }
 
 DATA_PROCESSOR_DESTINATION_STAGE_PROPERTIES = {
+    DataprocessorDestinationStageType.blob_storage.value: [
+        ("accountName", "Account name", False),
+        ("containerName", "Container name", False),
+        ("blobPath", "Blob path", True),
+        ("batch", "Batch method", True),
+        ("retry", "Retry mechanism", True),
+    ],
     DataprocessorDestinationStageType.fabric.value: [
-        ("url", "Fabric Endpoint", False),
         ("workspace", "Fabric workspace ID", False),
         ("lakehouse", "Fabric lakehouse ID", False),
         ("table", "Fabric lakehouse table", False),
-        ("authentication.type", "Data Explorer authentication type", False),
-        ("authentication.tenantId", "Tenant ID", False),
-        ("authentication.clientId", "Client ID", False),
-        ("authentication.clientSecret", "Client secret", False),
         ("filePath", "Fabric template file path", True),
         ("batch", "Fabric batch method", True),
         ("columns", "Fabric table column", True),
         ("retry", "Fabric retry mechanism", True)
+    ],
+    DataprocessorDestinationStageType.file.value: [
+        ("rootDirectory", "Root directory", False),
+        ("filePath", "File path", False),
+        ("batch", "File batch method", True),
+        ("filePermissions", "File permissions", True),
     ],
     DataprocessorDestinationStageType.grpc.value: [
         ("serverAddress", "gRPC server address", False),
         ("rpcName", "gRPC RPC name", False),
         ("descriptor", "gRPC descriptor", False),
         ("request", "gRPC request", True),
-        ("retry", "gRPC retry mechanism", True)
+        ("retry", "gRPC retry mechanism", True),
+    ],
+    DataprocessorDestinationStageType.http.value: [
+        ("url", "Request URL", False),
+        ("method", "Request method", False),
+        ("request", "HTTP request", True),
+        ("retry", "HTTP retry mechanism", True),
     ],
     DataprocessorDestinationStageType.data_explorer.value: [
         ("clusterUrl", "Data Explorer cluster URL", False),
         ("database", "Data Explorer database", False),
         ("table", "Data Explorer table", False),
-        ("authentication.type", "Data Explorer authentication type", False),
-        ("authentication.tenantId", "Tenant ID", False),
-        ("authentication.clientId", "Client ID", False),
-        ("authentication.clientSecret", "Client secret", False),
         ("batch", "Data Explorer batch method", True),
         ("columns", "Data Explorer table column", True),
         ("retry", "Data Explorer retry mechanism", True)
     ],
     DataprocessorDestinationStageType.mqtt.value: [
-        ("broker", "MQTT broker URL", False), ("qos", "MQTT QoS", False),
+        ("broker", "MQTT broker URL", False),
+        ("qos", "MQTT QoS", False),
         ("topic", "MQTT topic", False),
-        ("format", "MQTT format", True),
-        ("authentication", "MQTT authentication", True),
         ("userProperties", "MQTT user property", True),
         ("retry", "MQTT retry mechanism", True)
     ],

--- a/azext_edge/edge/providers/check/dataprocessor.py
+++ b/azext_edge/edge/providers/check/dataprocessor.py
@@ -22,6 +22,7 @@ from rich.padding import Padding
 
 from ...common import (
     CheckTaskStatus,
+    ListableEnum,
     ProvisioningState,
 )
 
@@ -39,8 +40,10 @@ from .common import (
     DATA_PROCESSOR_SOURCE_DISPLAY_PROPERTIES,
     ERROR_NO_DETAIL,
     PADDING_SIZE,
+    DataProcessorStageType,
     DataSourceStageType,
     DataprocessorAuthenticationType,
+    DataprocessorDestinationStageType,
     ResourceOutputDetailLevel,
 )
 
@@ -640,7 +643,7 @@ def _evaluate_source_node(
 
     # check specific required properties
     # fine the matching enum for stage_type, which should start with the enum value
-    stage_type_value = next((e for e in DataSourceStageType.list() if stage_type.startswith(e)), None)
+    stage_type_value = _get_stage_enum(stage_type=stage_type, stage_type_enums=DataSourceStageType)
     stage_required_properties = required_specific_properties.get(stage_type_value, [])
     for prop in stage_required_properties:
         prop_value = pipeline_source_node.get(prop, "")
@@ -709,37 +712,16 @@ def _evaluate_source_node(
         resource_name=pipeline_name
     )
 
-    # check format
-    pipeline_source_node_format = pipeline_source_node.get("format", {})
-    format_type = pipeline_source_node_format.get("type", "")
-    format_type_status = CheckTaskStatus.success.value
-    format_type_display_text = f"Format: [cyan]{pipeline_source_node_format}[/cyan] [green]detected[/green]."
-    if not format_type:
-        format_type_status = CheckTaskStatus.error.value
-        format_type_display_text = "Format: type [red]not detected[/red]."
-
-    check_manager.add_display(
-        target_name=target_pipelines,
-        namespace=namespace,
-        display=Padding(format_type_display_text, (0, 0, 0, property_padding))
-    )
-
-    check_manager.add_target_eval(
-        target_name=target_pipelines,
-        namespace=namespace,
-        status=format_type_status,
-        value={"format.type": format_type},
-        resource_name=pipeline_name
-    )
-
-    _evaluate_authentication(
-        pipeline_source_node=pipeline_source_node,
-        target_pipelines=target_pipelines,
-        pipeline_name=pipeline_name,
+    _evaluate_common_stage_properties(
         check_manager=check_manager,
-        namespace=namespace,
+        detail_level=detail_level,
+        stage_name="input",
+        stage_type=stage_type,
+        stage_type_enums=DataSourceStageType,
+        target_name=target_pipelines,
+        pipeline_node=pipeline_source_node,
         padding=property_padding,
-        detail_level=detail_level
+        namespace=namespace
     )
 
     if detail_level != ResourceOutputDetailLevel.summary.value:
@@ -780,16 +762,32 @@ def _evaluate_intermediate_nodes(
 
     property_padding = padding + PADDING_SIZE
 
-    if detail_level != ResourceOutputDetailLevel.summary.value:
-        for stage_name in pipeline_intermediate_stages_node:
-            stage_type = pipeline_intermediate_stages_node[stage_name]["type"]
-            stage_display_text = f"- Stage resource {{[bright_blue]{stage_name}[/bright_blue]}} of type {{[bright_blue]{stage_type}[/bright_blue]}}"
-            check_manager.add_display(
-                target_name=target_pipelines,
+    for stage_name in pipeline_intermediate_stages_node:
+        stage_type = pipeline_intermediate_stages_node[stage_name]["type"]
+        stage_display_text = f"- Stage resource {{[bright_blue]{stage_name}[/bright_blue]}} of type {{[bright_blue]{stage_type}[/bright_blue]}}"
+        check_manager.add_display(
+            target_name=target_pipelines,
+            namespace=namespace,
+            display=Padding(stage_display_text, (0, 0, 0, property_padding))
+        )
+
+        stage_enum = _get_stage_enum(stage_type=stage_type, stage_type_enums=DataProcessorStageType)
+        if stage_enum in [
+            DataProcessorStageType.grpc.value,
+            DataProcessorStageType.http.value,
+        ]:
+            _evaluate_authentication(
+                pipeline_node=pipeline_intermediate_stages_node[stage_name],
+                target_pipelines=target_pipelines,
+                pipeline_name=stage_name,
+                check_manager=check_manager,
                 namespace=namespace,
-                display=Padding(stage_display_text, (0, 0, 0, property_padding))
+                stage_name=stage_name,
+                padding=property_padding + PADDING_SIZE,
+                detail_level=detail_level
             )
 
+        if detail_level != ResourceOutputDetailLevel.summary.value:
             _process_stage_properties(
                 check_manager,
                 detail_level,
@@ -830,26 +828,110 @@ def _evaluate_destination_node(
     )
 
     if output_node:
+        (name, node_properties) = output_node
+        property_padding = padding + PADDING_SIZE
+
+        # get data source type
+        stage_type = node_properties["type"]
+
+        stage_display_text = f"Stage type: {{[cyan]{stage_type}[/cyan]}}"
+        check_manager.add_display(
+            target_name=target_pipelines,
+            namespace=namespace,
+            display=Padding(stage_display_text, (0, 0, 0, property_padding))
+        )
+
+        _evaluate_common_stage_properties(
+            check_manager=check_manager,
+            detail_level=detail_level,
+            stage_name=name,
+            stage_type=stage_type,
+            stage_type_enums=DataprocessorDestinationStageType,
+            target_name=target_pipelines,
+            pipeline_node=node_properties,
+            padding=property_padding,
+            namespace=namespace
+        )
+
         if detail_level != ResourceOutputDetailLevel.summary.value:
-            property_padding = padding + PADDING_SIZE
             _process_stage_properties(
                 check_manager,
                 detail_level,
                 target_name=target_pipelines,
-                stage=output_node[1],
+                stage=node_properties,
                 stage_properties=DATA_PROCESSOR_DESTINATION_STAGE_PROPERTIES,
                 padding=(0, 0, 0, property_padding),
                 namespace=namespace
             )
 
 
+def _evaluate_common_stage_properties(
+    check_manager: CheckManager,
+    detail_level: int,
+    stage_name: str,
+    stage_type: str,
+    stage_type_enums: ListableEnum,
+    target_name: str,
+    pipeline_node: Dict[str, Any],
+    padding: int,
+    namespace: str
+) -> None:
+    stage_enum = _get_stage_enum(stage_type=stage_type, stage_type_enums=stage_type_enums)
+    # check format
+
+    if stage_enum not in [
+        DataprocessorDestinationStageType.data_explorer.value,
+        DataprocessorDestinationStageType.fabric.value,
+        DataprocessorDestinationStageType.grpc.value,
+        DataprocessorDestinationStageType.http.value,
+        DataprocessorDestinationStageType.reference_data.value,
+    ]:
+        pipeline_node_format = pipeline_node.get("format", {})
+        format_type = pipeline_node_format.get("type", "")
+        format_type_status = CheckTaskStatus.success.value
+        format_type_display_text = f"Format: [cyan]{pipeline_node_format}[/cyan] [green]detected[/green]."
+        if not format_type:
+            format_type_status = CheckTaskStatus.error.value
+            format_type_display_text = "Format: type [red]not detected[/red]."
+
+        check_manager.add_display(
+            target_name=target_name,
+            namespace=namespace,
+            display=Padding(format_type_display_text, (0, 0, 0, padding))
+        )
+
+        check_manager.add_target_eval(
+            target_name=target_name,
+            namespace=namespace,
+            status=format_type_status,
+            value={f"{stage_name}.format.type": format_type},
+            resource_name=target_name
+        )
+
+    if stage_enum not in [
+        DataprocessorDestinationStageType.file.value,
+        DataprocessorDestinationStageType.reference_data.value,
+    ]:
+        _evaluate_authentication(
+            pipeline_node=pipeline_node,
+            target_pipelines=target_name,
+            pipeline_name=target_name,
+            check_manager=check_manager,
+            namespace=namespace,
+            padding=padding,
+            stage_name=stage_name,
+            detail_level=detail_level
+        )
+
+
 def _evaluate_authentication(
-    pipeline_source_node: Dict[str, Any],
+    pipeline_node: Dict[str, Any],
     target_pipelines: str,
     pipeline_name: str,
     check_manager: CheckManager,
     namespace: str,
     padding: int,
+    stage_name: str,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
 ) -> None:
     def add_verbose_display(
@@ -871,7 +953,7 @@ def _evaluate_authentication(
                     display=Padding(f"{label}: [cyan]{detail['value']}[/cyan]", (0, 0, 0, padding + PADDING_SIZE))
                 )
 
-    auth_info = pipeline_source_node.get("authentication", {})
+    auth_info = pipeline_node.get("authentication", {})
     auth_type = auth_info.get("type", "")
 
     if detail_level > ResourceOutputDetailLevel.summary.value:
@@ -910,6 +992,10 @@ def _evaluate_authentication(
         target_name=target_pipelines,
         namespace=namespace,
         status=authentication_status,
-        value={"authentication.type": auth_type},
+        value={f"{stage_name}.authentication.type": auth_type},
         resource_name=pipeline_name
     )
+
+
+def _get_stage_enum(stage_type: str, stage_type_enums: ListableEnum) -> str:
+    return next((e for e in stage_type_enums.list() if stage_type.startswith(e)), None)

--- a/azext_edge/tests/edge/checks/test_dataprocessor_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_dataprocessor_checks_unit.py
@@ -244,7 +244,23 @@ def test_instance_checks(
                 ],
                 [
                     ("status", "success"),
+                    ("value/spec.stage1.dataset", "vendorData"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage1.outputPath", ".payload.vendor"),
+                ],
+                [
+                    ("status", "success"),
                     ("value/destinationNodeCount", 1),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage2.url", "https://contoso.com/some/url/path"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage2.method", "POST"),
                 ],
                 [
                     ("status", "success"),
@@ -380,7 +396,19 @@ def test_instance_checks(
                 ],
                 [
                     ("status", "success"),
+                    ("value/spec.stage1.expression", ".payload.temperature > 50 and .payload.humidity < 20"),
+                ],
+                [
+                    ("status", "success"),
                     ("value/destinationNodeCount", 1),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage2.accountName", "myStorageAccount"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage2.containerName", "mycontainer"),
                 ],
                 [
                     ("status", "success"),
@@ -531,6 +559,18 @@ def test_instance_checks(
                 [
                     ("status", "success"),
                     ("value/input.authentication.type", "header"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage1.serverAddress", "my-grpc-server.default.svc.cluster.local:80"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage1.rpcName", "mypackage.SampleService/ExampleMethod"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.stage1.descriptor", "Zm9v..."),
                 ],
                 [
                     ("status", "success"),


### PR DESCRIPTION
This pr added further support for dataprocessor check(dataprocessor service as source of truth):
1. Updated some properties in processor stages
2. Added blob storage, file and http destination type for dp pipeline
3. Refacted some common used code

level 0:
<img width="625" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/cdf072c8-698f-4442-b3c9-2add099a9263">

level 1:
<img width="464" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/abbc23fb-ef1b-459f-a5d4-de1368673688">

level 2:
<img width="539" alt="image" src="https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/c52306ab-bb28-4560-93e0-2929b0de3455">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
