### PR TITLE
test: add integration testing for `az iot ops init`

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -15,10 +15,6 @@ on:
         description: Additional init arguments (beyond cluster name, resource group, key vault, and service principal arguments).
         type: string
         required: false
-      removemekeyvault:
-        description: Keyvault.
-        type: string
-        required: false
       custom-locations-oid:
         description: Custom Locations OID
         type: string
@@ -171,7 +167,6 @@ jobs:
           resource-group: ${{ env.RESOURCE_GROUP }}
           custom-locations-oid: ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "Get Keyvault ID"
-        if: ${{ !inputs.removemekeyvault }}
         run: |
           KV_ID=$(az keyvault show -n ${{env.KV_NAME}} -g ${{ env.RESOURCE_GROUP }} -o tsv --query id)
           echo "KV_ID=$KV_ID" >> $GITHUB_ENV
@@ -205,11 +200,18 @@ jobs:
           >custom-template.json cat <<-'EOF'
           ${{ env.template }}
           EOF
+      - name: "Tox test environment setup"
+        if: ${{!inputs.use-container && matrix.feature == 'default'}}
+        run: |
+          cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
+          python -m pip install tox
+          tox r -vv -e python-int --notest
+          tox r -vv -e python-init-int --notest
       - name: "Tox INIT Integration Tests"
         env:
           azext_edge_rg: ${{ steps.env_out.outputs.RESOURCE_GROUP }}
           azext_edge_cluster: ${{ steps.env_out.outputs.CLUSTER_NAME }}
-          azext_edge_kv: ${{ inputs.removemekeyvault || steps.env_out.KV_ID }}
+          azext_edge_kv: ${{ steps.env_out.KV_ID }}
           azext_edge_init_args: ${{ matrix.init-args }}
           azext_edge_sp_app_id: ${{ secrets.AIO_SP_APP_ID || '' }}
           azext_edge_sp_object_id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
@@ -217,12 +219,6 @@ jobs:
         run: |
           cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
           tox r -e python-init-int --skip-pkg-install -- --durations=0
-      - name: "Tox test environment setup"
-        if: ${{!inputs.use-container && matrix.feature == 'default'}}
-        run: |
-          cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
-          python -m pip install tox
-          tox r -vv -e python-int --notest
       - name: "Az CLI login refresh"
         if: ${{matrix.feature == 'default'}}
         uses: azure/login@v2
@@ -310,7 +306,7 @@ jobs:
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
-          keyvault-id: ${{ inputs.removemekeyvault || env.KV_ID }}
+          keyvault-id: ${{ env.KV_ID }}
           sp-app-id: ${{ secrets.AIO_SP_APP_ID || '' }}
           sp-object-id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
           sp-secret: ${{ secrets.AIO_SP_SECRET || '' }}
@@ -332,3 +328,15 @@ jobs:
         if: ${{ always() }}
         run: |
           az connectedk8s delete --name ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
+
+  delete_kv:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: "Az CLI login"
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: "Delete Key Vault for clusters"
+      run: az keyvault delete -n ${{ env.KV_NAME }} -g ${{ env.RESOURCE_GROUP }} --no-wait

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -11,6 +11,14 @@ on:
         description: Custom AIO deployment template file contents, used for all deployments in this workflow.
         type: string
         required: false
+      runtime-init-args:
+        description: Additional init arguments (beyond cluster name, resource group, key vault, and service principal arguments).
+        type: string
+        required: false
+      removemekeyvault:
+        description: Keyvault.
+        type: string
+        required: false
       custom-locations-oid:
         description: Custom Locations OID
         type: string
@@ -91,21 +99,19 @@ jobs:
         include:
           # default / limited options
           - feature: default
-            ca-valid-days: 3
-            kv-spc-secret-name: test-kv-secret
+            init-args: "--ca-valid-days 3 --kv-spc-secret-name test-kv-secret ${{ inputs.runtime-init-args || '' }}"
           # test --mq-insecure deployment
           - feature: mq-insecure
-            mq-insecure: true
-            no-preflight: true
-            csi-config: 'telegraf.resources.limits.memory=500Mi telegraf.resources.limits.cpu=100m'
+            init-args: "--mq-insecure --no-preflight --csi-config 'telegraf.resources.limits.memory=500Mi telegraf.resources.limits.cpu=100m' ${{ inputs.runtime-init-args || '' }}"
           # test disabling custom sync rules
           - feature: no-syncrules
-            disable-rsync-rules: true
+            init-args: "--disable-rsync-rules  ${{ inputs.runtime-init-args || '' }}"
           # test custom ca files
           - feature: ca-certs
-            ca-file: 'test-ca.pem'
-            ca-key-file: 'test-ca-key.pem'
-            include-dp: true
+            init-args: "--ca-file test-ca.pem --ca-key-file test-ca-key.pem --include-dp ${{ inputs.runtime-init-args || '' }}"
+          # test custom template
+          - feature: use-custom-template
+            init-args: "${{ inputs.template-content && '--template custom-template.json' || '' }}"
     name: "Run cluster tests"
     runs-on: ubuntu-22.04
     steps:
@@ -165,11 +171,13 @@ jobs:
           resource-group: ${{ env.RESOURCE_GROUP }}
           custom-locations-oid: ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "Get Keyvault ID"
+        if: ${{ !inputs.removemekeyvault }}
         run: |
           KV_ID=$(az keyvault show -n ${{env.KV_NAME}} -g ${{ env.RESOURCE_GROUP }} -o tsv --query id)
           echo "KV_ID=$KV_ID" >> $GITHUB_ENV
+          echo "KV_ID=$KV_ID" >> $GITHUB_OUTPUT
       - name: "Create CA certificates"
-        if: ${{matrix.feature == 'ca-certs'}}
+        if: ${{ matrix.feature == 'ca-certs'}}
         run: |
           >ca.conf cat <<-EOF
           [ req ]
@@ -190,37 +198,27 @@ jobs:
           openssl req -new -x509 -key ${{ matrix.ca-key-file }} -days 30 -config ca.conf -out ${{ matrix.ca-file }}
           rm ca.conf
       - name: "Create local template file"
-        if: ${{ inputs.template-content }}
+        if: ${{ inputs.template-content && matrix.feature == 'use-custom-template' }}
         env:
           template: "${{ inputs.template-content }}"
         run: |
           >custom-template.json cat <<-'EOF'
           ${{ env.template }}
           EOF
-      - name: "AIO Deployment"
-        uses: azure/azure-iot-ops-cli-extension/.github/actions/deploy-aio@dev
-        with:
-          cluster: ${{ env.CLUSTER_NAME }}
-          resource-group: ${{ env.RESOURCE_GROUP }}
-          keyvault-id: ${{ env.KV_ID }}
-          sp-app-id: ${{ secrets.AIO_SP_APP_ID || '' }}
-          sp-object-id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
-          sp-secret: ${{ secrets.AIO_SP_SECRET || '' }}
-          no-preflight: ${{ matrix.no-preflight }}
-          mq-insecure: ${{ matrix.mq-insecure }}
-          disable-rsync-rules: ${{ matrix.disable-rsync-rules }}
-          ca-valid-days: ${{ matrix.ca-valid-days || '' }}
-          ca-file: ${{ matrix.ca-file || '' }}
-          ca-key-file: ${{ matrix.ca-key-file || '' }}
-          kv-spc-secret-name: ${{ matrix.kv-spc-secret-name || '' }}
-          template-file: ${{ inputs.template-content && 'custom-template.json' || '' }}
-          csi-config: ${{ matrix.csi-config || ''}}
-          include-dp: ${{ matrix.include-dp }}
-      - name: "Allow cluster to finish provisioning"
+      - name: "Tox INIT Integration Tests"
+        env:
+          azext_edge_rg: ${{ steps.env_out.outputs.RESOURCE_GROUP }}
+          azext_edge_cluster: ${{ steps.env_out.outputs.CLUSTER_NAME }}
+          azext_edge_kv: ${{ inputs.removemekeyvault || steps.env_out.KV_ID }}
+          azext_edge_init_args: ${{ matrix.init-args }}
+          azext_edge_sp_app_id: ${{ secrets.AIO_SP_APP_ID || '' }}
+          azext_edge_sp_object_id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
+          azext_edge_sp_secret: ${{ secrets.AIO_SP_SECRET || '' }}
         run: |
-          sleep 2m
+          cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
+          tox r -e python-init-int --skip-pkg-install -- --durations=0
       - name: "Tox test environment setup"
-        if: ${{matrix.feature == 'default' && !inputs.use-container}}
+        if: ${{!inputs.use-container && matrix.feature == 'default'}}
         run: |
           cd ${{ env.EXTENSION_SOURCE_DIRECTORY }}
           python -m pip install tox
@@ -312,7 +310,7 @@ jobs:
         with:
           cluster: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.RESOURCE_GROUP }}
-          keyvault-id: ${{ env.KV_ID }}
+          keyvault-id: ${{ inputs.removemekeyvault || env.KV_ID }}
           sp-app-id: ${{ secrets.AIO_SP_APP_ID || '' }}
           sp-object-id: ${{ secrets.AIO_SP_OBJECT_ID || '' }}
           sp-secret: ${{ secrets.AIO_SP_SECRET || '' }}
@@ -327,8 +325,10 @@ jobs:
           csi-config: ${{ matrix.csi-config || ''}}
           include-dp: ${{ matrix.include-dp }}
       - name: "Delete AIO resources"
+        if: ${{ always() }}
         run: |
           az iot ops delete --cluster ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y
       - name: "Delete connected cluster"
+        if: ${{ always() }}
         run: |
           az connectedk8s delete --name ${{ env.CLUSTER_NAME }} -g ${{ env.RESOURCE_GROUP }} -y

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -48,7 +48,6 @@ def build_bundle(
     from rich.progress import Progress
     from rich.table import Table
 
-    from .support.billing import prepare_bundle as prepare_billing_bundle
     from .support.dataprocessor import prepare_bundle as prepare_dataprocessor_bundle
     from .support.mq import prepare_bundle as prepare_mq_bundle
     from .support.lnm import prepare_bundle as prepare_lnm_bundle
@@ -63,7 +62,8 @@ def build_bundle(
     pending_work.pop(OpsServiceType.auto.value)
 
     api_map = {
-        OpsServiceType.billing.value: {"apis": COMPAT_CLUSTER_CONFIG_APIS, "prepare_bundle": prepare_billing_bundle},
+        # TODO: re-enable billing once service is available post 0.6.0 release
+        # OpsServiceType.billing.value: {"apis": COMPAT_CLUSTER_CONFIG_APIS, "prepare_bundle": prepare_billing_bundle},
         OpsServiceType.mq.value: {"apis": COMPAT_MQ_APIS, "prepare_bundle": prepare_mq_bundle},
         OpsServiceType.opcua.value: {
             "apis": COMPAT_OPCUA_APIS,

--- a/azext_edge/tests/edge/conftest.py
+++ b/azext_edge/tests/edge/conftest.py
@@ -147,27 +147,9 @@ def tracked_resources():
 
 
 @pytest.fixture(scope="session")
-def tracked_keyvault(request, tracked_resources, settings):
-    # TODO: clean up env variables later
-    from ..settings import convert_flag, EnvironmentVariables
-    settings.add_to_config(EnvironmentVariables.rg.value)
-    settings.add_to_config(EnvironmentVariables.kv.value)
-    settings.add_to_config(EnvironmentVariables.skip_init.value, conversion=convert_flag)
-    if settings.env.azext_edge_skip_init:
-        # kv only needed for init for now
-        kv = None
-    elif settings.env.azext_edge_kv:
-        kv = run(f"az keyvault show -n {settings.env.azext_edge_kv} -g {settings.env.azext_edge_rg}")
-    else:
-        run_id = id(request.session)
-        kv_name = f"opstestkv-{run_id}"
-        kv = run(f"az keyvault create -n {kv_name} -g {settings.env.azext_edge_rg}")
-        tracked_resources.append(kv["id"])
-    yield kv
-
-
-@pytest.fixture(scope="session")
-def cluster_setup(settings):
+def cluster_connection(settings):
+    """Fixture to ensure that the cluster is connected."""
+    from urllib3.exceptions import MaxRetryError
     from kubernetes.client.rest import ApiException
     from ..settings import EnvironmentVariables
     settings.add_to_config(EnvironmentVariables.context_name.value)
@@ -184,17 +166,15 @@ def cluster_setup(settings):
         # Check for cluster access
         client.VersionApi().get_code()
         yield
+    except MaxRetryError:
+        raise CLIInternalError("Cluster is not connected.")
     except ApiException:
         raise NotImplementedError("Local cluster creation for testing not fully implemented yet.")
-        # import os
-        # os.environ["K3D_FIX_MOUNTS"] = "1"
-        # run("kubectl cluster create -i ghcr.io/jlian/k3d-nfs:v1.25.3-k3s1")
-        # yield
-        # run("kubectl cluster delete")
 
 
+# TODO: change the check/support bundle tests to point to cluster connection instead
 @pytest.fixture(scope="session")
-def init_setup(request, cluster_setup, settings):
+def init_setup(request, cluster_connection, settings):
     from ..settings import EnvironmentVariables
     settings.add_to_config(EnvironmentVariables.rg.value)
     settings.add_to_config(EnvironmentVariables.cluster.value)
@@ -202,62 +182,6 @@ def init_setup(request, cluster_setup, settings):
     run("az iot ops verify-host")
     yield {
         "clusterName": settings.env.azext_edge_cluster,
-        "resourceGroup": settings.env.azext_edge_rg
+        "resourceGroup": settings.env.azext_edge_rg,
     }
     return
-
-    # cluster_resources = []
-    # scenario = {}
-    # if request and hasattr(request, "param"):
-    #     scenario = request.param
-
-    # run_id = id(request.session)
-    # cluster_name = settings.env.azext_edge_cluster or f"az-iot-ops-test-cluster-{run_id}"
-    # try:
-    #     run(f"az connectedk8s connect --name {cluster_name} -g {settings.env.azext_edge_rg}")
-    #     custom_locations_guid = run("az ad sp show --id bc313c14-388c-4e7d-a58e-70017303ee3b --query id -o tsv")
-    #     run(
-    #         f"az connectedk8s enable-features --name {cluster_name} -g {settings.env.azext_edge_rg}"
-    #         f" --features custom-locations cluster-connect --custom-locations-oid {custom_locations_guid}"
-    #     )
-    # except CLIInternalError as e:
-    #     logger.warning(e.error_msg)
-    # result = run(f"az connectedk8s show --name {cluster_name} -g {settings.env.azext_edge_rg}")
-    # resource_id_prefix = result["id"].split("Microsoft.Kubernetes")[0]
-    # tracked_resources.append(result["id"])
-    # cluster_resources.append(result["id"])
-
-    # command = f"az iot ops init --cluster {cluster_name} -g {settings.env.azext_edge_rg} "\
-    #     f"--kv-id {tracked_keyvault['id']} --no-progress --no-preflight"
-    # for arg in scenario:
-    #     command += f" {arg} {scenario[arg]}"
-    # result = run(command)
-    # # reverse the list so things can be deleted in the right order
-    # converted_resources = []
-    # for res in result["deploymentState"]["resources"][::-1]:
-    #     if not res.startswith("Microsoft.Kubernetes"):
-    #         converted_resources.append(resource_id_prefix + res)
-    # tracked_resources.extend(converted_resources)
-    # cluster_resources.extend(converted_resources)
-    # assert result["clusterName"] == cluster_name
-    # assert result["clusterNamespace"] == scenario.get("--cluster-namespace", "azure-iot-operations")
-    # assert result["deploymentLink"]
-    # assert result["deploymentName"]
-
-    # dstate = result["deploymentState"]
-    # assert dstate["correlationId"]
-    # assert dstate["opsVersion"]
-
-    # assert result["tls"]["aioTrustConfigMap"] == "aio-ca-trust-bundle-test-only"
-    # assert result["tls"]["aioTrustSecretName"] == "aio-ca-key-pair-test-only"
-
-    # # just incase
-    # run("az iot ops verify-host -y")
-    # yield result
-
-    # for res in cluster_resources:
-    #     try:
-    #         run(f"az resource delete --id {res} -v")
-    #         tracked_resources.remove(res)
-    #     except CLIInternalError:
-    #         logger.warning(f"failed to delete {res}")

--- a/azext_edge/tests/edge/init/int/__init__.py
+++ b/azext_edge/tests/edge/init/int/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------

--- a/azext_edge/tests/edge/init/int/dataprocessor_helper.py
+++ b/azext_edge/tests/edge/init/int/dataprocessor_helper.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import List, Optional
+from .helper import get_resource_from_partial_id, ResourceKeys
+
+
+def assert_dataprocessor_args(
+    resource_group: str,
+    cluster_name: str,
+    init_resources: List[str],
+    include_dp: Optional[bool] = None,
+    dp_instance: Optional[str] = None,
+    **_
+):
+    include_dp = include_dp or False
+    resources = [res for res in init_resources if res.startswith(ResourceKeys.dataprocessor.value)]
+    assert bool(resources) is include_dp
+    if not include_dp:
+        return
+    
+    expected_name = dp_instance or (f"{cluster_name}-ops-init-processor")
+    assert len(resources) == 1
+    assert resources[0].endswith(expected_name)
+    # nothing interesting here.
+    get_resource_from_partial_id(resources[0], resource_group)

--- a/azext_edge/tests/edge/init/int/helper.py
+++ b/azext_edge/tests/edge/init/int/helper.py
@@ -1,0 +1,127 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+from azext_edge.edge.providers.orchestration.common import KEYVAULT_ARC_EXTENSION_VERSION
+from ....helpers import run
+
+
+class ResourceKeys(Enum):
+    custom_location = "Microsoft.ExtendedLocation/customLocations"
+    dataprocessor = "Microsoft.IoTOperationsDataProcessor"
+    mq = "Microsoft.IoTOperationsMQ/mq"
+    orchestrator = "Microsoft.IoTOperationsOrchestrator/targets"
+    connected_cluster = "Microsoft.Kubernetes/connectedClusters"
+
+
+def assert_init_result(
+    result: Dict[str, Any], 
+    cluster_name: str,
+    key_vault: str,
+    resource_group: str,
+    arg_dict: Dict[str, Union[str, bool]],
+    sp_app_id: Optional[str] = None,
+    sp_object_id: Optional[str] = None,
+):
+    assert result
+    assert result["deploymentState"]["status"] == "Succeeded", "AIO deployment failed"
+
+    assert result["clusterName"] == cluster_name
+    assert result["clusterNamespace"] == arg_dict.get("cluster_namespace", "azure-iot-operations")
+    assert result["deploymentLink"]
+    assert result["deploymentName"]
+    assert result["deploymentLink"].endswith(result["deploymentName"])
+
+    # CSI driver
+    assert result["csiDriver"]["keyVaultId"] == key_vault
+    assert result["csiDriver"]["kvSpcSecretName"] == arg_dict.get("kv_spc_secret_name", "azure-iot-operations")
+    assert result["csiDriver"]["version"] == arg_dict.get("csi_ver", KEYVAULT_ARC_EXTENSION_VERSION)
+    
+    if sp_app_id:
+        assert result["csiDriver"]["spAppId"] == sp_app_id
+    if sp_object_id:
+        assert result["csiDriver"]["spObjectId"] == sp_object_id
+    csi_config = result["csiDriver"]["configurationSettings"]
+    enabled_rotation = 'false' if arg_dict.get("disable_rotation") else 'true'
+    assert csi_config["secrets-store-csi-driver.enableSecretRotation"] == enabled_rotation
+    assert csi_config["secrets-store-csi-driver.rotationPollInterval"] == arg_dict.get("rotation_int", "1h")
+    assert csi_config["secrets-store-csi-driver.syncSecret.enabled"]
+
+    # deployment state
+    assert result["deploymentState"]["correlationId"]
+    assert result["deploymentState"]["timestampUtc"]
+    _assert_aio_versions(result["deploymentState"]["opsVersion"], arg_dict.get("include_dp", False))
+    _assert_deployment_resources(
+        resources=result["deploymentState"]["resources"],
+        cluster_name=cluster_name,
+        resource_group=resource_group,
+        **arg_dict
+    )
+    
+    # Tls
+    assert result["tls"]["aioTrustConfigMap"]
+    assert result["tls"]["aioTrustSecretName"]
+
+
+def get_resource_from_partial_id(
+    partial_id: str,
+    resource_group: str,
+    api_version: Optional[str] = None,
+):
+    split_id = partial_id.split("/")
+    resource_name = split_id[-1]
+    resource_type = split_id[-2]
+    namespace = split_id[0]
+    command = f"az resource show -g {resource_group} -n {resource_name} --resource-type {resource_type} --namespace {namespace}"
+    command += f" --api-version {api_version}" if api_version else " -v"
+    if len(split_id) > 3:
+        command += f" --parent {'/'.join(split_id[1:-2])}"
+    return run(command)
+
+
+def _assert_aio_versions(aio_versions: Dict[str, str], include_dp: bool = False):
+    from azext_edge.edge.providers.orchestration.template import CURRENT_TEMPLATE
+    template_versions = CURRENT_TEMPLATE.get_component_vers(include_dp=include_dp)
+    for key, value in aio_versions.items():
+        assert value == template_versions[key]
+
+
+def _assert_deployment_resources(resources: List[str], cluster_name: str, resource_group: str, **arg_dict):
+    # only check the custom location + connected cluster resources
+    resources.sort()
+    ext_loc_resources = [res for res in resources if res.startswith(ResourceKeys.custom_location.value)]
+    custom_loc_name = ext_loc_resources[0].split("/")[-1]
+    expected_rules = ['adr', 'aio', 'mq']
+    if arg_dict.get("include_dp"):
+        expected_rules.append("dp")
+    custom_loc_obj = get_resource_from_partial_id(ext_loc_resources[0], resource_group)
+    assert custom_loc_obj["properties"]["hostResourceId"].endswith(cluster_name)
+    extensions = custom_loc_obj["properties"]["clusterExtensionIds"]
+    # should be the same number of extensions vs resource sync rules
+    assert len(extensions) == len(expected_rules)
+
+    assert len(ext_loc_resources) - 1 == len(expected_rules)
+    for res in ext_loc_resources[1:]:
+        assert custom_loc_name in res
+        assert "resourceSyncRules" in res
+        # get the service from custom-location-service-sync
+        assert res.rsplit("-", maxsplit=2)[1] in expected_rules
+        # check existance
+        get_resource_from_partial_id(res, resource_group)
+
+    # connected cluster resources
+    con_clus_resources = [res for res in resources if res.startswith(ResourceKeys.connected_cluster.value)]
+    expected_extensions = ["akri", "assets", "azure-iot-operations", "layered-networking", "mq", "opc-ua-broker"]
+    if arg_dict.get("include_dp"):
+        expected_extensions.append("processor")
+    assert len(expected_extensions) == len(con_clus_resources)
+    keyhash = con_clus_resources[0].rsplit("-")[-1]
+    for res in con_clus_resources:
+        assert cluster_name in res
+        assert res.endswith(keyhash)
+        ext_name = res.split("/")[-1]
+        assert ext_name.rsplit("-", maxsplit=1)[0] in expected_extensions

--- a/azext_edge/tests/edge/init/int/mq_helper.py
+++ b/azext_edge/tests/edge/init/int/mq_helper.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import List, Optional
+
+from .helper import get_resource_from_partial_id, ResourceKeys
+
+
+def assert_mq_args(
+    resource_group: str,
+    init_resources: List[str],
+    mq_authn: Optional[str] = None,
+    mq_broker: Optional[str] = None,
+    mq_frontend_server: Optional[str] = None,
+    mq_insecure: Optional[bool] = None,
+    mq_instance: Optional[str] = None,
+    mq_listener: Optional[str] = None,
+    mq_mem_profile: Optional[str] = None,
+    mq_mode: Optional[str] = None,
+    mq_service_type: Optional[str] = None,
+    mq_backend_part: Optional[str] = None,
+    mq_backend_rf: Optional[str] = None,
+    mq_backend_workers: Optional[str] = None,
+    mq_frontend_replicas: Optional[str] = None,
+    mq_frontend_workers: Optional[str] = None,
+    **_
+):
+    mq_resources = [res for res in init_resources if res.startswith(ResourceKeys.mq.value)]
+    mq_name = mq_resources[0].split("/")[-1]
+    if mq_instance:
+        assert mq_instance == mq_name
+    else:
+        assert mq_name.startswith("init-")
+        assert mq_name.endswith("-mq-instance")
+    
+    # there isn't anything interesting in the resource
+    get_resource_from_partial_id(mq_resources[0], resource_group)
+ 
+    # broker
+    assert mq_resources[1].split("/")[-1] == (mq_broker or "broker")
+    broker_obj = get_resource_from_partial_id(mq_resources[1], resource_group)
+    assert broker_obj["properties"]["memoryProfile"] == (mq_mem_profile or "medium")
+    assert broker_obj["properties"]["mode"] == (mq_mode or "distributed")
+    assert broker_obj["properties"]["encryptInternalTraffic"] is not mq_insecure
+
+    cardinality = broker_obj["properties"]["cardinality"]
+    assert cardinality["backendChain"]["partitions"] == (mq_backend_part or 2)
+    assert cardinality["backendChain"]["redundancyFactor"] == (mq_backend_rf or 2)
+    assert cardinality["backendChain"]["workers"] == (mq_backend_workers or 2)
+    assert cardinality["frontend"]["replicas"] == (mq_frontend_replicas or 2)
+    assert cardinality["frontend"]["workers"] == (mq_frontend_workers or 2)
+
+    # nothing interesting in the authenticator
+    assert mq_resources[2].split("/")[-1] == (mq_authn or "authn")
+    get_resource_from_partial_id(mq_resources[2], resource_group)
+
+    # listener
+    assert mq_resources[3].split("/")[-1] == (mq_listener or "listener")
+    listener_obj = get_resource_from_partial_id(mq_resources[3], resource_group)
+    assert listener_obj["properties"]["serviceType"] == (mq_service_type or "clusterIp")
+    assert listener_obj["properties"]["tls"]["automatic"]["issuerRef"]["name"] == (mq_frontend_server or "mq-dmqtt-frontend")
+
+    # nothing interesting in the diagnostics
+    assert mq_resources[4].split("/")[-1] == "diagnostics"
+    get_resource_from_partial_id(mq_resources[4], resource_group)

--- a/azext_edge/tests/edge/init/int/opcua_helper.py
+++ b/azext_edge/tests/edge/init/int/opcua_helper.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import Optional
+from ....helpers import run
+
+
+def assert_simulate_plc_args(
+    custom_location: str,
+    simulate_plc: Optional[bool] = None,
+    **_
+):
+    if not simulate_plc:
+        simulate_plc = False
+    # note that the simulator may take a bit 
+    query_result = run(f"az iot ops asset query --cl {custom_location}")
+    assert bool(query_result) is simulate_plc
+    query_result = run(f"az iot ops asset endpoint query --cl {custom_location}")
+    assert bool(query_result) is simulate_plc

--- a/azext_edge/tests/edge/init/int/orchestrator_helper.py
+++ b/azext_edge/tests/edge/init/int/orchestrator_helper.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import List, Optional
+from .helper import get_resource_from_partial_id, ResourceKeys
+
+
+def assert_orchestrator_args(
+    resource_group: str,
+    cluster_name: str,
+    namespace: str,
+    init_resources: List[str],
+    target: Optional[str] = None,
+    opcua_discovery_url: Optional[str] = None,
+    simulate_plc: Optional[bool] = None,
+    **_
+):
+    resources = [res for res in init_resources if res.startswith(ResourceKeys.orchestrator.value)]
+    assert len(resources) == 1
+    
+    expected_name = target or (f"{cluster_name}-ops-init-target")
+    assert resources[0].endswith(expected_name)
+
+    orch_obj = get_resource_from_partial_id(resources[0], resource_group)
+    if simulate_plc:
+        from yaml import safe_load
+        components = orch_obj["properties"]["components"]
+        akri_component = None
+        for comp in components:
+            if comp["name"] == "akri-opcua-asset":
+                akri_component = comp
+                break
+        discovery_yaml = akri_component["properties"]["resource"]["spec"]["discoveryHandler"]["discoveryDetails"]
+        discovery_yaml = safe_load(discovery_yaml)
+        expected_url = opcua_discovery_url or f"opc.tcp://opcplc-000000.{namespace}:50000"
+        assert discovery_yaml["opcuaDiscoveryMethod"][0]["asset"]["endpointUrl"] == expected_url

--- a/azext_edge/tests/edge/init/int/test_init_int.py
+++ b/azext_edge/tests/edge/init/int/test_init_int.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import pytest
+from os import mkdir
+
+from ....helpers import run
+from .dataprocessor_helper import assert_dataprocessor_args
+from .mq_helper import assert_mq_args
+from .opcua_helper import assert_simulate_plc_args
+from .orchestrator_helper import assert_orchestrator_args
+from .helper import assert_init_result
+
+
+@pytest.fixture(scope="function")
+def init_test_setup(cluster_connection, settings):
+    from ....settings import EnvironmentVariables
+    settings.add_to_config(EnvironmentVariables.rg.value)
+    settings.add_to_config(EnvironmentVariables.kv.value)
+    settings.add_to_config(EnvironmentVariables.cluster.value)
+    settings.add_to_config(EnvironmentVariables.sp_app_id.value)
+    settings.add_to_config(EnvironmentVariables.sp_object_id.value)
+    settings.add_to_config(EnvironmentVariables.sp_secret.value)
+    settings.add_to_config(EnvironmentVariables.init_args.value)
+    settings.add_to_config(EnvironmentVariables.aio_cleanup.value)
+    if not all([settings.env.azext_edge_cluster, settings.env.azext_edge_rg, settings.env.azext_edge_kv]):
+        pytest.skip("Cannot run init tests without a connected cluster, resource group, and precreated keyvault.")
+
+    yield {
+        "clusterName": settings.env.azext_edge_cluster,
+        "resourceGroup": settings.env.azext_edge_rg,
+        "keyVault": settings.env.azext_edge_kv,
+        "servicePrincipalAppId": settings.env.azext_edge_sp_app_id,
+        "servicePrincipalObjectId": settings.env.azext_edge_sp_object_id,
+        "servicePrincipalSecret": settings.env.azext_edge_sp_secret,
+        "additionalArgs": settings.env.azext_edge_init_args.strip('"')
+    }
+    if settings.env.azext_edge_aio_cleanup:
+        run(
+            f"az iot ops delete --cluster {settings.env.azext_edge_cluster} -g {settings.env.azext_edge_rg} "
+            "-y --no-progress --force"
+        )
+
+
+@pytest.mark.init_scenario_test
+def test_init_scenario(
+    init_test_setup, tracked_files
+):
+    additional_args = init_test_setup["additionalArgs"]
+    arg_dict = {}
+    for arg in additional_args.split("--"):
+        arg = arg.replace("-", "_").strip().split(" ", maxsplit=1)
+        # --simualte-plc vs --dp-instance dp_name
+        if len(arg) == 1:
+            arg_dict[arg[0]] = True
+        else:
+            arg_dict[arg[0]] = arg[1]
+
+    if "ca_dir" in arg_dict:
+        try:
+            mkdir(arg_dict["ca_dir"])
+            tracked_files.append(arg_dict["ca_dir"])
+        except FileExistsError:
+            pass
+    elif all([
+        "ca_key_file" not in arg_dict,
+        "ca_file" not in arg_dict
+    ]):
+        tracked_files.append("aio-test-ca.crt")
+        tracked_files.append("aio-test-private.key")
+
+    cluster_name = init_test_setup["clusterName"]
+    resource_group = init_test_setup["resourceGroup"]
+    key_vault = init_test_setup["keyVault"]
+    sp_app_id = init_test_setup["servicePrincipalAppId"]
+    sp_object_id = init_test_setup["servicePrincipalObjectId"]
+    sp_secret = init_test_setup["servicePrincipalSecret"]
+
+    command = f"az iot ops init -g {resource_group} --cluster {cluster_name} "\
+        f"--kv-id {key_vault} --no-progress {additional_args} "
+    if sp_app_id:
+        command += f"--sp-app-id {sp_app_id} "
+    if sp_object_id:
+        command += f"--sp-object-id {sp_object_id} "
+    if sp_secret:
+        command += f"--sp-secret {sp_secret} "
+
+
+    result = run(command)
+    assert_init_result(
+        result=result,
+        cluster_name=cluster_name,
+        key_vault=key_vault,
+        resource_group=resource_group,
+        arg_dict=arg_dict,
+        sp_app_id=sp_app_id,
+        sp_object_id=sp_object_id
+    )
+
+    custom_location = sorted(result["deploymentState"]["resources"])[0]
+
+    for assertion in [
+        assert_dataprocessor_args,
+        assert_simulate_plc_args,
+        assert_mq_args,
+        assert_orchestrator_args
+    ]:
+        assertion(
+            namespace=result["clusterNamespace"],
+            cluster_name=cluster_name,
+            custom_location=custom_location,
+            resource_group=resource_group,
+            init_resources=result["deploymentState"]["resources"],
+            **arg_dict
+        )

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -127,17 +127,6 @@ def get_kubectl_workload_items(
     )
 
 
-def parse_rest_command(rest_command: str) -> Dict[str, str]:
-    """Simple az rest command parsing."""
-    assert rest_command.startswith("rest")
-    rest_list = rest_command.split("--")[1:]
-    result = {}
-    for rest_input in rest_list:
-        key, value = rest_input.split(maxsplit=1)
-        result[key] = value.strip()
-    return result
-
-
 def remove_file_or_folder(file_path):
     if os.path.isfile(file_path):
         try:

--- a/azext_edge/tests/settings.py
+++ b/azext_edge/tests/settings.py
@@ -15,8 +15,12 @@ class EnvironmentVariables(Enum):
     cluster = "azext_edge_cluster"
     context_name = "azext_edge_context_name"
     kv = "azext_edge_kv"
-    skip_init = "azext_edge_skip_init"
+    sp_app_id = "azext_edge_sp_app_id"
+    sp_object_id = "azext_edge_sp_object_id"
+    sp_secret = "azext_edge_sp_secret"
+    init_args = "azext_edge_init_args"
     skip_cluster_check = "azext_edge_skip_cluster_check"
+    aio_cleanup = "azext_edge_aio_cleanup"
 
 
 class Setting(object):

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     {[base]deps}
     # azure-cli deps
     azure-cli
-setenv = 
+setenv =
     PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
 commands =
     python --version
@@ -63,6 +63,32 @@ commands =
     az -v
     # run unit tests
     pytest -k _unit ./azext_edge/tests --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/test-aziotops-ext-unit.xml {posargs}
+    # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
+
+# init integration tests
+[testenv:py{thon,38,39,310,311}-init-int]
+skip_install = True
+description =
+    {[base]description}
+    int: integration tests
+deps =
+    # base deps
+    {[testenv:python]deps}
+passenv =
+    # pass all env vars with this prefix to tox
+    azext_edge_*
+setenv =
+    # You can temporarily add variables here to modify your tests
+    # azext_edge_skip_init=true
+    PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
+commands =
+    python --version
+    # install to tox extension dir
+    pip install -U --target {envsitepackagesdir}/azure-cli-extensions/azure-iot-ops .
+    # validate az and extension version
+    az -v
+    # run integration tests
+    pytest -k "_int.py" ./azext_edge/tests/edge/init --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/JUnit.xml {posargs}
     # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
 
 # integration tests
@@ -77,7 +103,7 @@ deps =
 passenv =
     # pass all env vars with this prefix to tox
     azext_edge_*
-setenv = 
+setenv =
     # You can temporarily add variables here to modify your tests
     # azext_edge_skip_init=true
     PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
@@ -88,7 +114,7 @@ commands =
     # validate az and extension version
     az -v
     # run integration tests
-    pytest -k "_int.py" ./azext_edge/tests --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/JUnit.xml {posargs}
+    pytest -k "_int.py" ./azext_edge/tests -m "not init_scenario_test" --cov=azext_edge/edge --cov-config .coveragerc --junitxml=junit/JUnit.xml {posargs}
     # You can pass additional positional args to pytest using `tox -e [env] -- -s -vv`
 
 # code coverage - HTML and JSON


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
