### PR TITLE
test: some improvements to support bundle integration tests

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -269,11 +269,17 @@ def process_top_levels(
     for name in namespaces:
         # determine which namespace belongs to aio vs billing
         level_1 = walk_result.get(path.join(BASE_ZIP_PATH, name, "clusterconfig", "billing"), {})
-        files = [f for f in level_1.get("files", []) if f.startswith("job")]
+        files = [f for f in level_1.get("files", []) if f.startswith("deployment")]
         if files:
-            namespace = name
-        elif level_1:
+            # if there is a deployment, should be azure-extensions-usage-system
             clusterconfig_namespace = name
+        else:
+            namespace = name
+
+    logger.info("Determined the following namespaces:")
+    logger.info(f"AIO namespace: {namespace}")
+    if clusterconfig_namespace:
+        logger.info(f"Usage system namespace: {clusterconfig_namespace}")
 
     if clusterconfig_namespace:
         # remove empty billing related folders

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -6,7 +6,7 @@
 
 from knack.log import get_logger
 from typing import Any, Dict, List, Optional, Tuple, Union
-from os import path, sep
+from os import path
 from zipfile import ZipFile
 from azure.cli.core.azclierror import CLIInternalError
 import pytest
@@ -276,12 +276,10 @@ def process_top_levels(
         else:
             namespace = name
 
-    logger.info("Determined the following namespaces:")
-    logger.info(f"AIO namespace: {namespace}")
     if clusterconfig_namespace:
-        logger.info(f"Usage system namespace: {clusterconfig_namespace}")
-
-    if clusterconfig_namespace:
+        logger.debug("Determined the following namespaces:")
+        logger.debug(f"AIO namespace: {namespace}")
+        logger.debug(f"Usage system namespace: {clusterconfig_namespace}")
         # remove empty billing related folders
         level_1 = walk_result.pop(path.join(BASE_ZIP_PATH, clusterconfig_namespace))
         assert level_1["folders"] == ["clusterconfig"]
@@ -309,20 +307,30 @@ def run_bundle_command(
         file_names = zip.namelist()
         for name in file_names:
             name = path.join(BASE_ZIP_PATH, name)
-            # fill out files
             directory, file_name = path.split(name)
-            if directory not in walk_result:
-                walk_result[directory] = {"folders": [], "files": []}
-            walk_result[directory]["files"].append(file_name)
 
-            # fill out folders - handle all levels on first time seeing it
-            while sep in directory:
-                directory, sub = directory.rsplit(sep, 1)
-                if directory not in walk_result:
-                    walk_result[directory] = {"folders": [], "files": []}
-                if sub not in walk_result[directory]["folders"]:
-                    walk_result[directory]["folders"].append(sub)
-                else:
-                    # if we have seen sub before, then the higher levels should have been handled already
-                    break
+            # decompose incase seperator from zipfile is different from os sep. Example:
+            # windows sep is \\
+            # zipfile returns azure-extensions-usage-system/clusterconfig/billing
+            decomposed_folders = []
+            while path.split(directory)[0]:
+                directory, sub = path.split(directory)
+                decomposed_folders.append(sub)
+            decomposed_folders.append(directory)
+
+            built_path = ""
+            while decomposed_folders:
+                folder = decomposed_folders.pop(-1)
+                # make sure to add in directory to parent folder if it exists
+                if built_path and folder not in walk_result[built_path]["folders"]:
+                    walk_result[built_path]["folders"].append(folder)
+
+                built_path = path.join(built_path, folder)
+                # add in the current built directory in
+                if built_path not in walk_result:
+                    walk_result[built_path] = {"folders": [], "files": []}
+
+            # lastly add in the file (with the correct seperators)
+            walk_result[built_path]["files"].append(file_name)
+
     return walk_result


### PR DESCRIPTION
Trying to use a different method to determine namespaces + add in some logging for tests

Added in fixes for tests running on windows (with explanations in comments)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
