### PR TITLE
test(support bundles): make data processor and pod metrics optional

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -137,7 +137,8 @@ def check_custom_resource_files(
 def check_workload_resource_files(
     file_objs: Dict[str, List[Dict[str, str]]],
     expected_workload_types: List[str],
-    prefixes: Union[str, List[str]]
+    prefixes: Union[str, List[str]],
+    optional_workload_types: Optional[List[str]] = None,
 ):
     if "pod" in expected_workload_types:
         expected_workload_types.remove("pod")
@@ -176,14 +177,23 @@ def check_workload_resource_files(
         for extension, value in files.items():
             assert value, f"Pod {name} is missing {extension}."
 
+    def _check_non_pod_files(workload_types: List[str], required: bool = False):
+        for key in workload_types:
+            try:
+                expected_items = get_kubectl_items(prefixes, service_type=key)
+                expected_item_names = [item["metadata"]["name"] for item in expected_items]
+                for file in file_objs.get(key, []):
+                    assert file["extension"] == "yaml"
+                present_names = [file["name"] for file in file_objs.get(key, [])]
+                find_extra_or_missing_files(key, present_names, expected_item_names)
+            except CLIInternalError as e:
+                if required:
+                    raise e
+
     # other
-    for key in expected_workload_types:
-        expected_items = get_kubectl_items(prefixes, service_type=key)
-        expected_item_names = [item["metadata"]["name"] for item in expected_items]
-        for file in file_objs.get(key, []):
-            assert file["extension"] == "yaml"
-        present_names = [file["name"] for file in file_objs.get(key, [])]
-        find_extra_or_missing_files(key, present_names, expected_item_names)
+    _check_non_pod_files(expected_workload_types)
+    if optional_workload_types:
+        _check_non_pod_files(optional_workload_types, required=False)
 
 
 def find_extra_or_missing_files(

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+from azext_edge.edge.providers.edge_api.dataprocessor import DATA_PROCESSOR_API_V1
 import pytest
 from os import mkdir, path
 from knack.log import get_logger
@@ -32,6 +33,9 @@ def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
 @pytest.mark.parametrize("ops_service, mq_traces, bundle_dir", generate_bundle_test_cases())
 def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_files):
     """Test to focus on ops_service param."""
+
+    if ops_service == OpsServiceType.dataprocessor.value and not DATA_PROCESSOR_API_V1.is_deployed():
+        pytest.skip("Data processor is not deployed on this cluster.")
 
     command = f"az iot ops support create-bundle --mq-traces {mq_traces} " + "--ops-service {0}"
     if bundle_dir:
@@ -112,6 +116,8 @@ def _get_expected_services(
         expected_services.remove(OpsServiceType.auto.value)
         expected_services.remove(OpsServiceType.billing.value)
         expected_services.append("otel")
+        if not DATA_PROCESSOR_API_V1.is_deployed():
+            expected_services.remove(OpsServiceType.dataprocessor.value)
         if walk_result.get(path.join(BASE_ZIP_PATH, namespace, "clusterconfig", "billing")):
             expected_services.append("clusterconfig")
         # device registry folder will not be created if there are no device registry resources

--- a/azext_edge/tests/edge/support/create_bundle_int/test_dataprocessor_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_dataprocessor_int.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.edge_api import DATA_PROCESSOR_API_V1
@@ -14,6 +15,8 @@ logger = get_logger(__name__)
 
 def test_create_bundle_dataprocessor(init_setup, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS dataprocessor."""
+    if not DATA_PROCESSOR_API_V1.is_deployed():
+        pytest.skip("Data processor is not deployed on this cluster.")
     ops_service = OpsServiceType.dataprocessor.value
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result = run_bundle_command(command=command, tracked_files=tracked_files)

--- a/azext_edge/tests/edge/support/create_bundle_int/test_opcua_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_opcua_int.py
@@ -24,7 +24,13 @@ def test_create_bundle_opcua(init_setup, tracked_files):
         resource_api=OPCUA_API_V1
     )
 
-    expected_workload_types = ["daemonset", "deployment", "pod", "podmetric", "replicaset", "service"]
-    expected_types = set(expected_workload_types).union(OPCUA_API_V1.kinds)
+    expected_workload_types = ["daemonset", "deployment", "pod", "replicaset", "service"]
+    optional_workload_types = ["podmetric"]
+    expected_types = set(expected_workload_types + optional_workload_types).union(OPCUA_API_V1.kinds)
     assert set(file_map.keys()).issubset(expected_types)
-    check_workload_resource_files(file_map, expected_workload_types, ["aio-opc", "opcplc"])
+    check_workload_resource_files(
+        file_objs=file_map,
+        expected_workload_types=expected_workload_types,
+        prefixes=["aio-opc", "opcplc"],
+        optional_workload_types=optional_workload_types
+    )


### PR DESCRIPTION
Fixes:
1. DP is now optional (will skip test/remove the key)
2. pod metrics is now optional

![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/7e530c2b-cf3e-454d-bbd6-131878621cb0)

idk how I got this into the azure fork but will be more careful

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
