### PR TITLE
fix: error when expected CRD is not deployed instead of skip

### DIFF
--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -49,10 +49,9 @@ def enumerate_ops_service_resources(
     )
 
     if not api_resources:
-        check_manager.add_target_eval(target_name=target_api, status=CheckTaskStatus.skipped.value)
+        check_manager.add_target_eval(target_name=target_api, status=CheckTaskStatus.error.value)
         missing_api_text = (
             f"[bright_blue]{target_api}[/bright_blue] API resources [red]not[/red] detected."
-            "\n\n[bright_white]Skipping deployment evaluation[/bright_white]."
         )
         check_manager.add_display(target_name=target_api, display=Padding(missing_api_text, (0, 0, 0, 8)))
         return check_manager.as_dict(as_list), resource_kind_map

--- a/azext_edge/edge/providers/checks.py
+++ b/azext_edge/edge/providers/checks.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 from ..common import ListableEnum, OpsServiceType
 from .check.base import check_pre_deployment, display_as_list
-from .check.common import ResourceOutputDetailLevel
+from .check.common import COLOR_STR_FORMAT, ResourceOutputDetailLevel
 from .check.dataprocessor import check_dataprocessor_deployment
 from .check.deviceregistry import check_deviceregistry_deployment
 from .check.lnm import check_lnm_deployment
@@ -48,7 +48,7 @@ def run_checks(
 
         sleep(0.5)
 
-        color = "[bright_blue]{text}[/bright_blue]" if as_list else "{text}"
+        color = COLOR_STR_FORMAT.format(color="bright_blue", value="{text}") if as_list else "{text}"
         title_subject = (
             f"{{{color.format(text=ops_service)}}} service deployment"
             if post_deployment

--- a/azext_edge/edge/providers/checks.py
+++ b/azext_edge/edge/providers/checks.py
@@ -48,10 +48,11 @@ def run_checks(
 
         sleep(0.5)
 
+        color = "[bright_blue]{text}[/bright_blue]" if as_list else "{text}"
         title_subject = (
-            f"{{[bright_blue]{ops_service}[/bright_blue]}} service deployment"
+            f"{{{color.format(text=ops_service)}}} service deployment"
             if post_deployment
-            else "[bright_blue]IoT Operations readiness[/bright_blue]"
+            else color.format(text="IoT Operations readiness")
         )
         result["title"] = f"Evaluation for {title_subject}"
 

--- a/azext_edge/tests/edge/checks/int/test_pre_post_int.py
+++ b/azext_edge/tests/edge/checks/int/test_pre_post_int.py
@@ -23,8 +23,8 @@ def test_check_pre_post(init_setup, post, pre):
     result = run(command)
 
     # default service title
-    expected_title = "Evaluation for {[bright_blue]mq[/bright_blue]} service deployment"
-    expected_precheck_title = "[bright_blue]IoT Operations readiness[/bright_blue]"
+    expected_title = "Evaluation for {mq} service deployment"
+    expected_precheck_title = "IoT Operations readiness"
     expected_pre = not post if pre is None else pre
     expected_post = not pre if post is None else post
     assert result["title"] == expected_title if expected_post else expected_precheck_title


### PR DESCRIPTION
error when expected CRD is not deployed instead of skip
fix color code showing in --as-object title

before fix:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/f1702bbf-9ccb-4e7a-8508-a7b5b7b89ae4)

after fix:
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/22055990/efd7083c-c3fb-42df-8730-c4b64f5cd69a)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
