### PR TITLE
refactor: add pod related unit tests

### DIFF
--- a/azext_edge/edge/providers/check/base/__init__.py
+++ b/azext_edge/edge/providers/check/base/__init__.py
@@ -8,7 +8,7 @@ from .check_manager import CheckManager
 from .deployment import check_pre_deployment, check_post_deployment
 from .display import add_display_and_eval, display_as_list, process_value_color
 from .node import check_nodes
-from .pod import decorate_pod_phase, evaluate_pod_health, process_pods_status
+from .pod import decorate_pod_phase, evaluate_pod_health, process_pods_status, evaluate_detailed_pod_health
 from .resource import (
     decorate_resource_status,
     filter_resources_by_name,
@@ -33,6 +33,7 @@ __all__ = [
     "decorate_resource_status",
     "display_as_list",
     "evaluate_pod_health",
+    "evaluate_detailed_pod_health",
     "filter_resources_by_name",
     "filter_resources_by_namespace",
     "generate_target_resource_name",

--- a/azext_edge/edge/providers/check/base/pod.py
+++ b/azext_edge/edge/providers/check/base/pod.py
@@ -167,7 +167,7 @@ def evaluate_detailed_pod_health(
         for condition in pod_conditions:
             type = condition.get("type")
             condition_type = POD_CONDITION_TEXT_MAP[type]
-            condition_status =  condition.get("status") == "True"
+            condition_status = condition.get("status") == "True"
             pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
 
             add_display_and_eval(

--- a/azext_edge/edge/providers/check/base/pod.py
+++ b/azext_edge/edge/providers/check/base/pod.py
@@ -167,7 +167,7 @@ def evaluate_detailed_pod_health(
         for condition in pod_conditions:
             type = condition.get("type")
             condition_type = POD_CONDITION_TEXT_MAP[type]
-            condition_status = True if condition.get("status") == "True" else False
+            condition_status =  condition.get("status") == "True"
             pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
 
             add_display_and_eval(

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -219,7 +219,7 @@ LNM_REST_PROPERTIES = [
     ("replicas", "Replicas", False),
 ]
 
-LNM_POD_CONDITION_TEXT_MAP = {
+POD_CONDITION_TEXT_MAP = {
     "Ready": "Pod Readiness",
     "Initialized": "Pod Initialized",
     "ContainersReady": "Containers Readiness",

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -6,6 +6,8 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from azext_edge.edge.providers.check.base.pod import evaluate_detailed_pod_health
+
 from ..base import get_namespaced_pods_by_prefix
 from .base import (
     CheckManager,
@@ -31,7 +33,7 @@ from .common import (
     LNM_ALLOWLIST_PROPERTIES,
     LNM_EXCLUDED_SUBRESOURCE,
     LNM_IMAGE_PROPERTIES,
-    LNM_POD_CONDITION_TEXT_MAP,
+    POD_CONDITION_TEXT_MAP,
     LNM_REST_PROPERTIES,
     ResourceOutputDetailLevel,
 )
@@ -281,7 +283,7 @@ def evaluate_lnms(
             pods = get_namespaced_pods_by_prefix(prefix=AIO_LNM_PREFIX, namespace="", label_selector=lnm_label)
 
             for pod in pods:
-                _evaluate_lnm_pod_health(
+                evaluate_detailed_pod_health(
                     check_manager=check_manager,
                     target=target_lnms,
                     pod=pod,
@@ -339,7 +341,7 @@ def _process_lnm_pods(
         )
 
         for pod in pods:
-            _evaluate_lnm_pod_health(
+            evaluate_detailed_pod_health(
                 check_manager=check_manager,
                 target=target,
                 pod=pod,
@@ -371,6 +373,7 @@ def _evaluate_lnm_pod_health(
         f"{target_service_pod}.status.conditions.initialized",
         f"{target_service_pod}.status.conditions.containersready",
         f"{target_service_pod}.status.conditions.podscheduled",
+        f"{target_service_pod}.status.conditions.podreadytostartcontainers",
     ]
 
     if check_manager.targets.get(target, {}).get(namespace, {}).get("conditions", None):
@@ -419,7 +422,7 @@ def _evaluate_lnm_pod_health(
 
         for condition in pod_conditions:
             type = condition.get("type")
-            condition_type = LNM_POD_CONDITION_TEXT_MAP[type]
+            condition_type = POD_CONDITION_TEXT_MAP[type]
             condition_status = True if condition.get("status") == "True" else False
             pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
 

--- a/azext_edge/edge/providers/check/lnm.py
+++ b/azext_edge/edge/providers/check/lnm.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from azext_edge.edge.providers.check.base.pod import evaluate_detailed_pod_health
 
@@ -13,7 +13,6 @@ from .base import (
     CheckManager,
     add_display_and_eval,
     check_post_deployment,
-    decorate_pod_phase,
     filter_resources_by_name,
     generate_target_resource_name,
     get_resources_by_name,
@@ -22,7 +21,6 @@ from .base import (
 )
 
 from rich.padding import Padding
-from kubernetes.client.models import V1Pod
 
 from ...common import CheckTaskStatus
 
@@ -33,7 +31,6 @@ from .common import (
     LNM_ALLOWLIST_PROPERTIES,
     LNM_EXCLUDED_SUBRESOURCE,
     LNM_IMAGE_PROPERTIES,
-    POD_CONDITION_TEXT_MAP,
     LNM_REST_PROPERTIES,
     ResourceOutputDetailLevel,
 )
@@ -286,6 +283,7 @@ def evaluate_lnms(
                 evaluate_detailed_pod_health(
                     check_manager=check_manager,
                     target=target_lnms,
+                    target_service_pod=f"pod/{AIO_LNM_PREFIX}",
                     pod=pod,
                     display_padding=padding + PADDING_SIZE,
                     namespace=namespace,
@@ -344,111 +342,9 @@ def _process_lnm_pods(
             evaluate_detailed_pod_health(
                 check_manager=check_manager,
                 target=target,
+                target_service_pod=f"pod/{prefix}",
                 pod=pod,
                 display_padding=padding + PADDING_SIZE,
                 namespace=namespace,
                 detail_level=detail_level,
             )
-
-
-def _evaluate_lnm_pod_health(
-    check_manager: CheckManager,
-    target: str,
-    pod: V1Pod,
-    display_padding: int,
-    namespace: str,
-    detail_level: int = ResourceOutputDetailLevel.summary.value,
-) -> None:
-
-    def _decorate_pod_condition(condition: bool) -> Tuple[str, str]:
-        if condition:
-            return f"[green]{condition}[/green]", CheckTaskStatus.success.value
-        return f"[red]{condition}[/red]", CheckTaskStatus.error.value
-
-    target_service_pod = f"pod/{pod.metadata.name}"
-
-    pod_conditions = [
-        f"{target_service_pod}.status.phase",
-        f"{target_service_pod}.status.conditions.ready",
-        f"{target_service_pod}.status.conditions.initialized",
-        f"{target_service_pod}.status.conditions.containersready",
-        f"{target_service_pod}.status.conditions.podscheduled",
-        f"{target_service_pod}.status.conditions.podreadytostartcontainers",
-    ]
-
-    if check_manager.targets.get(target, {}).get(namespace, {}).get("conditions", None):
-        check_manager.add_target_conditions(target_name=target, namespace=namespace, conditions=pod_conditions)
-    else:
-        check_manager.set_target_conditions(target_name=target, namespace=namespace, conditions=pod_conditions)
-
-    if not pod:
-        add_display_and_eval(
-            check_manager=check_manager,
-            target_name=target,
-            display_text=f"{target_service_pod}* [yellow]not detected[/yellow].",
-            eval_status=CheckTaskStatus.warning.value,
-            eval_value=None,
-            resource_name=target_service_pod,
-            namespace=namespace,
-            padding=(0, 0, 0, display_padding)
-        )
-    else:
-        pod_dict = pod.to_dict()
-        pod_name = pod_dict["metadata"]["name"]
-        pod_phase = pod_dict.get("status", {}).get("phase")
-        pod_conditions = pod_dict.get("status", {}).get("conditions", {})
-        pod_phase_deco, status = decorate_pod_phase(pod_phase)
-
-        check_manager.add_target_eval(
-            target_name=target,
-            namespace=namespace,
-            status=status,
-            resource_name=target_service_pod,
-            value={"name": pod_name, "status.phase": pod_phase},
-        )
-
-        for text in [
-            f"\nPod {{[bright_blue]{pod_name}[/bright_blue]}}",
-            f"- Phase: {pod_phase_deco}",
-            "- Conditions:"
-        ]:
-            padding = 2 if "\nPod" not in text else 0
-            padding += display_padding
-            check_manager.add_display(
-                target_name=target,
-                namespace=namespace,
-                display=Padding(text, (0, 0, 0, padding)),
-            )
-
-        for condition in pod_conditions:
-            type = condition.get("type")
-            condition_type = POD_CONDITION_TEXT_MAP[type]
-            condition_status = True if condition.get("status") == "True" else False
-            pod_condition_deco, status = _decorate_pod_condition(condition=condition_status)
-
-            add_display_and_eval(
-                check_manager=check_manager,
-                target_name=target,
-                display_text=f"{condition_type}: {pod_condition_deco}",
-                eval_status=status,
-                eval_value={"name": pod_name, f"status.conditions.{type.lower()}": condition_status},
-                resource_name=target_service_pod,
-                namespace=namespace,
-                padding=(0, 0, 0, display_padding + 8)
-            )
-
-            if detail_level > ResourceOutputDetailLevel.summary.value:
-                condition_reason = condition.get("message")
-                condition_reason_text = f"{condition_reason}" if condition_reason else ""
-
-                if condition_reason_text:
-                    # remove the [ and ] to prevent console not printing the text
-                    condition_reason_text = condition_reason_text.replace("[", "\\[")
-                    check_manager.add_display(
-                        target_name=target,
-                        namespace=namespace,
-                        display=Padding(
-                            f"[red]Reason: {condition_reason_text}[/red]",
-                            (0, 0, 0, display_padding + 8),
-                        ),
-                    )

--- a/azext_edge/tests/edge/checks/base/test_pod_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_pod_unit.py
@@ -12,8 +12,8 @@ from azext_edge.edge.providers.check.base import (
     evaluate_detailed_pod_health,
 )
 from azext_edge.edge.providers.check.base.pod import (
-    evaluate_pod_health, 
-    process_pods_status
+    evaluate_pod_health,
+    process_pods_status,
 )
 from azext_edge.edge.providers.check.common import ALL_NAMESPACES_TARGET, ResourceOutputDetailLevel
 from azext_edge.tests.edge.checks.conftest import generate_pod_stub

--- a/azext_edge/tests/edge/checks/base/test_pod_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_pod_unit.py
@@ -5,15 +5,18 @@
 # ----------------------------------------------------------------------------------------------
 
 import pytest
+
 from azext_edge.edge.common import CheckTaskStatus, PodState
-from azext_edge.edge.providers.check.base.pod import evaluate_pod_health, process_pods_status
-from azext_edge.edge.providers.check.common import ALL_NAMESPACES_TARGET, ResourceOutputDetailLevel
-from azext_edge.tests.edge.checks.conftest import generate_pod_stub
 from azext_edge.edge.providers.check.base import (
     decorate_pod_phase,
     evaluate_detailed_pod_health,
 )
-
+from azext_edge.edge.providers.check.base.pod import (
+    evaluate_pod_health, 
+    process_pods_status
+)
+from azext_edge.edge.providers.check.common import ALL_NAMESPACES_TARGET, ResourceOutputDetailLevel
+from azext_edge.tests.edge.checks.conftest import generate_pod_stub
 from ....generators import generate_random_string
 
 
@@ -62,12 +65,12 @@ def test_decorate_pod_phase(phase, expected):
 )
 def test_evaluate_pod_health(
     mocker,
+    mock_process_pods_status,
     mocked_check_manager,
     namespace,
-    pods,
     padding,
+    pods,
     target_service_pod,
-    mock_process_pods_status,
 ):
     mocker = mocker.patch(
         "azext_edge.edge.providers.check.base.pod.get_namespaced_pods_by_prefix",
@@ -132,12 +135,12 @@ def test_evaluate_pod_health(
     ]
 )
 def test_process_pods_status(
+    mock_add_display_and_eval,
     mocked_check_manager,
     namespace,
-    pods,
     padding,
+    pods,
     target_service_pod,
-    mock_add_display_and_eval,
 ):
     process_pods_status(
         check_manager=mocked_check_manager,
@@ -392,21 +395,21 @@ def test_process_pods_status(
         # resource_name
         "lnm-operator-5",
         # conditions
-        []
+        None
     )
 ])
 def test_evaluate_detailed_pod_health(
-    mocked_check_manager,
+    conditions,
     detail_level,
-    resource_name,
+    eval_status,
+    eval_value,
+    mock_add_display_and_eval,
+    mocked_check_manager,
     namespace,
     padding,
     pod,
-    eval_status,
-    eval_value,
+    resource_name,
     target_service_pod,
-    conditions,
-    mock_add_display_and_eval
 ):
     target_name = generate_random_string()
 
@@ -441,6 +444,9 @@ def test_evaluate_detailed_pod_health(
             value=eval_value,
             resource_name=f"pod/{resource_name}"
         )
+
+        if not conditions:
+            return
 
         for condition in conditions:
             condition_status = True if condition.get("status") == "True" else False

--- a/azext_edge/tests/edge/checks/base/test_pod_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_pod_unit.py
@@ -1,0 +1,459 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import pytest
+from azext_edge.edge.common import CheckTaskStatus, PodState
+from azext_edge.edge.providers.check.base.pod import evaluate_pod_health, process_pods_status
+from azext_edge.edge.providers.check.common import ALL_NAMESPACES_TARGET, ResourceOutputDetailLevel
+from azext_edge.tests.edge.checks.conftest import generate_pod_stub
+from azext_edge.edge.providers.check.base import (
+    decorate_pod_phase,
+    evaluate_detailed_pod_health,
+)
+
+from ....generators import generate_random_string
+
+
+@pytest.mark.parametrize("phase, expected", [
+    ("Running", ("[green]Running[/green]", PodState.map_to_status("Running").value)),
+    ("Pending", ("[yellow]Pending[/yellow]", PodState.map_to_status("Pending").value)),
+    ("Failed", ("[red]Failed[/red]", PodState.map_to_status("Failed").value)),
+    ("Succeeded", ("[green]Succeeded[/green]", PodState.map_to_status("Succeeded").value)),
+    ("Unknown", ("[yellow]Unknown[/yellow]", PodState.map_to_status("Unknown").value))
+])
+def test_decorate_pod_phase(phase, expected):
+    assert decorate_pod_phase(phase) == expected
+
+
+@pytest.mark.parametrize("target_service_pod", [generate_random_string()])
+@pytest.mark.parametrize("namespace", [ALL_NAMESPACES_TARGET, generate_random_string()])
+@pytest.mark.parametrize("padding", [4])
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [],
+        [generate_pod_stub(name="lnm-operator-1", phase="Running")],
+        [generate_pod_stub(name="lnm-operator-1", phase="Pending")],
+        [generate_pod_stub(name="lnm-operator-1", phase="Failed")],
+        [
+            generate_pod_stub(
+                name="lnm-operator-1",
+                phase="Running",
+            ),
+            generate_pod_stub(
+                name="lnm-operator-2",
+                phase="Pending",
+            ),
+        ],
+        [
+            generate_pod_stub(
+                name="lnm-operator-1",
+                phase="Running",
+            ),
+            generate_pod_stub(
+                name="lnm-operator-3",
+                phase="Failed",
+            ),
+        ],
+    ]
+)
+def test_evaluate_pod_health(
+    mocker,
+    mocked_check_manager,
+    namespace,
+    pods,
+    padding,
+    target_service_pod,
+    mock_process_pods_status,
+):
+    mocker = mocker.patch(
+        "azext_edge.edge.providers.check.base.pod.get_namespaced_pods_by_prefix",
+        return_value=pods,
+    )
+
+    evaluate_pod_health(
+        check_manager=mocked_check_manager,
+        namespace=namespace,
+        target=target_service_pod,
+        pod=target_service_pod,
+        display_padding=padding,
+        service_label=generate_random_string(),
+    )
+
+    mocked_check_manager.add_target_conditions.assert_called_once_with(
+        target_name=target_service_pod,
+        namespace=namespace,
+        conditions=[f"pod/{target_service_pod}.status.phase"]
+    )
+
+    mock_process_pods_status.assert_called_once_with(
+        check_manager=mocked_check_manager,
+        namespace=namespace,
+        target=target_service_pod,
+        target_service_pod=f"pod/{target_service_pod}",
+        pods=pods,
+        display_padding=padding
+    )
+
+
+@pytest.mark.parametrize("target_service_pod", [generate_random_string()])
+@pytest.mark.parametrize("namespace", [ALL_NAMESPACES_TARGET, generate_random_string()])
+@pytest.mark.parametrize("padding", [4])
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [],
+        [generate_pod_stub(name="lnm-operator-1", phase="Running")],
+        [generate_pod_stub(name="lnm-operator-1", phase="Pending")],
+        [generate_pod_stub(name="lnm-operator-1", phase="Failed")],
+        [
+            generate_pod_stub(
+                name="lnm-operator-1",
+                phase="Running",
+            ),
+            generate_pod_stub(
+                name="lnm-operator-2",
+                phase="Pending",
+            ),
+        ],
+        [
+            generate_pod_stub(
+                name="lnm-operator-1",
+                phase="Running",
+            ),
+            generate_pod_stub(
+                name="lnm-operator-3",
+                phase="Failed",
+            ),
+        ],
+    ]
+)
+def test_process_pods_status(
+    mocked_check_manager,
+    namespace,
+    pods,
+    padding,
+    target_service_pod,
+    mock_add_display_and_eval,
+):
+    process_pods_status(
+        check_manager=mocked_check_manager,
+        namespace=namespace,
+        target=target_service_pod,
+        target_service_pod=target_service_pod,
+        pods=pods,
+        display_padding=padding,
+    )
+
+    if not pods:
+        mock_add_display_and_eval.assert_called_once_with(
+            check_manager=mocked_check_manager,
+            target_name=target_service_pod,
+            display_text=f"{target_service_pod}* [yellow]not detected[/yellow].",
+            eval_status=CheckTaskStatus.warning.value,
+            eval_value=None,
+            resource_name=target_service_pod,
+            namespace=namespace,
+            padding=(0, 0, 0, padding)
+        )
+
+    else:
+        for pod in pods:
+            pod_dict = pod.to_dict()
+            pod_name = pod_dict["metadata"]["name"]
+            pod_phase = pod_dict.get("status", {}).get("phase")
+            pod_phase_deco, status = decorate_pod_phase(pod_phase)
+            resource_name = f"pod/{pod_name}"
+            mock_add_display_and_eval.assert_any_call(
+                check_manager=mocked_check_manager,
+                target_name=target_service_pod,
+                display_text=f"Pod {{[bright_blue]{pod_name}[/bright_blue]}} in phase {{{pod_phase_deco}}}.",
+                eval_status=status,
+                eval_value={"name": pod_name, "status.phase": pod_phase},
+                resource_name=resource_name,
+                namespace=namespace,
+                padding=(0, 0, 0, padding)
+            )
+
+
+@pytest.mark.parametrize("target_service_pod", [generate_random_string()])
+@pytest.mark.parametrize("namespace", [ALL_NAMESPACES_TARGET, generate_random_string()])
+@pytest.mark.parametrize("padding", [4])
+@pytest.mark.parametrize("detail_level", ResourceOutputDetailLevel.list())
+@pytest.mark.parametrize("pod, eval_status, eval_value, resource_name, conditions", [
+    (
+        # pod
+        None,
+        # eval_status
+        CheckTaskStatus.warning.value,
+        # eval_value
+        None,
+        # resource_name
+        "",
+        # conditions
+        []
+    ),
+    (
+        # pod
+        generate_pod_stub(
+            name="lnm-operator-1",
+            phase="Running",
+            conditions=[
+                {
+                    "type": "Ready",
+                    "status": "True",
+                },
+                {
+                    "type": "Initialized",
+                    "status": "True",
+                },
+                {
+                    "type": "ContainersReady",
+                    "status": "True",
+                },
+                {
+                    "type": "PodScheduled",
+                    "status": "True",
+                },
+            ]
+        ),
+        # eval_status
+        CheckTaskStatus.success.value,
+        # eval_value
+        {"name": "lnm-operator-1", "status.phase": "Running"},
+        # resource_name
+        "lnm-operator-1",
+        # conditions
+        [
+            {
+                "type": "Ready",
+                "status": "True",
+                "status_text": "Pod Readiness: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            },
+            {
+                "type": "Initialized",
+                "status": "True",
+                "status_text": "Pod Initialized: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            },
+            {
+                "type": "ContainersReady",
+                "status": "True",
+                "status_text": "Containers Readiness: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "status_text": "Pod Scheduled: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            },
+        ]
+    ),
+    (
+        # pod
+        generate_pod_stub(
+            name="lnm-operator-2",
+            phase="Pending",
+            conditions=[
+                {
+                    "type": "PodReadyToStartContainers",
+                    "status": "True",
+                }
+            ]
+        ),
+        # eval_status
+        CheckTaskStatus.warning.value,
+        # eval_value
+        {"name": "lnm-operator-2", "status.phase": "Pending"},
+        # resource_name
+        "lnm-operator-2",
+        # conditions
+        [
+            {
+                "type": "PodReadyToStartContainers",
+                "status": "True",
+                "status_text": "Pod Ready To Start Containers: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            }
+        ]
+    ),
+    (
+        # pod
+        generate_pod_stub(
+            name="lnm-operator-3",
+            phase="Running",
+            conditions=[
+                {
+                    "type": "Ready",
+                    "status": "False",
+                },
+                {
+                    "type": "Initialized",
+                    "status": "False",
+                },
+                {
+                    "type": "ContainersReady",
+                    "status": "False",
+                },
+                {
+                    "type": "PodScheduled",
+                    "status": "False",
+                },
+                {
+                    "type": "PodReadyToStartContainers",
+                    "status": "False",
+                }
+            ]
+        ),
+        # eval_status
+        CheckTaskStatus.success.value,
+        # eval_value
+        {"name": "lnm-operator-3", "status.phase": "Running"},
+        # resource_name
+        "lnm-operator-3",
+        # conditions
+        [
+            {
+                "type": "Ready",
+                "status": "False",
+                "status_text": "Pod Readiness: [red]False[/red]",
+                "eval_status": CheckTaskStatus.error.value
+            },
+            {
+                "type": "Initialized",
+                "status": "False",
+                "status_text": "Pod Initialized: [red]False[/red]",
+                "eval_status": CheckTaskStatus.error.value
+            },
+            {
+                "type": "ContainersReady",
+                "status": "False",
+                "status_text": "Containers Readiness: [red]False[/red]",
+                "eval_status": CheckTaskStatus.error.value
+            },
+            {
+                "type": "PodScheduled",
+                "status": "False",
+                "status_text": "Pod Scheduled: [red]False[/red]",
+                "eval_status": CheckTaskStatus.error.value
+            },
+            {
+                "type": "PodReadyToStartContainers",
+                "status": "False",
+                "status_text": "Pod Ready To Start Containers: [red]False[/red]",
+                "eval_status": CheckTaskStatus.error.value
+            }
+        ]
+    ),
+    (
+        # pod
+        generate_pod_stub(
+            name="lnm-operator-4",
+            phase="Pending",
+            conditions=[
+                {
+                    "type": "Ready",
+                    "status": "True",
+                },
+            ]
+        ),
+        # eval_status
+        CheckTaskStatus.warning.value,
+        # eval_value
+        {"name": "lnm-operator-4", "status.phase": "Pending"},
+        # resource_name
+        "lnm-operator-4",
+        # conditions
+        [
+            {
+                "type": "Ready",
+                "status": "True",
+                "status_text": "Pod Readiness: [green]True[/green]",
+                "eval_status": CheckTaskStatus.success.value
+            }
+        ]
+    ),
+    (
+        # pod
+        generate_pod_stub(
+            name="lnm-operator-5",
+            phase="Failed",
+            conditions=None
+        ),
+        # eval_status
+        CheckTaskStatus.error.value,
+        # eval_value
+        {"name": "lnm-operator-5", "status.phase": "Failed"},
+        # resource_name
+        "lnm-operator-5",
+        # conditions
+        []
+    )
+])
+def test_evaluate_detailed_pod_health(
+    mocked_check_manager,
+    detail_level,
+    resource_name,
+    namespace,
+    padding,
+    pod,
+    eval_status,
+    eval_value,
+    target_service_pod,
+    conditions,
+    mock_add_display_and_eval
+):
+    target_name = generate_random_string()
+
+    evaluate_detailed_pod_health(
+        check_manager=mocked_check_manager,
+        target=target_name,
+        target_service_pod=target_service_pod,
+        pod=pod,
+        display_padding=padding,
+        namespace=namespace,
+        detail_level=detail_level,
+    )
+
+    if not pod:
+        mock_add_display_and_eval.assert_any_call(
+            check_manager=mocked_check_manager,
+            target_name=target_name,
+            display_text=f"{target_service_pod}* [yellow]not detected[/yellow].",
+            eval_status=eval_status,
+            eval_value=eval_value,
+            resource_name=target_service_pod,
+            namespace=namespace,
+            padding=(0, 0, 0, padding)
+        )
+
+    else:
+        assert mocked_check_manager.set_target_conditions.called or mocked_check_manager.add_target_conditions.called
+        mocked_check_manager.add_target_eval.assert_any_call(
+            target_name=target_name,
+            namespace=namespace,
+            status=eval_status,
+            value=eval_value,
+            resource_name=f"pod/{resource_name}"
+        )
+
+        for condition in conditions:
+            condition_status = True if condition.get("status") == "True" else False
+            mock_add_display_and_eval.assert_any_call(
+                check_manager=mocked_check_manager,
+                target_name=target_name,
+                display_text=condition["status_text"],
+                eval_status=condition["eval_status"],
+                eval_value={"name": resource_name, f"status.conditions.{condition['type'].lower()}": condition_status},
+                resource_name=f"pod/{resource_name}",
+                namespace=namespace,
+                padding=(0, 0, 0, padding + 8)
+            )
+
+            if detail_level > ResourceOutputDetailLevel.summary.value:
+                mocked_check_manager.add_display.assert_called()

--- a/azext_edge/tests/edge/checks/conftest.py
+++ b/azext_edge/tests/edge/checks/conftest.py
@@ -12,7 +12,22 @@ from azext_edge.edge.providers.check.common import CoreServiceResourceKinds
 
 @pytest.fixture
 def mocked_check_manager(mocker):
-    return mocker.patch("azext_edge.edge.providers.check.base.CheckManager", autospec=True)
+    manager = mocker.patch("azext_edge.edge.providers.check.base.CheckManager", autospec=True)
+    # add `targets` attribute
+    manager.configure_mock(targets={})
+    return manager
+
+
+@pytest.fixture
+def mock_process_pods_status(mocker):
+    patched = mocker.patch("azext_edge.edge.providers.check.base.pod.process_pods_status")
+    yield patched
+
+
+@pytest.fixture
+def mock_add_display_and_eval(mocker):
+    patched = mocker.patch('azext_edge.edge.providers.check.base.pod.add_display_and_eval')
+    yield patched
 
 
 @pytest.fixture


### PR DESCRIPTION
1. Add unit tests for pod functions
2. Moved a function for the pod check refactor preparation post release
ps: will do more refactoring function-wise post release
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
