### PR TITLE
feat: init ux layer improvements + refactors

### DIFF
--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -5,6 +5,7 @@
 # ----------------------------------------------------------------------------------------------
 
 from os.path import exists
+from os import getenv
 from pathlib import PurePath
 from typing import Any, Dict, List, Optional, Union
 
@@ -135,13 +136,15 @@ def init(
     template_path: Optional[str] = None,
     no_deploy: Optional[bool] = None,
     no_tls: Optional[bool] = None,
-    no_preflight: Optional[bool] = None,
     disable_rsync_rules: Optional[bool] = None,
     context_name: Optional[str] = None,
     ensure_latest: Optional[bool] = None,
 ) -> Union[Dict[str, Any], None]:
     from .providers.orchestration import deploy
     from .util import url_safe_hash_phrase
+    from .common import INIT_NO_PREFLIGHT_ENV_KEY
+
+    no_preflight = getenv(INIT_NO_PREFLIGHT_ENV_KEY)
 
     if all([no_tls, not keyvault_resource_id, no_deploy, no_preflight]):
         logger.warning("Nothing to do :)")

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -144,7 +144,7 @@ def init(
     from .util import url_safe_hash_phrase
     from .common import INIT_NO_PREFLIGHT_ENV_KEY
 
-    no_preflight = getenv(INIT_NO_PREFLIGHT_ENV_KEY)
+    no_preflight = bool(getenv(INIT_NO_PREFLIGHT_ENV_KEY))
 
     if all([no_tls, not keyvault_resource_id, no_deploy, no_preflight]):
         logger.warning("Nothing to do :)")

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -149,6 +149,7 @@ class AEPAuthModes(Enum):
     """
     Authentication modes for asset endpoints
     """
+
     anonymous = "Anonymous"
     certificate = "Certificate"
     userpass = "UsernamePassword"
@@ -181,3 +182,7 @@ AIO_MQ_DIAGNOSTICS_SERVICE = "aio-mq-diagnostics-service"
 AIO_MQ_OPERATOR = "aio-mq-operator"
 METRICS_SERVICE_API_PORT = 9600
 PROTOBUF_SERVICE_API_PORT = 9800
+
+# Init Env Control
+
+INIT_NO_PREFLIGHT_ENV_KEY = "AIO_CLI_INIT_PREFLIGHT_DISABLED"

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -279,12 +279,6 @@ def load_iotops_arguments(self, _):
             help="The TLS configuration workflow will be skipped.",
         )
         context.argument(
-            "no_preflight",
-            options_list=["--no-preflight"],
-            arg_type=get_three_state_flag(),
-            help="The pre-flight workflow will be skipped.",
-        )
-        context.argument(
             "disable_rsync_rules",
             options_list=["--disable-rsync-rules"],
             arg_type=get_three_state_flag(),

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -519,7 +519,7 @@ def load_iotops_arguments(self, _):
             "tls_ca_dir",
             options_list=["--ca-dir"],
             help="The local directory the generated test CA and private key will be placed in. "
-            "If no directory is provided the current directory is used. Applicable when no "
+            "If no directory is provided no files will be written to disk. Applicable when no "
             "--ca-file and --ca-key-file are provided.",
             arg_group="TLS",
         )

--- a/azext_edge/edge/providers/orchestration/base.py
+++ b/azext_edge/edge/providers/orchestration/base.py
@@ -184,20 +184,20 @@ def prepare_ca(
         if tls_ca_key_path:
             private_key = read_file_content(file_path=tls_ca_key_path, read_as_binary=True)
     else:
-        normalized_path = normalize_dir(dir_path=tls_ca_dir)
-        test_ca_path = normalized_path.joinpath("aio-test-ca.crt")
-        test_pk_path = normalized_path.joinpath("aio-test-private.key")
-
         public_cert, private_key = generate_self_signed_cert(tls_ca_valid_days)
-
-        with open(str(test_ca_path), "wb") as f:
-            f.write(public_cert)
-
-        with open(str(test_pk_path), "wb") as f:
-            f.write(private_key)
-
         secret_name = f"{secret_name}-test-only"
         cm_name = f"{cm_name}-test-only"
+
+        if tls_ca_dir:
+            normalized_path = normalize_dir(dir_path=tls_ca_dir)
+            test_ca_path = normalized_path.joinpath("aio-test-ca.crt")
+            test_pk_path = normalized_path.joinpath("aio-test-private.key")
+
+            with open(str(test_ca_path), "wb") as f:
+                f.write(public_cert)
+
+            with open(str(test_pk_path), "wb") as f:
+                f.write(private_key)
 
     return public_cert, private_key, secret_name, cm_name
 

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -31,7 +31,7 @@ class TemplateVer(NamedTuple):
 
 V1_TEMPLATE = TemplateVer(
     commit_id="eac42bb5f3b13579b27adbcbbb71ef20e3d45df8",
-    moniker="0.4.0-preview",
+    moniker="v0.4.0-preview",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "contentVersion": "1.0.0.0",

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -50,8 +50,6 @@ class WorkStepKey(IntEnum):
     TLS_CERT = 11
     TLS_CLUSTER = 12
 
-    DEPLOY_AIO_MONIKER = 13
-
 
 class WorkRecord:
     def __init__(self, title: str):
@@ -194,12 +192,11 @@ class WorkManager:
         self.display.add_step(WorkCategoryKey.TLS_CA, WorkStepKey.TLS_CERT, tls_ca_desc)
         self.display.add_step(WorkCategoryKey.TLS_CA, WorkStepKey.TLS_CLUSTER, "Configure cluster for tls")
 
-        self.display.add_category(WorkCategoryKey.DEPLOY_AIO, "Deploy IoT Operations", skipped=self._no_deploy)
         deployment_moniker = "Custom template" if self._template_path else CURRENT_TEMPLATE.moniker
-        self.display.add_step(
+        self.display.add_category(
             WorkCategoryKey.DEPLOY_AIO,
-            WorkStepKey.DEPLOY_AIO_MONIKER,
-            f"[cyan]{deployment_moniker}[/cyan]",
+            f"Deploy IoT Operations - [cyan]{deployment_moniker}[/cyan]",
+            skipped=self._no_deploy,
         )
 
     def do_work(self):  # noqa: C901

--- a/azext_edge/tests/edge/init/conftest.py
+++ b/azext_edge/tests/edge/init/conftest.py
@@ -234,3 +234,13 @@ def spy_get_current_template_copy(mocker):
     spy = mocker.spy(work, "get_current_template_copy")
 
     yield spy
+
+
+@pytest.fixture
+def spy_work_displays(mocker):
+    from azext_edge.edge.providers.orchestration.work import WorkManager
+
+    yield {
+        "render_display": mocker.spy(WorkManager, "render_display"),
+        "complete_step": mocker.spy(WorkManager, "complete_step"),
+    }


### PR DESCRIPTION
* Refactor step presentation for Pre-Flight stage
  * Also tweak how the "Deploy IoT Operations" stage looks.
* Adds an (asterisk) indicator for which step is in work.
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/28658112/f0755148-93b5-4747-b4bb-e66b1a7c5a70)
* Backfills some gaps in presentation layer unit tests.
* Changes how disabling pre-flight stage works. Uses env var over CLI parameter to reduce visibility and disincentivize usage.
* The generated test only CA + key do not get written to disk by default. Instead the user must use `--ca-dir` i.e. `--ca-dir .`
* Swaps green variable indicators with cyan.
