### PR TITLE
fix(test): Update preflight testing to use environment variable instead of parameter

### DIFF
--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -96,7 +96,7 @@ runs:
         custom-location: ${{ inputs.custom-location != '' && format('--custom-location "{0}"', inputs.custom-location) || '' }}
         location: ${{ inputs.location != '' && format('--location "{0}"', inputs.location) || '' }}
         no-deploy: ${{ inputs.no-deploy == 'true' && '--no-deploy' || '' }}
-        no-preflight: ${{ inputs.no-preflight == 'true' && '--no-preflight' || '' }}
+        no-preflight: ${{ inputs.no-preflight }}
         no-tls: ${{ inputs.no-tls == 'true' && '--no-tls' || '' }}
         keyvault-id: ${{ inputs.keyvault-id != '' && format('--kv-id "{0}"', inputs.keyvault-id) || '' }}  
         sp-app-id: ${{ inputs.sp-app-id != '' && format('--sp-app-id "{0}"', inputs.sp-app-id) || '' }}
@@ -111,6 +111,8 @@ runs:
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
+          export AIO_CLI_INIT_PREFLIGHT_DISABLED=$no-preflight
+
           az iot ops init
           ${{ env.cluster }}
           ${{ env.resource-group }}
@@ -119,7 +121,6 @@ runs:
           ${{ env.disable-rsync-rules }}
           ${{ env.location }}
           ${{ env.no-deploy }}
-          ${{ env.no-preflight }}
           ${{ env.no-tls }}
           ${{ env.keyvault-id }}
           ${{ env.sp-app-id }}

--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -90,13 +90,13 @@ runs:
       shell: bash
     - name: "Deploy Azure IoT Operations"
       env:
+        AIO_CLI_INIT_PREFLIGHT_DISABLED: ${{ inputs.no-preflight }}
         cluster: ${{ format('--cluster "{0}"', inputs.cluster) }}
         resource-group: ${{ format('--resource-group "{0}"', inputs.resource-group) }}
         cluster-namespace: ${{ inputs.cluster-namespace != '' && format('--cluster-namespace "{0}"', inputs.cluster-namespace) || '' }}
         custom-location: ${{ inputs.custom-location != '' && format('--custom-location "{0}"', inputs.custom-location) || '' }}
         location: ${{ inputs.location != '' && format('--location "{0}"', inputs.location) || '' }}
         no-deploy: ${{ inputs.no-deploy == 'true' && '--no-deploy' || '' }}
-        no-preflight: ${{ inputs.no-preflight }}
         no-tls: ${{ inputs.no-tls == 'true' && '--no-tls' || '' }}
         keyvault-id: ${{ inputs.keyvault-id != '' && format('--kv-id "{0}"', inputs.keyvault-id) || '' }}  
         sp-app-id: ${{ inputs.sp-app-id != '' && format('--sp-app-id "{0}"', inputs.sp-app-id) || '' }}
@@ -111,8 +111,6 @@ runs:
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
-          export AIO_CLI_INIT_PREFLIGHT_DISABLED=$no-preflight
-
           az iot ops init
           ${{ env.cluster }}
           ${{ env.resource-group }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -196,7 +196,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@preflight
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -196,7 +196,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@preflight
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}


### PR DESCRIPTION
Sample run: https://github.com/c-ryan-k/azure-iot-ops-cli-extension/actions/runs/8694602561/job/23843909384

MQ-insecure uses the `no-preflight` matrix, and successfully skips preflight checks - the other feature sets use an empty var, and they do not skip the preflight checks.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
