### PR TITLE
fix: IT add null check for run("kubectl get lnm -A") in support bundle

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -75,11 +75,9 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
 
     # Level 2 and 3 - bottom
     actual_walk_result = (len(expected_services) + int("clusterconfig" in expected_services))
-    lnm_instances = run("kubectl get lnm -A")
+    lnm_instances = run("kubectl get lnm -A") or []
 
-    if (ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value]
-       and lnm_instances
-       and namespace in lnm_instances):
+    if ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value] and namespace in lnm_instances:
         # when a lnm instance is deployed, more lnm resources will be under namespace kube-system
         actual_walk_result += 1
     assert len(walk_result) == actual_walk_result

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -77,7 +77,9 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
     actual_walk_result = (len(expected_services) + int("clusterconfig" in expected_services))
     lnm_instances = run("kubectl get lnm -A")
 
-    if ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value] and lnm_instances and namespace in run("kubectl get lnm -A"):
+    if (ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value]
+       and lnm_instances
+       and namespace in lnm_instances):
         # when a lnm instance is deployed, more lnm resources will be under namespace kube-system
         actual_walk_result += 1
     assert len(walk_result) == actual_walk_result

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -75,7 +75,9 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
 
     # Level 2 and 3 - bottom
     actual_walk_result = (len(expected_services) + int("clusterconfig" in expected_services))
-    if ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value] and namespace in run("kubectl get lnm -A"):
+    lnm_instances = run("kubectl get lnm -A")
+
+    if ops_service in [OpsServiceType.auto.value, OpsServiceType.lnm.value] and lnm_instances and namespace in run("kubectl get lnm -A"):
         # when a lnm instance is deployed, more lnm resources will be under namespace kube-system
         actual_walk_result += 1
     assert len(walk_result) == actual_walk_result

--- a/azext_edge/tests/edge/support/create_bundle_int/test_lnm_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_lnm_int.py
@@ -19,8 +19,8 @@ def test_create_bundle_lnm(init_setup, tracked_files):
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)
-    lnm_instances = run("kubectl get lnm -A")
-    lnm_present = lnm_instances and file_map["__namespaces__"]["aio"] in lnm_instances
+    lnm_instances = run("kubectl get lnm -A") or []
+    lnm_present = file_map["__namespaces__"]["aio"] in lnm_instances
 
     # TODO: when adding scenarios - make sure one scenario is adding in an lnm instance
     # Note that this is structured by namespace folder instead of by if

--- a/azext_edge/tests/edge/support/create_bundle_int/test_lnm_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_lnm_int.py
@@ -19,7 +19,8 @@ def test_create_bundle_lnm(init_setup, tracked_files):
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)
-    lnm_present = file_map["__namespaces__"]["aio"] in run("kubectl get lnm -A")
+    lnm_instances = run("kubectl get lnm -A")
+    lnm_present = lnm_instances and file_map["__namespaces__"]["aio"] in lnm_instances
 
     # TODO: when adding scenarios - make sure one scenario is adding in an lnm instance
     # Note that this is structured by namespace folder instead of by if


### PR DESCRIPTION
test failed when there is no lnm instance and try to find resource against running "kubectl get lnm -A"
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/eec1c83f-bae2-4ee8-846a-32c31cab9e19)
therefore adding null check before find resource in kubectl output

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
