### PR TITLE
chore(test): Add integration test environment to tox.ini

### DIFF
--- a/azext_edge/tests/edge/rpsaas/adr/conftest.py
+++ b/azext_edge/tests/edge/rpsaas/adr/conftest.py
@@ -35,9 +35,5 @@ def require_init(init_setup, tracked_files):
         "az rest --method POST --url https://management.azure.com/providers/Microsoft.ResourceGraph"
         f"/resources?api-version=2022-10-01 --body @{file_name}"
     )["data"]
-    custom_location_result = run(
-        "az graph query -q \"where type =~ 'Microsoft.ExtendedLocation/customLocations' | "
-        f"where properties.hostResourceId =~ '{cluster_id}' | project name\""
-    )["data"]
     init_setup["customLocation"] = custom_location_result[0]["name"]
     yield init_setup

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,37 @@ commands =
     az -v
     # run unit tests
     pytest -k _unit ./azext_edge/tests {posargs}
-    # You can pass additional positional args to pytest using `-- {args}`
+    # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
+
+# integration tests
+[testenv:py{thon,38,39,310,311}-int]
+skip_install = True
+description =
+    {[base]description}
+    int: integration tests
+deps =
+    # base deps
+    {[testenv:python]deps}
+passenv =
+    # pass all env vars with this prefix to tox
+    azext_edge_*
+setenv = 
+    # You can temporarily add variables here to modify your tests
+    # azext_edge_skip_init=true
+    PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
+commands =
+    python --version
+    # install to tox extension dir
+    pip install -U --target {envsitepackagesdir}/azure-cli-extensions/azure-iot-ops .
+    # validate az and extension version
+    az -v
+    # run integration tests
+    pytest -k "_int.py" ./azext_edge/tests {posargs}
+    # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
+
 # code coverage - HTML and JSON
 [testenv:coverage]
+description = run code coverage
 deps =
     {[testenv:python]deps}
 commands =


### PR DESCRIPTION
This PR adds `-int` variants for all of our existing python test environments in tox:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/13545962/2f9ec6b0-9b86-44d4-97b0-270162fca571)

These tests run `pytest -k "_int.py" ./azext_edge/tests {posargs}` and pass env vars with a prefix of `azext_edge_*` to tox.

You can modify your local vars for global pytest in `pytest.ini` or for a specific environment in `tox.ini` under the `setenv =` config.


![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/13545962/d84edb02-ede0-4d97-9afb-999975ae5786)

This will enable our pipelines to simply call `tox -e python-int` to run these tests in an agent.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
