### PR TITLE
test: Update dockerfile to only run int tests, fix junit filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install tox
 
 # run tests
-ENTRYPOINT ["tox", "r", "-vv", "-e", "python,python-int", "--", "--durations=0"]
+ENTRYPOINT ["tox", "r", "-vv", "-e", "python-int", "--", "--durations=0"]

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands =
     # validate az and extension version
     az -v
     # run integration tests
-    pytest -k "_int.py" ./azext_edge/tests --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/test-aziotops-ext-int.xml {posargs}
+    pytest -k "_int.py" ./azext_edge/tests --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/JUnit.xml {posargs}
     # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
 
 # code coverage - HTML and JSON


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
