### PR TITLE
test: overall improvements for integration tests

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -7,7 +7,7 @@
 import pytest
 from os import mkdir, path
 from knack.log import get_logger
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 from azext_edge.edge.common import OpsServiceType
 from .helpers import (
     assert_file_names,
@@ -22,11 +22,16 @@ from .helpers import (
 logger = get_logger(__name__)
 
 
-@pytest.mark.parametrize("bundle_dir", ["support_bundles"])
-@pytest.mark.parametrize("ops_service", OpsServiceType.list())
-@pytest.mark.parametrize("mq_traces", [False, True])
+def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
+    # case = ops_service, mq_traces, bundle_dir
+    cases = [(service, False, "support_bundles") for service in OpsServiceType.list()]
+    cases.append((OpsServiceType.mq.value, True, None))
+    return cases
+
+
+@pytest.mark.parametrize("ops_service, mq_traces, bundle_dir", generate_bundle_test_cases())
 def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_files):
-    """Test to focus on ops_service param."""
+    """Test to focus on ops_service param: Are all the service bundle files also in auto?"""
 
     command = f"az iot ops support create-bundle --mq-traces {mq_traces} " + "--ops-service {0}"
     if bundle_dir:

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     {[base]deps}
     # azure-cli deps
     azure-cli
-setenv = 
+setenv =
     PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
 commands =
     python --version
@@ -77,7 +77,7 @@ deps =
 passenv =
     # pass all env vars with this prefix to tox
     azext_edge_*
-setenv = 
+setenv =
     # You can temporarily add variables here to modify your tests
     # azext_edge_skip_init=true
     PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
@@ -88,7 +88,7 @@ commands =
     # validate az and extension version
     az -v
     # run integration tests
-    pytest -k "_int.py" ./azext_edge/tests {posargs}
+    pytest -k "_int.py" ./azext_edge/tests {posargs} --durations=0
     # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
 
 # code coverage - HTML and JSON


### PR DESCRIPTION
- durations = 0 for timing breakdowns
- minimize the number of inputs in `azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py::test_create_bundle`

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
