### PR TITLE
fix(ci): Update cleanup script to fix timeouts and also remove asset collateral 

### DIFF
--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -12,9 +12,9 @@ on:
         description: "Resource group to clean up"
         required: true
       keyvault_prefix:
-          type: string
-          description: "Prefix of keyvault to delete"
-          required: true
+        type: string
+        description: "Prefix of keyvault to delete"
+        required: true
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -32,7 +32,7 @@ on:
         default: ops-cli-int-test-rg
   # Run every night at midnight (Pacific) to cleanup resources
   schedule:
-    - cron: '0 8 * * *'
+    - cron: "0 8 * * *"
 
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}
@@ -41,8 +41,8 @@ env:
 
 permissions:
   # required for OpenID federation
-  contents: 'read'
-  id-token: 'write'
+  contents: "read"
+  id-token: "write"
 
 jobs:
   keyvault-cleanup:
@@ -106,7 +106,7 @@ jobs:
           inlineScript: |
             mq_type="Microsoft.IoTOperationsMQ/mq"
             in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
-            
+
             # MQ instance cannot be deleted until all child resources have successfully deleted
             sleep 15s
 

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -132,6 +132,16 @@ jobs:
             for asset in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $asset_type --query "[?$in_cluster_ext_loc].id" -o tsv); do
               az resource delete -v --id $asset --verbose
             done
+      - name: Delete asset endpoint profiles
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            endpoint_type="Microsoft.DeviceRegistry/assetEndpointProfiles"
+            in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
+            for endpoint in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $endpoint_type --query "[?$in_cluster_ext_loc].id" -o tsv); do
+              az resource delete -v --id $endpoint --verbose
+            done
   arc-cleanup:
     runs-on: ubuntu-latest
     needs: [resource-cleanup, mq-cleanup]

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -45,21 +45,6 @@ permissions:
   id-token: 'write'
 
 jobs:
-  arc-cleanup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Az CLI login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Delete ARC instances
-        run: |
-          cluster_type="Microsoft.Kubernetes/connectedClusters"
-          for cluster in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $cluster_type --query "[?starts_with(name, '${{ env.CLUSTER_PREFIX }}')].id" -o tsv); do
-            az resource delete -v --id $cluster --verbose
-          done
   keyvault-cleanup:
     runs-on: ubuntu-latest
     steps:
@@ -70,12 +55,14 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Delete keyvaults
-        run: |
-          for vault in $(az keyvault list --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
-            az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }} --no-wait
-          done
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            for vault in $(az keyvault list --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
+              az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }} --no-wait
+            done
   resource-cleanup:
-    needs: [arc-cleanup]
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
@@ -85,10 +72,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Delete linked AIO resources
-        run: |
-          for resource in $(az resource list -g ${{ env.RESOURCE_GROUP }} --query "[?starts_with(name, '${{ env.CLUSTER_PREFIX }}')].id" -o tsv); do
-            az resource delete -v --id $resource --verbose
-          done
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            for resource in $(az resource list -g ${{ env.RESOURCE_GROUP }} --query "[?starts_with(name, '${{ env.CLUSTER_PREFIX }}')].id" -o tsv); do
+              az resource delete -v --id $resource --verbose
+            done
   mq-cleanup:
     runs-on: ubuntu-latest
     steps:
@@ -99,21 +89,65 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Delete MQ child resources
-        run: |
-          is_mq_child_resource="contains(to_string(type), 'Microsoft.IoTOperationsMQ/mq/')"
-          in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            is_mq_child_resource="contains(to_string(type), 'Microsoft.IoTOperationsMQ/mq/')"
+            in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
 
-          for mq_resource in $(az resource list -g ${{ env.RESOURCE_GROUP }} --query "[?$in_cluster_ext_loc && $is_mq_child_resource].id" -o tsv); do
-            az resource delete -v --id $mq_resource --verbose
-          done
+            for mq_resource in $(az resource list -g ${{ env.RESOURCE_GROUP }} --query "[?$in_cluster_ext_loc && $is_mq_child_resource].id" -o tsv); do
+              az resource delete -v --id $mq_resource --verbose
+            done
       - name: Delete MQ instances
-        run: |
-          mq_type="Microsoft.IoTOperationsMQ/mq"
-          in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
-          
-          # MQ instance cannot be deleted until all child resources have successfully deleted
-          sleep 15s
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            mq_type="Microsoft.IoTOperationsMQ/mq"
+            in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
+            
+            # MQ instance cannot be deleted until all child resources have successfully deleted
+            sleep 15s
 
-          for mq in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $mq_type  --query "[?$in_cluster_ext_loc].id" -o tsv); do
-            az resource delete -v --id $mq --verbose
-          done
+            for mq in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $mq_type  --query "[?$in_cluster_ext_loc].id" -o tsv); do
+              az resource delete -v --id $mq --verbose
+            done
+  asset-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Az CLI login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Delete Assets
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            asset_type="Microsoft.DeviceRegistry/assets"
+            in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
+            for asset in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $asset_type --query "[?$in_cluster_ext_loc].id" -o tsv); do
+              az resource delete -v --id $asset --verbose
+            done
+  arc-cleanup:
+    runs-on: ubuntu-latest
+    needs: [resource-cleanup, mq-cleanup]
+    steps:
+      - name: Az CLI login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Delete ARC instances
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.58.0
+          inlineScript: |
+            cluster_type="Microsoft.Kubernetes/connectedClusters"
+            for cluster in $(az resource list -g ${{ env.RESOURCE_GROUP }} --resource-type $cluster_type --query "[?starts_with(name, '${{ env.CLUSTER_PREFIX }}')].id" -o tsv); do
+              az resource delete -v --id $cluster --verbose
+            done


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
