### PR TITLE
refactor: Change pre-check for custom locations feature to use field selector 

### DIFF
--- a/azext_edge/edge/providers/k8s/cluster_role_binding.py
+++ b/azext_edge/edge/providers/k8s/cluster_role_binding.py
@@ -13,10 +13,10 @@ logger = get_logger(__name__)
 generic = client.ApiClient()
 
 
-def get_binding(name: str) -> Optional[dict]:
+def get_bindings(field_selector: str) -> Optional[dict]:
     try:
         v1_auth_client = client.RbacAuthorizationV1Api()
-        result = v1_auth_client.read_cluster_role_binding(name=name)
+        result = v1_auth_client.list_cluster_role_binding(field_selector=field_selector)
     except ApiException as ae:
         logger.debug(msg=str(ae))
         if int(ae.status) == 404:

--- a/azext_edge/edge/providers/orchestration/base.py
+++ b/azext_edge/edge/providers/orchestration/base.py
@@ -27,7 +27,7 @@ from ..base import (
     get_cluster_namespace,
 )
 from ..edge_api import KEYVAULT_API_V1
-from ..k8s.cluster_role_binding import get_binding
+from ..k8s.cluster_role_binding import get_bindings
 from .common import (
     DEFAULT_SERVICE_PRINCIPAL_SECRET_DAYS,
     EXTENDED_LOCATION_ROLE_BINDING,
@@ -519,8 +519,8 @@ def wait_for_terminal_state(poller: "LROPoller") -> "GenericResource":
 
 
 def verify_custom_locations_enabled():
-    target_binding = get_binding(EXTENDED_LOCATION_ROLE_BINDING)
-    if not target_binding:
+    target_bindings = get_bindings(field_selector=f"metadata.name=={EXTENDED_LOCATION_ROLE_BINDING}")
+    if not target_bindings or (target_bindings and not target_bindings.get("items")):
         raise ValidationError(
             "The custom-locations feature is required but not enabled on the cluster. For guidance refer to:\n"
             "https://aka.ms/ArcK8sCustomLocationsDocsEnableFeature"

--- a/azext_edge/tests/edge/init/test_base_unit.py
+++ b/azext_edge/tests/edge/init/test_base_unit.py
@@ -343,7 +343,9 @@ def test_prepare_sp_catches(mocker, mocked_cmd, mocked_get_tenant_id, mocked_sen
 @pytest.mark.parametrize("app_id", [None, generate_generic_id()])
 @pytest.mark.parametrize("object_id", [None, generate_generic_id()])
 @pytest.mark.parametrize("secret", [None, generate_generic_id()])
-def test_prepare_sp_error(mocker, mocked_cmd, mocked_get_tenant_id, mocked_send_raw_request, app_id, object_id, secret):
+def test_prepare_sp_error(
+    mocker, mocked_cmd, mocked_get_tenant_id, mocked_send_raw_request, app_id, object_id, secret
+):
     response = mocker.Mock(status_code=400)
     mocked_send_raw_request.return_value.json.side_effect = HTTPError(
         error_msg=generate_generic_id(), response=response
@@ -694,12 +696,29 @@ def test_wait_for_terminal_state(mocker, done):
     assert sleep_patch.call_count == (1 if done else poll_num)
 
 
-@pytest.mark.parametrize("role_binding", [None, {"truthy": "value"}])
-def test_verify_custom_locations_enabled(mocker, role_binding):
-    get_binding_patch = mocker.patch(f"{BASE_PATH}.get_binding", return_value=role_binding)
+@pytest.mark.parametrize(
+    "role_bindings",
+    [
+        None,
+        {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "items": [],
+            "kind": "ClusterRoleBindingList",
+            "metadata": {"resourceVersion": "1"},
+        },
+        {
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "items": [{"metadata": {"name": "AzureArc-Microsoft.ExtendedLocation-RP-RoleBinding", "namespace": "az"}}],
+            "kind": "ClusterRoleBindingList",
+            "metadata": {"resourceVersion": "2"},
+        },
+    ],
+)
+def test_verify_custom_locations_enabled(mocker, role_bindings):
+    get_binding_patch = mocker.patch(f"{BASE_PATH}.get_bindings", return_value=role_bindings)
     from azext_edge.edge.providers.orchestration.base import verify_custom_locations_enabled
 
-    if not role_binding:
+    if not role_bindings or (role_bindings and not role_bindings["items"]):
         with pytest.raises(ValidationError):
             verify_custom_locations_enabled()
             get_binding_patch.assert_called_once()


### PR DESCRIPTION
* For reasons AKS-EE has issues with direct-lookup of the target mixed case cluster role binding via proxy. This issue does not repro against arc-connected k3s via proxy. Refactoring to field selector allows consistent results including against AKS-EE.