### PR TITLE
feat: verify cluster arc config as routed by kubeconfig matches target cloud connected cluster

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.4.0b3"
+VERSION = "0.4.0b4"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/providers/k8s/config_map.py
+++ b/azext_edge/edge/providers/k8s/config_map.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from knack.log import get_logger
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+from typing import Optional
+
+logger = get_logger(__name__)
+generic = client.ApiClient()
+
+
+def get_config_map(name: str, namespace: str) -> Optional[dict]:
+    try:
+        v1_core_api = client.CoreV1Api()
+        result = v1_core_api.read_namespaced_config_map(name=name, namespace=namespace)
+    except ApiException as ae:
+        logger.debug(msg=str(ae))
+        if int(ae.status) == 404:
+            return
+        raise ae
+    else:
+        if result:
+            return generic.sanitize_for_serialization(obj=result)

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -18,6 +18,8 @@ GRAPH_V1_APP_ENDPOINT = f"{GRAPH_V1_ENDPOINT}/applications"
 DEFAULT_SERVICE_PRINCIPAL_SECRET_DAYS = 365
 
 EXTENDED_LOCATION_ROLE_BINDING = "AzureArc-Microsoft.ExtendedLocation-RP-RoleBinding"
+ARC_CONFIG_MAP = "azure-clusterconfig"
+ARC_NAMESPACE = "azure-arc"
 
 
 class MqMode(Enum):

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -202,6 +202,7 @@ class WorkManager:
             provision_akv_csi_driver,
             throw_if_iotops_deployed,
             validate_keyvault_permission_model,
+            verify_arc_cluster_config,
             verify_cluster_and_use_location,
             verify_custom_locations_enabled,
             wait_for_terminal_state,
@@ -218,6 +219,7 @@ class WorkManager:
                 verify_cli_client_connections(include_graph=bool(self._keyvault_resource_id))
                 # cluster_location uses actual connected cluster location. Same applies to location IF not provided.
                 self._connected_cluster = verify_cluster_and_use_location(self._kwargs)
+                verify_arc_cluster_config(self._connected_cluster)
 
             # Always run this check
             if not self._keyvault_resource_id and not KEYVAULT_API_V1.is_deployed():

--- a/azext_edge/tests/edge/init/conftest.py
+++ b/azext_edge/tests/edge/init/conftest.py
@@ -208,6 +208,14 @@ def mocked_verify_custom_locations_enabled(mocker):
 
 
 @pytest.fixture
+def mocked_verify_arc_cluster_config(mocker):
+    patched = mocker.patch(
+        "azext_edge.edge.providers.orchestration.base.verify_arc_cluster_config", autospec=True
+    )
+    yield patched
+
+
+@pytest.fixture
 def spy_get_current_template_copy(mocker):
     from azext_edge.edge.providers.orchestration import work
 

--- a/azext_edge/tests/edge/init/test_base_unit.py
+++ b/azext_edge/tests/edge/init/test_base_unit.py
@@ -736,11 +736,6 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
         {  # fail no config map
             "failure": True,
             "config_map": None,
-            "connected_cluster": ConnectedCluster(
-                subscription_id=ZEROED_SUB,
-                cluster_name="cluster1",
-                resource_group_name="rg1",
-            ),
         },
         {  # fail config indicates diff cluster
             "failure": "cluster name",
@@ -756,11 +751,6 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
                     "namespace": "azure-arc",
                 },
             },
-            "connected_cluster": ConnectedCluster(
-                subscription_id=ZEROED_SUB,
-                cluster_name="cluster1",
-                resource_group_name="rg1",
-            ),
         },
         {  # fail config indicates diff rg
             "failure": "resource group",
@@ -776,11 +766,6 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
                     "namespace": "azure-arc",
                 },
             },
-            "connected_cluster": ConnectedCluster(
-                subscription_id=ZEROED_SUB,
-                cluster_name="cluster1",
-                resource_group_name="rg1",
-            ),
         },
         {  # fail config indicates diff sub
             "failure": "subscription Id",
@@ -796,11 +781,6 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
                     "namespace": "azure-arc",
                 },
             },
-            "connected_cluster": ConnectedCluster(
-                subscription_id=ZEROED_SUB,
-                cluster_name="cluster1",
-                resource_group_name="rg1",
-            ),
         },
         {  # success
             "failure": False,
@@ -816,11 +796,6 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
                     "namespace": "azure-arc",
                 },
             },
-            "connected_cluster": ConnectedCluster(
-                subscription_id=ZEROED_SUB,
-                cluster_name="cluster1",
-                resource_group_name="rg1",
-            ),
         },
     ],
 )
@@ -828,15 +803,21 @@ def test_verify_arc_cluster_config(mocker, test_scenario):
     get_config_map_patch = mocker.patch(f"{BASE_PATH}.get_config_map", return_value=test_scenario["config_map"])
     from azext_edge.edge.providers.orchestration.base import verify_arc_cluster_config
 
+    connected_cluster = ConnectedCluster(
+        subscription_id=ZEROED_SUB,
+        cluster_name="cluster1",
+        resource_group_name="rg1",
+    )
+
     failure = test_scenario["failure"]
     if failure:
         match_str = ""
         if isinstance(failure, str):
             match_str = failure
         with pytest.raises(ValidationError, match=rf".*{match_str}.*"):
-            verify_arc_cluster_config(test_scenario["connected_cluster"])
+            verify_arc_cluster_config(connected_cluster)
             get_config_map_patch.assert_called_once()
         return
 
-    verify_arc_cluster_config(test_scenario["connected_cluster"])
+    verify_arc_cluster_config(connected_cluster)
     get_config_map_patch.assert_called_once()

--- a/azext_edge/tests/edge/init/test_base_unit.py
+++ b/azext_edge/tests/edge/init/test_base_unit.py
@@ -7,15 +7,17 @@
 import json
 import pytest
 from azure.cli.core.azclierror import HTTPError, ValidationError
+from azext_edge.edge.providers.orchestration.connected_cluster import ConnectedCluster
 from azext_edge.edge.providers.orchestration.common import (
     GRAPH_V1_ENDPOINT,
     GRAPH_V1_SP_ENDPOINT,
     GRAPH_V1_APP_ENDPOINT,
 )
 
-from ...generators import generate_random_string
+from ...generators import generate_random_string, get_zeroed_subscription
 
 BASE_PATH = "azext_edge.edge.providers.orchestration.base"
+ZEROED_SUB = get_zeroed_subscription()
 
 
 # TODO: move fixtues once functions are moved
@@ -726,3 +728,115 @@ def test_verify_custom_locations_enabled(mocker, role_bindings):
 
     verify_custom_locations_enabled()
     get_binding_patch.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "test_scenario",
+    [
+        {  # fail no config map
+            "failure": True,
+            "config_map": None,
+            "connected_cluster": ConnectedCluster(
+                subscription_id=ZEROED_SUB,
+                cluster_name="cluster1",
+                resource_group_name="rg1",
+            ),
+        },
+        {  # fail config indicates diff cluster
+            "failure": "cluster name",
+            "config_map": {
+                "apiVersion": "v1",
+                "data": {
+                    "AZURE_RESOURCE_NAME": "cluster2",
+                    "AZURE_RESOURCE_GROUP": "rg1",
+                    "AZURE_SUBSCRIPTION_ID": ZEROED_SUB,
+                },
+                "metadata": {
+                    "name": "azure-clusterconfig",
+                    "namespace": "azure-arc",
+                },
+            },
+            "connected_cluster": ConnectedCluster(
+                subscription_id=ZEROED_SUB,
+                cluster_name="cluster1",
+                resource_group_name="rg1",
+            ),
+        },
+        {  # fail config indicates diff rg
+            "failure": "resource group",
+            "config_map": {
+                "apiVersion": "v1",
+                "data": {
+                    "AZURE_RESOURCE_NAME": "cluster1",
+                    "AZURE_RESOURCE_GROUP": "rg2",
+                    "AZURE_SUBSCRIPTION_ID": ZEROED_SUB,
+                },
+                "metadata": {
+                    "name": "azure-clusterconfig",
+                    "namespace": "azure-arc",
+                },
+            },
+            "connected_cluster": ConnectedCluster(
+                subscription_id=ZEROED_SUB,
+                cluster_name="cluster1",
+                resource_group_name="rg1",
+            ),
+        },
+        {  # fail config indicates diff sub
+            "failure": "subscription Id",
+            "config_map": {
+                "apiVersion": "v1",
+                "data": {
+                    "AZURE_RESOURCE_NAME": "cluster1",
+                    "AZURE_RESOURCE_GROUP": "rg1",
+                    "AZURE_SUBSCRIPTION_ID": "8757c60a-a398-4c09-adaf-be328caf42d4",
+                },
+                "metadata": {
+                    "name": "azure-clusterconfig",
+                    "namespace": "azure-arc",
+                },
+            },
+            "connected_cluster": ConnectedCluster(
+                subscription_id=ZEROED_SUB,
+                cluster_name="cluster1",
+                resource_group_name="rg1",
+            ),
+        },
+        {  # success
+            "failure": False,
+            "config_map": {
+                "apiVersion": "v1",
+                "data": {
+                    "AZURE_RESOURCE_NAME": "cluster1",
+                    "AZURE_RESOURCE_GROUP": "rg1",
+                    "AZURE_SUBSCRIPTION_ID": ZEROED_SUB,
+                },
+                "metadata": {
+                    "name": "azure-clusterconfig",
+                    "namespace": "azure-arc",
+                },
+            },
+            "connected_cluster": ConnectedCluster(
+                subscription_id=ZEROED_SUB,
+                cluster_name="cluster1",
+                resource_group_name="rg1",
+            ),
+        },
+    ],
+)
+def test_verify_arc_cluster_config(mocker, test_scenario):
+    get_config_map_patch = mocker.patch(f"{BASE_PATH}.get_config_map", return_value=test_scenario["config_map"])
+    from azext_edge.edge.providers.orchestration.base import verify_arc_cluster_config
+
+    failure = test_scenario["failure"]
+    if failure:
+        match_str = ""
+        if isinstance(failure, str):
+            match_str = failure
+        with pytest.raises(ValidationError, match=rf".*{match_str}.*"):
+            verify_arc_cluster_config(test_scenario["connected_cluster"])
+            get_config_map_patch.assert_called_once()
+        return
+
+    verify_arc_cluster_config(test_scenario["connected_cluster"])
+    get_config_map_patch.assert_called_once()

--- a/azext_edge/tests/edge/init/test_work_unit.py
+++ b/azext_edge/tests/edge/init/test_work_unit.py
@@ -517,6 +517,7 @@ def test_work_order(
     mocked_connected_cluster_location: Mock,
     mocked_connected_cluster_extensions: Mock,
     mocked_verify_custom_locations_enabled: Mock,
+    mocked_verify_arc_cluster_config: Mock,
     spy_get_current_template_copy: Mock,
     cluster_name,
     cluster_namespace,
@@ -578,6 +579,7 @@ def test_work_order(
         mocked_register_providers.assert_called_once()
         mocked_verify_custom_locations_enabled.assert_called_once()
         mocked_connected_cluster_extensions.assert_called_once()
+        mocked_verify_arc_cluster_config.assert_called_once()
 
         if not disable_rsync_rules:
             mocked_verify_write_permission_against_rg.assert_called_once()
@@ -589,6 +591,7 @@ def test_work_order(
         mocked_register_providers.assert_not_called()
         mocked_verify_custom_locations_enabled.assert_not_called()
         mocked_connected_cluster_extensions.assert_not_called()
+        mocked_verify_arc_cluster_config.assert_not_called()
 
     if not keyvault_resource_id:
         mocked_edge_api_keyvault_api_v1.is_deployed.assert_called_once()


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
