### PR TITLE
fix: orchestrator labels for 0.5.0 support bundle

### DIFF
--- a/azext_edge/edge/providers/support/orc.py
+++ b/azext_edge/edge/providers/support/orc.py
@@ -16,14 +16,13 @@ from .base import (
     process_deployments,
     process_v1_pods,
     process_services,
-    process_replicasets
+    process_replicasets,
 )
 
 logger = get_logger(__name__)
 
 
-ORC_INSTANCE_LABEL = "app.kubernetes.io/instance in (azure-iot-operations)"
-ORC_APP_LABEL = "app in (aio-orc-api)"
+ORC_APP_LABEL = "app in (aio-orc-api, cert-manager, cainjector, webhook)"
 ORC_CONTROLLER_LABEL = "control-plane in (aio-orc-controller-manager)"
 
 # TODO: @jiacju - this label will be used near future for consistency
@@ -31,47 +30,40 @@ ORC_CONTROLLER_LABEL = "control-plane in (aio-orc-controller-manager)"
 
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
-    processed = process_v1_pods(
-        resource_api=ORC_API_V1,
-        label_selector=ORC_INSTANCE_LABEL,
-        since_seconds=since_seconds,
-    )
-    processed.extend(
-        process_v1_pods(
-            resource_api=ORC_API_V1,
-            label_selector=ORC_APP_LABEL,
-            since_seconds=since_seconds,
+    processed = []
+    for label in [ORC_APP_LABEL, ORC_CONTROLLER_LABEL]:
+        processed.extend(
+            process_v1_pods(
+                resource_api=ORC_API_V1,
+                label_selector=label,
+                since_seconds=since_seconds,
+            )
         )
-    )
-    processed.extend(
-        process_v1_pods(
-            resource_api=ORC_API_V1,
-            label_selector=ORC_CONTROLLER_LABEL,
-            since_seconds=since_seconds,
-        )
-    )
 
     return processed
 
 
 def fetch_deployments():
-    processed = process_deployments(resource_api=ORC_API_V1, label_selector=ORC_INSTANCE_LABEL)
-    processed.extend(process_deployments(resource_api=ORC_API_V1, label_selector=ORC_APP_LABEL))
-    processed.extend(process_deployments(resource_api=ORC_API_V1, label_selector=ORC_CONTROLLER_LABEL))
+    processed = []
+    for label in [ORC_APP_LABEL, ORC_CONTROLLER_LABEL]:
+        processed.extend(process_deployments(resource_api=ORC_API_V1, label_selector=label))
+
     return processed
 
 
 def fetch_services():
-    processed = process_services(resource_api=ORC_API_V1, label_selector=ORC_INSTANCE_LABEL)
-    processed.extend(process_services(resource_api=ORC_API_V1, label_selector=ORC_APP_LABEL))
-    processed.extend(process_services(resource_api=ORC_API_V1, label_selector=ORC_CONTROLLER_LABEL))
+    processed = []
+    for label in [ORC_APP_LABEL, ORC_CONTROLLER_LABEL]:
+        processed.extend(process_services(resource_api=ORC_API_V1, label_selector=label))
+
     return processed
 
 
 def fetch_replicasets():
-    processed = process_replicasets(resource_api=ORC_API_V1, label_selector=ORC_INSTANCE_LABEL)
-    processed.extend(process_replicasets(resource_api=ORC_API_V1, label_selector=ORC_APP_LABEL))
-    processed.extend(process_replicasets(resource_api=ORC_API_V1, label_selector=ORC_CONTROLLER_LABEL))
+    processed = []
+    for label in [ORC_APP_LABEL, ORC_CONTROLLER_LABEL]:
+        processed.extend(process_replicasets(resource_api=ORC_API_V1, label_selector=label))
+
     return processed
 
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -769,7 +769,7 @@ def assert_list_pods(
                 )
                 assert_zipfile_write(
                     mocked_zipfile,
-                    zinfo=f"{namespace}/{resource_api.moniker}/" f"pod.{pod_name}.metric.yaml",
+                    zinfo=f"{namespace}/{resource_api.moniker}/pod.{pod_name}.metric.yaml",
                     data="apiVersion: metrics.k8s.io/v1beta1\nkind: PodMetrics\nmetadata:\n  "
                     "creationTimestamp: '0000-00-00T00:00:00Z'\n  name: mock_custom_object\n  "
                     "namespace: namespace\ntimestamp: '0000-00-00T00:00:00Z'\n",

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -347,7 +347,10 @@ def test_create_bundle(
 
             # Assert runtime resources
             assert_list_deployments(
-                mocked_client, mocked_zipfile, label_selector=DATA_PROCESSOR_LABEL, resource_api=DATA_PROCESSOR_API_V1
+                mocked_client,
+                mocked_zipfile,
+                label_selector=DATA_PROCESSOR_LABEL,
+                resource_api=DATA_PROCESSOR_API_V1,
             )
             assert_list_deployments(
                 mocked_client,


### PR DESCRIPTION
* Can no longer rely on the instance name as that has a generated suffix. 