### PR TITLE
test: Add dataprocessor optional switch to int tests and deployment action

### DIFF
--- a/.github/actions/deploy-aio/action.yml
+++ b/.github/actions/deploy-aio/action.yml
@@ -59,6 +59,8 @@ inputs:
     description: 'Optional Service Principal Secret to use for cluster operations.'
   csi-config:
     description: 'Customize configuration of the Key Vault CSI driver with space-separated key=value options.'
+  include-dp:
+    description: 'Include Data Processor in the IoT Operations deployment.'
   debug:
     description: 'Run `az iot ops init` with debugging output.'
 
@@ -112,6 +114,7 @@ runs:
         kv-spc-secret-name: ${{ inputs.kv-spc-secret-name && format('--kv-spc-secret-name "{0}"', inputs.kv-spc-secret-name) || '' }}
         template-file: ${{ inputs.template-file && format('--template-file "{0}"', inputs.template-file) || '' }}
         csi-config: ${{ inputs.csi-config && format('--csi-config {0}', inputs.csi-config) || '' }}
+        include-dp: ${{ inputs.include-dp == 'true' && '--include-dp' || '' }}
         debug: ${{ inputs.debug == 'true' && '--debug' || '' }}
       run: >-
           az iot ops init
@@ -135,6 +138,7 @@ runs:
           ${{ env.kv-spc-secret-name }}
           ${{ env.template-file }}
           ${{ env.csi-config }}
+          ${{ env.include-dp }}
           ${{ env.debug }}
           --no-progress
       shell: bash

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -115,6 +115,7 @@ jobs:
           - feature: ca-certs
             ca-file: 'test-ca.pem'
             ca-key-file: 'test-ca-key.pem'
+            include-dp: true
     name: "Run cluster tests"
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -208,7 +208,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@int_test_dataproc_opt
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -225,6 +225,7 @@ jobs:
           kv-spc-secret-name: ${{ matrix.kv-spc-secret-name || '' }}
           template-file: ${{ inputs.template-content && 'custom-template.json' || '' }}
           csi-config: ${{ matrix.csi-config || ''}}
+          include-dp: ${{ matrix.include-dp }}
       - name: "Allow cluster to finish provisioning"
         run: |
           sleep 2m
@@ -317,7 +318,7 @@ jobs:
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
       - name: "Test cluster redeployment"
         if: ${{matrix.feature == 'ca-certs'}}
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
+        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@int_test_dataproc_opt
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -334,6 +335,7 @@ jobs:
           kv-spc-secret-name: ${{ matrix.kv-spc-secret-name || '' }}
           template-file: ${{ inputs.template-content && 'custom-template.json' || '' }}
           csi-config: ${{ matrix.csi-config || ''}}
+          include-dp: ${{ matrix.include-dp }}
 
   # Optional cleanup job
   cleanup:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -208,7 +208,7 @@ jobs:
           ${{ env.template }}
           EOF
       - name: "AIO Deployment"
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@int_test_dataproc_opt
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
@@ -318,7 +318,7 @@ jobs:
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
       - name: "Test cluster redeployment"
         if: ${{matrix.feature == 'ca-certs'}}
-        uses: c-ryan-k/azure-iot-ops-cli-extension/.github/actions/deploy-aio@int_test_dataproc_opt
+        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}


### PR DESCRIPTION
Adds `--include-dp` switch to AIO deployment action and integration test scenario.

Test run here: https://github.com/c-ryan-k/azure-iot-ops-cli-extension/actions/runs/9387570312

Specifically, [here](https://github.com/c-ryan-k/azure-iot-ops-cli-extension/actions/runs/9387570312/job/25850848018#step:16:73)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
