### PR TITLE
fix: update labels in checks for services

### DIFF
--- a/azext_edge/edge/providers/check/akri.py
+++ b/azext_edge/edge/providers/check/akri.py
@@ -15,7 +15,12 @@ from ..edge_api import (
     AkriResourceKinds,
 )
 
-from ..support.akri import AKRI_INSTANCE_LABEL, AKRI_APP_LABEL, AKRI_POD_NAME_LABEL, AKRI_NAME_LABEL_V2
+from ..support.akri import (
+    AKRI_INSTANCE_LABEL,
+    AKRI_APP_LABEL,
+    AKRI_POD_NAME_LABEL,
+    AKRI_NAME_LABEL_V2,
+)
 
 from .base import (
     CheckManager,

--- a/azext_edge/edge/providers/check/akri.py
+++ b/azext_edge/edge/providers/check/akri.py
@@ -15,12 +15,7 @@ from ..edge_api import (
     AkriResourceKinds,
 )
 
-from ..support.akri import (
-    AKRI_INSTANCE_LABEL,
-    AKRI_APP_LABEL,
-    AKRI_POD_NAME_LABEL,
-    AKRI_NAME_LABEL_V2,
-)
+from ..support.akri import AKRI_NAME_LABEL_V2
 
 from .base import (
     CheckManager,

--- a/azext_edge/edge/providers/check/akri.py
+++ b/azext_edge/edge/providers/check/akri.py
@@ -77,21 +77,11 @@ def evaluate_core_service_runtime(
     check_manager = CheckManager(check_name="evalCoreServiceRuntime", check_desc="Evaluate Akri core service")
 
     padding = 6
-    akri_runtime_resources: List[dict] = []
-
-    for label in [
-        AKRI_INSTANCE_LABEL,
-        AKRI_APP_LABEL,
-        AKRI_POD_NAME_LABEL,
-        AKRI_NAME_LABEL_V2,
-    ]:
-        akri_runtime_resources.extend(
-            get_namespaced_pods_by_prefix(
-                prefix=AKRI_PREFIX,
-                namespace="",
-                label_selector=label,
-            )
-        )
+    akri_runtime_resources: List[dict] = get_namespaced_pods_by_prefix(
+        prefix=AKRI_PREFIX,
+        namespace="",
+        label_selector=AKRI_NAME_LABEL_V2,
+    )
 
     if resource_name:
         akri_runtime_resources = filter_resources_by_name(

--- a/azext_edge/edge/providers/check/akri.py
+++ b/azext_edge/edge/providers/check/akri.py
@@ -15,7 +15,7 @@ from ..edge_api import (
     AkriResourceKinds,
 )
 
-from ..support.akri import AKRI_INSTANCE_LABEL, AKRI_APP_LABEL
+from ..support.akri import AKRI_INSTANCE_LABEL, AKRI_APP_LABEL, AKRI_POD_NAME_LABEL, AKRI_NAME_LABEL_V2
 
 from .base import (
     CheckManager,
@@ -74,7 +74,12 @@ def evaluate_core_service_runtime(
     padding = 6
     akri_runtime_resources: List[dict] = []
 
-    for label in [AKRI_INSTANCE_LABEL, AKRI_APP_LABEL]:
+    for label in [
+        AKRI_INSTANCE_LABEL,
+        AKRI_APP_LABEL,
+        AKRI_POD_NAME_LABEL,
+        AKRI_NAME_LABEL_V2,
+    ]:
         akri_runtime_resources.extend(
             get_namespaced_pods_by_prefix(
                 prefix=AKRI_PREFIX,

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -320,6 +320,7 @@ AIO_MQ_FRONTEND_PREFIX = "aio-mq-dmqtt-frontend"
 AIO_MQ_BACKEND_PREFIX = "aio-mq-dmqtt-backend"
 AIO_MQ_AUTH_PREFIX = "aio-mq-dmqtt-authentication"
 AIO_MQ_KAFKA_CONFIG_PREFIX = "aio-mq-kafka-config"
+AIO_MQ_HEALTH_MANAGER = "aio-mq-dmqtt-health-manager"
 
 # Lnm runtime attributes
 AIO_LNM_PREFIX = "aio-lnm"

--- a/azext_edge/edge/providers/check/dataprocessor.py
+++ b/azext_edge/edge/providers/check/dataprocessor.py
@@ -214,7 +214,7 @@ def evaluate_instances(
                     service_label=DATA_PROCESSOR_NAME_LABEL_V2,
                     namespace=namespace
                 )
-            
+
             # TODO: remove once the new label is stabled
             evaluate_pod_health(
                 check_manager=check_manager,

--- a/azext_edge/edge/providers/check/dataprocessor.py
+++ b/azext_edge/edge/providers/check/dataprocessor.py
@@ -198,13 +198,12 @@ def evaluate_instances(
                 ),
             )
 
-            from ..support.dataprocessor import DATA_PROCESSOR_LABEL
+            from ..support.dataprocessor import DATA_PROCESSOR_NAME_LABEL_V2, DATA_PROCESSOR_ONEOFF_LABEL
 
             for pod in [
                 DATA_PROCESSOR_READER_WORKER_PREFIX,
                 DATA_PROCESSOR_RUNNER_WORKER_PREFIX,
                 DATA_PROCESSOR_REFDATA_STORE_PREFIX,
-                DATA_PROCESSOR_NATS_PREFIX,
                 DATA_PROCESSOR_OPERATOR,
             ]:
                 evaluate_pod_health(
@@ -212,9 +211,19 @@ def evaluate_instances(
                     target=target_instances,
                     pod=pod,
                     display_padding=12,
-                    service_label=DATA_PROCESSOR_LABEL,
+                    service_label=DATA_PROCESSOR_NAME_LABEL_V2,
                     namespace=namespace
                 )
+            
+            # TODO: remove once the new label is stabled
+            evaluate_pod_health(
+                check_manager=check_manager,
+                target=target_instances,
+                pod=DATA_PROCESSOR_NATS_PREFIX,
+                display_padding=12,
+                service_label=DATA_PROCESSOR_ONEOFF_LABEL,
+                namespace=namespace
+            )
 
     return check_manager.as_dict(as_list)
 

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -32,6 +32,7 @@ from .common import (
     AIO_MQ_FRONTEND_PREFIX,
     AIO_MQ_BACKEND_PREFIX,
     AIO_MQ_AUTH_PREFIX,
+    AIO_MQ_HEALTH_MANAGER,
     PADDING_SIZE,
     DataLakeConnectorTargetType,
     KafkaTopicMapRouteType,
@@ -42,7 +43,7 @@ from ...providers.edge_api import (
     MQ_ACTIVE_API,
     MqResourceKinds
 )
-from ..support.mq import MQ_LABEL
+from ..support.mq import MQ_NAME_LABEL
 
 from ..base import get_namespaced_service
 
@@ -264,7 +265,7 @@ def evaluate_diagnostics_service(
                     target=target_service_deployed,
                     pod=AIO_MQ_DIAGNOSTICS_SERVICE,
                     display_padding=12,
-                    service_label=MQ_LABEL
+                    service_label=MQ_NAME_LABEL
                 )
 
     return check_manager.as_dict(as_list)
@@ -760,7 +761,8 @@ def evaluate_brokers(
                 AIO_MQ_DIAGNOSTICS_PROBE_PREFIX,
                 AIO_MQ_FRONTEND_PREFIX,
                 AIO_MQ_BACKEND_PREFIX,
-                AIO_MQ_AUTH_PREFIX
+                AIO_MQ_AUTH_PREFIX,
+                AIO_MQ_HEALTH_MANAGER
             ]:
                 evaluate_pod_health(
                     check_manager=check_manager,
@@ -768,7 +770,7 @@ def evaluate_brokers(
                     namespace=namespace,
                     pod=pod,
                     display_padding=12,
-                    service_label=MQ_LABEL
+                    service_label=MQ_NAME_LABEL
                 )
 
     return check_manager.as_dict(as_list)

--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -34,6 +34,7 @@ AKRI_WEBHOOK_LABEL = "aio-akri-webhook-configuration"
 AKRI_NAME_LABEL_V2 = NAME_LABEL_FORMAT.format(label=AKRI_API_V0.label)
 AKRI_POD_NAME_LABEL = NAME_LABEL_FORMAT.format(label=f"{AKRI_AGENT_LABEL}, {AKRI_WEBHOOK_LABEL}")
 
+
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
     processed = []
     pod_name_labels = [

--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -32,14 +32,14 @@ AKRI_AGENT_LABEL = "aio-akri-agent"
 AKRI_WEBHOOK_LABEL = "aio-akri-webhook-configuration"
 
 AKRI_NAME_LABEL_V2 = NAME_LABEL_FORMAT.format(label=AKRI_API_V0.label)
-
+AKRI_POD_NAME_LABEL = NAME_LABEL_FORMAT.format(label=f"{AKRI_AGENT_LABEL}, {AKRI_WEBHOOK_LABEL}")
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
     processed = []
     pod_name_labels = [
         AKRI_INSTANCE_LABEL,
         AKRI_APP_LABEL,
-        NAME_LABEL_FORMAT.format(label=f"{AKRI_AGENT_LABEL}, {AKRI_WEBHOOK_LABEL}"),
+        AKRI_POD_NAME_LABEL,
     ]
     for pod_name_label in pod_name_labels:
         processed.extend(


### PR DESCRIPTION
This pr updated the labels in checks besides OPC UA, to fix the issue that some pods were not captured in new 0.5.0 template
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
