### PR TITLE
test: improvements for integration tests

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -87,23 +87,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [default]
+        feature: [default, mq-insecure, no-syncrules, ca-certs]
         include:
           # default / limited options
           - feature: default
             ca-valid-days: 3
             kv-spc-secret-name: test-kv-secret
-          # # test --mq-insecure deployment
-          # - feature: mq-insecure
-          #   mq-insecure: true
-          #   no-preflight: true
-          # # test disabling custom sync rules
-          # - feature: no-syncrules
-          #   disable-rsync-rules: true
-          # # test custom ca files
-          # - feature: ca-certs
-          #   ca-file: 'test-ca.pem'
-          #   ca-key-file: 'test-ca-key.pem'
+          # test --mq-insecure deployment
+          - feature: mq-insecure
+            mq-insecure: true
+            no-preflight: true
+          # test disabling custom sync rules
+          - feature: no-syncrules
+            disable-rsync-rules: true
+          # test custom ca files
+          - feature: ca-certs
+            ca-file: 'test-ca.pem'
+            ca-key-file: 'test-ca-key.pem'
     name: "Run cluster tests"
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -87,23 +87,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [default, mq-insecure, no-syncrules, ca-certs]
+        feature: [default]
         include:
           # default / limited options
           - feature: default
             ca-valid-days: 3
             kv-spc-secret-name: test-kv-secret
-          # test --mq-insecure deployment
-          - feature: mq-insecure
-            mq-insecure: true
-            no-preflight: true
-          # test disabling custom sync rules
-          - feature: no-syncrules
-            disable-rsync-rules: true
-          # test custom ca files
-          - feature: ca-certs
-            ca-file: 'test-ca.pem'
-            ca-key-file: 'test-ca-key.pem'
+          # # test --mq-insecure deployment
+          # - feature: mq-insecure
+          #   mq-insecure: true
+          #   no-preflight: true
+          # # test disabling custom sync rules
+          # - feature: no-syncrules
+          #   disable-rsync-rules: true
+          # # test custom ca files
+          # - feature: ca-certs
+          #   ca-file: 'test-ca.pem'
+          #   ca-key-file: 'test-ca-key.pem'
     name: "Run cluster tests"
     runs-on: ubuntu-22.04
     steps:
@@ -246,7 +246,7 @@ jobs:
           azext_edge_skip_init: True
         run: |
           cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
-          tox r -e python-int --skip-pkg-install --durations=0
+          tox r -e python-int --skip-pkg-install -- --durations=0
       - name: "Az CLI login refresh"
         uses: azure/login@v2
         with:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -72,7 +72,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: "Create Key Vault for clusters"
       run: az keyvault create -n ${{ env.KV_NAME }} -g ${{ env.RESOURCE_GROUP }} --enable-rbac-authorization false
-    
+
   test:
     needs: [create_kv]
     outputs:
@@ -246,7 +246,7 @@ jobs:
           azext_edge_skip_init: True
         run: |
           cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
-          tox r -e python-int --skip-pkg-install
+          tox r -e python-int --skip-pkg-install --durations=0
       - name: "Az CLI login refresh"
         uses: azure/login@v2
         with:

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -7,7 +7,7 @@
 import pytest
 from os import mkdir, path
 from knack.log import get_logger
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 from azext_edge.edge.common import OpsServiceType
 from .helpers import (
     assert_file_names,
@@ -22,9 +22,14 @@ from .helpers import (
 logger = get_logger(__name__)
 
 
-@pytest.mark.parametrize("bundle_dir", ["support_bundles"])
-@pytest.mark.parametrize("ops_service", OpsServiceType.list())
-@pytest.mark.parametrize("mq_traces", [False, True])
+def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
+    # case = ops_service, mq_traces, bundle_dir
+    cases = [(service, False, "support_bundles") for service in OpsServiceType.list()]
+    cases.append((OpsServiceType.mq.value, True, None))
+    return cases
+
+
+@pytest.mark.parametrize("ops_service, mq_traces, bundle_dir", generate_bundle_test_cases())
 def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_files):
     """Test to focus on ops_service param."""
 


### PR DESCRIPTION
1. limit test_create_bundle inputs
2. add in durations=0 for timing ease

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
