### PR TITLE
test: fix support bundle integration tests to allow no pods

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -143,7 +143,7 @@ def check_workload_resource_files(
         expected_workload_types.remove("pod")
     # pod
     file_pods = {}
-    for file in file_objs["pod"]:
+    for file in file_objs.get("pod", []):
         if file["name"] not in file_pods:
             file_pods[file["name"]] = {"yaml": False}
         converted_file = file_pods[file["name"]]
@@ -180,9 +180,9 @@ def check_workload_resource_files(
     for key in expected_workload_types:
         expected_items = get_kubectl_items(prefixes, service_type=key)
         expected_item_names = [item["metadata"]["name"] for item in expected_items]
-        for file in file_objs[key]:
+        for file in file_objs.get(key, []):
             assert file["extension"] == "yaml"
-        present_names = [file["name"] for file in file_objs[key]]
+        present_names = [file["name"] for file in file_objs.get(key, [])]
         find_extra_or_missing_files(key, present_names, expected_item_names)
 
 


### PR DESCRIPTION
Added in some gets to make sure that if the pod, etc is not present, it won't destroy the rest of the test. The name checks still ensures that if there are no pods, then the support bundle also reports no pods.


![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/d0d47d01-52e0-457d-aff9-7534b12d9076)

Note the lack of billing pods:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/597f1509-0476-4af3-bef2-5bc6de21abfd)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
