### PR TITLE
ci: Add integration test components for csi-config and `iot ops delete` features

### DIFF
--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -109,7 +109,7 @@ runs:
         ca-key-file: ${{ inputs.ca-key-file && format('--ca-key-file "{0}"', inputs.ca-key-file) || '' }}
         kv-spc-secret-name: ${{ inputs.kv-spc-secret-name && format('--kv-spc-secret-name "{0}"', inputs.kv-spc-secret-name) || '' }}
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
-        csi-config: ${{ inputs.csi-config && format('--csi-config "{0}"', inputs.csi-config) || '' }}
+        csi-config: ${{ inputs.csi-config && format('--csi-config {0}', inputs.csi-config) || '' }}
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
           az iot ops init

--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -57,6 +57,8 @@ inputs:
     description: 'Optional Service Principal Object ID to use for cluster operations.'
   sp-secret:
     description: 'Optional Service Principal Secret to use for cluster operations.'
+  csi-config:
+    description: 'Customize configuration of the Key Vault CSI driver with space-separated key=value options.'
   debug:
     description: 'Run `az iot ops init` with debugging output.'
 

--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -109,7 +109,7 @@ runs:
         ca-key-file: ${{ inputs.ca-key-file && format('--ca-key-file "{0}"', inputs.ca-key-file) || '' }}
         kv-spc-secret-name: ${{ inputs.kv-spc-secret-name && format('--kv-spc-secret-name "{0}"', inputs.kv-spc-secret-name) || '' }}
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
-        csi-config: ${{ inputs.csi-config && format('--csi-config "{0}"', inputs.csi-config) || '' }
+        csi-config: ${{ inputs.csi-config && format('--csi-config "{0}"', inputs.csi-config) || '' }}
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
           az iot ops init

--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -109,6 +109,7 @@ runs:
         ca-key-file: ${{ inputs.ca-key-file && format('--ca-key-file "{0}"', inputs.ca-key-file) || '' }}
         kv-spc-secret-name: ${{ inputs.kv-spc-secret-name && format('--kv-spc-secret-name "{0}"', inputs.kv-spc-secret-name) || '' }}
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
+        csi-config: ${{ inputs.csi-config && format('--csi-config "{0}"', inputs.csi-config) || '' }
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
           az iot ops init
@@ -131,6 +132,7 @@ runs:
           ${{ env.ca-key-file }}
           ${{ env.kv-spc-secret-name }}
           ${{ env.template-file }}
+          ${{ env.csi-config }}
           ${{ env.debug }}
           --no-progress
       shell: bash

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -271,7 +271,7 @@ jobs:
           az iot ops asset query -g ${{ env.RESOURCE_GROUP }} --location westus -o table
           az iot ops verify-host
       - name: "Test cluster deletion"
-        if: ${{matrix.feature == 'no-syncrules'}}
+        if: ${{matrix.feature == 'ca-certs'}}
         run: |
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
 

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -270,6 +270,10 @@ jobs:
           az iot ops mq get-password-hash -p test
           az iot ops asset query -g ${{ env.RESOURCE_GROUP }} --location westus -o table
           az iot ops verify-host
+      - name: "Test cluster deletion"
+        if: ${{matrix.feature == 'no-syncrules'}}
+        run: |
+          az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
 
   # Optional cleanup job
   cleanup:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -87,7 +87,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [default, mq-insecure, no-syncrules, ca-certs]
+        # feature: [default, mq-insecure, no-syncrules, ca-certs]
+        feature: [mq-insecure]
         include:
           # default / limited options
           - feature: default

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -274,6 +274,25 @@ jobs:
         if: ${{matrix.feature == 'ca-certs'}}
         run: |
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
+      - name: "Test cluster redeployment"
+        if: ${{matrix.feature == 'ca-certs'}}
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        with:
+          cluster: ${{ env.CLUSTER_NAME }}
+          resource-group: ${{ env.RESOURCE_GROUP }}
+          keyvault-id: ${{ env.KV_ID }}
+          sp-app-id: ${{ secrets.AIO_SP_APP_ID || '' }}
+          sp-object-id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
+          sp-secret: ${{ secrets.AIO_SP_SECRET || '' }}
+          no-preflight: ${{ matrix.no-preflight }}
+          mq-insecure: ${{ matrix.mq-insecure }}
+          disable-rsync-rules: ${{ matrix.disable-rsync-rules }}
+          ca-valid-days: ${{ matrix.ca-valid-days || '' }}
+          ca-file: ${{ matrix.ca-file || '' }}
+          ca-key-file: ${{ matrix.ca-key-file || '' }}
+          kv-spc-secret-name: ${{ matrix.kv-spc-secret-name || '' }}
+          template-file: ${{ inputs.template-content && 'custom-template.json' || '' }}
+          csi-config: ${{ matrix.csi-config || ''}}
 
   # Optional cleanup job
   cleanup:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -197,7 +197,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -197,7 +197,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -276,7 +276,7 @@ jobs:
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
       - name: "Test cluster redeployment"
         if: ${{matrix.feature == 'ca-certs'}}
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -197,7 +197,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -197,7 +197,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -276,7 +276,7 @@ jobs:
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
       - name: "Test cluster redeployment"
         if: ${{matrix.feature == 'ca-certs'}}
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@test_updates
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -87,8 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # feature: [default, mq-insecure, no-syncrules, ca-certs]
-        feature: [mq-insecure]
+        feature: [default, mq-insecure, no-syncrules, ca-certs]
         include:
           # default / limited options
           - feature: default

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -97,6 +97,7 @@ jobs:
           - feature: mq-insecure
             mq-insecure: true
             no-preflight: true
+            csi-config: 'telegraf.resources.limits.memory=500Mi telegraf.resources.limits.cpu=100m'
           # test disabling custom sync rules
           - feature: no-syncrules
             disable-rsync-rules: true
@@ -212,6 +213,7 @@ jobs:
           ca-key-file: ${{ matrix.ca-key-file || '' }}
           kv-spc-secret-name: ${{ matrix.kv-spc-secret-name || '' }}
           template-file: ${{ inputs.template-content && 'custom-template.json' || '' }}
+          csi-config: ${{ matrix.csi-config || ''}}
       - name: "Allow cluster to finish provisioning"
         run: |
           sleep 2m


### PR DESCRIPTION
Adds (and tests) the `csi-config` init arg as an input to the deploy-aio action.
Also adds `iot ops delete` inside our integration tests to one of our cluster scenarios.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
