### PR TITLE
fix: improve error functionality for asset data-point and event observability mode

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -533,7 +533,7 @@ def load_iotops_help():
         - name: Add an event to an asset with the given pre-filled values.
           text: >
             az iot ops asset event add --asset MyAsset -g MyRG --event-notifier eventId --name eventName
-            --capability-id tagId1 --observability-mode histogram --queue-size 2 --sampling-interval 500
+            --capability-id tagId1 --observability-mode log --queue-size 2 --sampling-interval 500
     """
 
     helps[

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -663,7 +663,7 @@ def load_iotops_arguments(self, _):
             action="append",
             help="Space-separated key=value pairs corresponding to properties of the event to create. "
             "The following key values are supported: `capability_id`, `event_notifier` (required), "
-            "`name`, `observability_mode` (none, gauge, counter, histogram, or log), `sampling_interval` "
+            "`name`, `observability_mode` (none or log), `sampling_interval` "
             "(int), `queue_size` (int). "
             "--event can be used 1 or more times. Review help examples for full parameter usage",
             arg_group="Additional Info",
@@ -759,11 +759,6 @@ def load_iotops_arguments(self, _):
             arg_type=tags_type,
         )
         context.argument(
-            "observability_mode",
-            options_list=["--observability-mode", "--om"],
-            help="Observability mode.",
-        )
-        context.argument(
             "queue_size",
             options_list=["--queue-size", "--qs"],
             help="Custom queue size.",
@@ -798,7 +793,7 @@ def load_iotops_arguments(self, _):
     with self.argument_context("iot ops asset update") as context:
         context.argument(
             "custom_attributes",
-            options_list=["--custom-attribute", "--ca"],
+            options_list=["--custom-attribute", "--attr"],
             help="Space-separated key=value pairs corresponding to additional custom attributes for the asset. "
             "To remove a custom attribute, please set the attribute's value to \"\".",
             nargs="+",
@@ -825,6 +820,11 @@ def load_iotops_arguments(self, _):
             "data_source",
             options_list=["--data-source", "--ds"],
             help="Data source.",
+        )
+        context.argument(
+            "observability_mode",
+            options_list=["--observability-mode", "--om"],
+            help="Observability mode. Must be none, gauge, counter, histogram, or log.",
         )
 
     with self.argument_context("iot ops asset data-point export") as context:
@@ -870,6 +870,11 @@ def load_iotops_arguments(self, _):
             "event_notifier",
             options_list=["--event-notifier", "--en"],
             help="Event notifier.",
+        )
+        context.argument(
+            "observability_mode",
+            options_list=["--observability-mode", "--om"],
+            help="Observability mode. Must be none or log.",
         )
 
     with self.argument_context("iot ops asset event export") as context:

--- a/azext_edge/edge/providers/rpsaas/adr/user_strings.py
+++ b/azext_edge/edge/providers/rpsaas/adr/user_strings.py
@@ -6,6 +6,7 @@
 
 # Asset Strings
 ENDPOINT_NOT_FOUND_WARNING = "Endpoint {0} not found. The asset may fail provisioning."
+INVALID_OBSERVABILITY_MODE_ERROR = "{0} has an invalid observability mode [{1}]."
 MISSING_DATA_EVENT_ERROR = "At least one data point or event is required to create the asset."
 
 

--- a/azext_edge/tests/edge/rpsaas/adr/asset/test_data_points_unit.py
+++ b/azext_edge/tests/edge/rpsaas/adr/asset/test_data_points_unit.py
@@ -17,6 +17,7 @@ from azext_edge.edge.commands_assets import (
 )
 from azext_edge.edge.common import FileType
 from azext_edge.edge.providers.rpsaas.adr.base import ADR_API_VERSION
+from azext_edge.edge.providers.rpsaas.adr.assets import VALID_DATA_OBSERVABILITY_MODES
 
 from .conftest import (
     MINIMUM_ASSET,
@@ -44,7 +45,7 @@ FULL_EVENT = FULL_ASSET["properties"]["dataPoints"][0]
 ], ids=["minimal", "full"], indirect=True)
 @pytest.mark.parametrize("capability_id", [None, generate_random_string()])
 @pytest.mark.parametrize("name", [None, generate_random_string()])
-@pytest.mark.parametrize("observability_mode", [None, generate_random_string()])
+@pytest.mark.parametrize("observability_mode", VALID_DATA_OBSERVABILITY_MODES + [None])
 @pytest.mark.parametrize("queue_size", [None, 20])
 @pytest.mark.parametrize("sampling_interval", [None, 33])
 def test_add_asset_data_point(
@@ -90,7 +91,7 @@ def test_add_asset_data_point(
     added_event = request_data_points[-1]
     assert added_event["capabilityId"] == (capability_id or name)
     assert added_event["name"] == name
-    assert added_event["observabilityMode"] == observability_mode
+    assert added_event["observabilityMode"] == (observability_mode or "none")
 
     assert added_event["dataSource"] == data_source
     assert added_event["dataPointConfiguration"]

--- a/azext_edge/tests/edge/rpsaas/adr/asset/test_events_unit.py
+++ b/azext_edge/tests/edge/rpsaas/adr/asset/test_events_unit.py
@@ -17,6 +17,7 @@ from azext_edge.edge.commands_assets import (
 )
 from azext_edge.edge.common import FileType
 from azext_edge.edge.providers.rpsaas.adr.base import ADR_API_VERSION
+from azext_edge.edge.providers.rpsaas.adr.assets import VALID_EVENT_OBSERVABILITY_MODES
 
 from .conftest import (
     MINIMUM_ASSET,
@@ -44,7 +45,7 @@ FULL_EVENT = FULL_ASSET["properties"]["events"][0]
 ], ids=["minimal", "full"], indirect=True)
 @pytest.mark.parametrize("capability_id", [None, generate_random_string()])
 @pytest.mark.parametrize("name", [None, generate_random_string()])
-@pytest.mark.parametrize("observability_mode", [None, generate_random_string()])
+@pytest.mark.parametrize("observability_mode", VALID_EVENT_OBSERVABILITY_MODES + [None])
 @pytest.mark.parametrize("queue_size", [None, 20])
 @pytest.mark.parametrize("sampling_interval", [None, 33])
 def test_add_asset_event(
@@ -90,7 +91,7 @@ def test_add_asset_event(
     added_event = request_events[-1]
     assert added_event["capabilityId"] == (capability_id or name)
     assert added_event["name"] == name
-    assert added_event["observabilityMode"] == observability_mode
+    assert added_event["observabilityMode"] == (observability_mode or "none")
 
     assert added_event["eventNotifier"] == event_notifier
     assert added_event["eventConfiguration"]

--- a/azext_edge/tests/edge/rpsaas/adr/asset_profile/test_asset_endpoint_lifecycle_int.py
+++ b/azext_edge/tests/edge/rpsaas/adr/asset_profile/test_asset_endpoint_lifecycle_int.py
@@ -21,7 +21,7 @@ def test_asset_endpoint_lifecycle(require_init, tracked_resources):
     anon_name = "test-endpoint-" + generate_random_string(force_lower=True)[:4]
     address = f"tcp://{generate_random_string()}:5000"
     anon_endpoint = run(
-        f"az iot ops asset endpoint create -n {anon_name} -g {rg} -c {cluster_name} "
+        f"az iot ops asset endpoint create -n {anon_name} -g {rg} -c {cluster_name} --crg {rg} "
         f"--ta {address}"
     )
     tracked_resources.append(anon_endpoint["id"])
@@ -59,7 +59,7 @@ def test_asset_endpoint_lifecycle(require_init, tracked_resources):
     password = generate_random_string()
     address = f"tcp://{generate_random_string()}:5000"
     userpass_endpoint = run(
-        f"az iot ops asset endpoint create -n {userpass_name} -g {rg} -c {cluster_name} "
+        f"az iot ops asset endpoint create -n {userpass_name} -g {rg} -c {cluster_name} --crg {rg} "
         f"--ta {address} --username-ref {username} --password-ref {password}"
     )
     tracked_resources.append(userpass_endpoint["id"])

--- a/azext_edge/tests/edge/rpsaas/adr/conftest.py
+++ b/azext_edge/tests/edge/rpsaas/adr/conftest.py
@@ -26,7 +26,7 @@ def require_init(init_setup, tracked_files):
     with open(file_name, "w", encoding="utf-8") as f:
         body = {
             "query": "where type =~ 'Microsoft.ExtendedLocation/customLocations' | where properties.hostResourceId "
-            f"=~ '{cluster_id}' | project name"
+            f"=~ '{cluster_id}' | project name, resourceGroup"
         }
         json.dump(body, f)
     tracked_files.append(file_name)
@@ -36,4 +36,5 @@ def require_init(init_setup, tracked_files):
         f"/resources?api-version=2022-10-01 --body @{file_name}"
     )["data"]
     init_setup["customLocation"] = custom_location_result[0]["name"]
+    init_setup["customLocationResourceGroup"] = custom_location_result[0]["resourceGroup"]
     yield init_setup

--- a/cluster_query.json
+++ b/cluster_query.json
@@ -1,1 +1,0 @@
-{"query": "where type =~ 'Microsoft.ExtendedLocation/customLocations' | where properties.hostResourceId =~ '/subscriptions/a386d5ea-ea90-441a-8263-d816368c84a1/resourceGroups/vilit-clusters/providers/Microsoft.Kubernetes/connectedClusters/space-yodel' | project name, resourceGroup"}

--- a/cluster_query.json
+++ b/cluster_query.json
@@ -1,0 +1,1 @@
+{"query": "where type =~ 'Microsoft.ExtendedLocation/customLocations' | where properties.hostResourceId =~ '/subscriptions/a386d5ea-ea90-441a-8263-d816368c84a1/resourceGroups/vilit-clusters/providers/Microsoft.Kubernetes/connectedClusters/space-yodel' | project name, resourceGroup"}


### PR DESCRIPTION
This does the following:
1. fix the `az iot ops asset update` custom attribute param
2. make the cli check if the asset data point or event has a valid observability mode and set the default to "none" (without having to wait for the service to do so)
4. "fix" up the integration tests to include cluster/custom location resource groups

Too tired to think of a meme so here is a deer:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/d70dc7d2-cd6d-4ac8-ad7b-4f561c5f40e0)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
