### PR TITLE
feat: update support bundle to adapt change for mqttbroker

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -15,7 +15,12 @@ from .providers.support_bundle import (
     COMPAT_CLUSTER_CONFIG_APIS,
     COMPAT_DATA_PROCESSOR_APIS,
     COMPAT_DEVICEREGISTRY_APIS,
+<<<<<<< HEAD
     COMPAT_MQ_APIS,
+=======
+    COMPAT_LNM_APIS,
+    COMPAT_MQTT_BROKER_APIS,
+>>>>>>> e8af49f (add tests)
     COMPAT_OPCUA_APIS,
     COMPAT_ORC_APIS,
 )
@@ -51,7 +56,7 @@ def load_iotops_help():
         short-summary: Creates a standard support bundle zip archive for use in troubleshooting and diagnostics.
         long-summary: |
             {{Supported service APIs}}
-            - {COMPAT_MQ_APIS.as_str()}
+            - {COMPAT_MQTT_BROKER_APIS.as_str()}
             - {COMPAT_OPCUA_APIS.as_str()}
             - {COMPAT_DATA_PROCESSOR_APIS.as_str()}
             - {COMPAT_ORC_APIS.as_str()}
@@ -91,7 +96,7 @@ def load_iotops_help():
             - {COMPAT_AKRI_APIS.as_str()}
             - {COMPAT_DATA_PROCESSOR_APIS.as_str()}
             - {COMPAT_DEVICEREGISTRY_APIS.as_str()}
-            - {COMPAT_MQ_APIS.as_str()}
+            - {COMPAT_MQTT_BROKER_APIS.as_str()}
             - {COMPAT_OPCUA_APIS.as_str()}
 
         examples:

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -15,12 +15,7 @@ from .providers.support_bundle import (
     COMPAT_CLUSTER_CONFIG_APIS,
     COMPAT_DATA_PROCESSOR_APIS,
     COMPAT_DEVICEREGISTRY_APIS,
-<<<<<<< HEAD
-    COMPAT_MQ_APIS,
-=======
-    COMPAT_LNM_APIS,
     COMPAT_MQTT_BROKER_APIS,
->>>>>>> e8af49f (add tests)
     COMPAT_OPCUA_APIS,
     COMPAT_ORC_APIS,
 )

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -57,7 +57,7 @@ def check(
     post_deployment_checks: Optional[bool] = None,
     as_object=None,
     context_name=None,
-    ops_service: str = "mq",
+    ops_service: str = OpsServiceType.mq.value,
     resource_kinds: List[str] = None,
     resource_name: str = None,
 ) -> Union[Dict[str, Any], None]:

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -140,7 +140,7 @@ class OpsServiceType(ListableEnum):
     """
 
     auto = "auto"
-    mq = "mqttbroker"
+    mq = "broker"
     opcua = "opcua"
     dataprocessor = "dataprocessor"
     orc = "orc"

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -140,7 +140,7 @@ class OpsServiceType(ListableEnum):
     """
 
     auto = "auto"
-    mq = "mq"
+    mq = "mqttbroker"
     opcua = "opcua"
     dataprocessor = "dataprocessor"
     orc = "orc"

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -149,6 +149,16 @@ class OpsServiceType(ListableEnum):
     # TODO: re-enable billing once service is available post 0.6.0 release
     # billing = "billing"
 
+    @classmethod
+    def list_check_services(cls):
+        return [
+            cls.mq.value,
+            cls.opcua.value,
+            cls.dataprocessor.value,
+            cls.akri.value,
+            cls.deviceregistry.value,
+        ]
+
 
 class ResourceProviderMapping(ListableEnum):
     """

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -72,19 +72,6 @@ def load_iotops_arguments(self, _):
             arg_type=get_three_state_flag(),
             help="Force the operation to execute.",
         )
-        context.argument(
-            "instance_name",
-            options_list=["--name", "-n"],
-            help="IoT Operations instance name.",
-        )
-
-    with self.argument_context("iot ops show") as context:
-        context.argument(
-            "show_tree",
-            options_list=["--tree"],
-            arg_type=get_three_state_flag(),
-            help="Use to visualize the IoT Operations deployment against the backing cluster.",
-        )
 
     with self.argument_context("iot ops support") as context:
         context.argument(
@@ -137,7 +124,7 @@ def load_iotops_arguments(self, _):
         context.argument(
             "ops_service",
             options_list=["--ops-service", "--svc"],
-            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "mqttbroker", "opcua"]),
+            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "mq", "opcua"]),
             help="The IoT Operations service deployment that will be evaluated.",
         )
         context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -137,7 +137,7 @@ def load_iotops_arguments(self, _):
         context.argument(
             "ops_service",
             options_list=["--ops-service", "--svc"],
-            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "mqttbroker", "opcua"]),
+            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "broker", "opcua"]),
             help="The IoT Operations service deployment that will be evaluated.",
         )
         context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -137,7 +137,7 @@ def load_iotops_arguments(self, _):
         context.argument(
             "ops_service",
             options_list=["--ops-service", "--svc"],
-            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "broker", "opcua"]),
+            choices=CaseInsensitiveList(OpsServiceType.list_check_services()),
             help="The IoT Operations service deployment that will be evaluated.",
         )
         context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -137,7 +137,7 @@ def load_iotops_arguments(self, _):
         context.argument(
             "ops_service",
             options_list=["--ops-service", "--svc"],
-            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "mq", "opcua"]),
+            choices=CaseInsensitiveList(["akri", "dataprocessor", "deviceregistry", "mqttbroker", "opcua"]),
             help="The IoT Operations service deployment that will be evaluated.",
         )
         context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -72,6 +72,19 @@ def load_iotops_arguments(self, _):
             arg_type=get_three_state_flag(),
             help="Force the operation to execute.",
         )
+        context.argument(
+            "instance_name",
+            options_list=["--name", "-n"],
+            help="IoT Operations instance name.",
+        )
+
+    with self.argument_context("iot ops show") as context:
+        context.argument(
+            "show_tree",
+            options_list=["--tree"],
+            arg_type=get_three_state_flag(),
+            help="Use to visualize the IoT Operations deployment against the backing cluster.",
+        )
 
     with self.argument_context("iot ops support") as context:
         context.argument(

--- a/azext_edge/edge/providers/edge_api/__init__.py
+++ b/azext_edge/edge/providers/edge_api/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import EdgeResourceApi, EdgeApiManager
 from .clusterconfig import CLUSTER_CONFIG_API_V1
-from .mq import MQ_ACTIVE_API, MQ_API_V1B1, MQTT_BROKER_API_V1B1, MqResourceKinds
+from .mq import MQ_ACTIVE_API, MQTT_BROKER_API_V1B1, MqResourceKinds
 from .dataprocessor import DATA_PROCESSOR_API_V1, DataProcessorResourceKinds
 from .opcua import OPCUA_API_V1, OpcuaResourceKinds
 from .orc import ORC_API_V1, OrcResourceKinds
@@ -22,7 +22,6 @@ __all__ = [
     "EdgeApiManager",
     "MqResourceKinds",
     "MQ_ACTIVE_API",
-    "MQ_API_V1B1",
     "MQTT_BROKER_API_V1B1",
     "OpcuaResourceKinds",
     "OPCUA_API_V1",

--- a/azext_edge/edge/providers/edge_api/__init__.py
+++ b/azext_edge/edge/providers/edge_api/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import EdgeResourceApi, EdgeApiManager
 from .clusterconfig import CLUSTER_CONFIG_API_V1
-from .mq import MQ_ACTIVE_API, MQ_API_V1B1, MqResourceKinds
+from .mq import MQ_ACTIVE_API, MQ_API_V1B1, MQTT_BROKER_API_V1B1, MqResourceKinds
 from .dataprocessor import DATA_PROCESSOR_API_V1, DataProcessorResourceKinds
 from .opcua import OPCUA_API_V1, OpcuaResourceKinds
 from .orc import ORC_API_V1, OrcResourceKinds
@@ -23,6 +23,7 @@ __all__ = [
     "MqResourceKinds",
     "MQ_ACTIVE_API",
     "MQ_API_V1B1",
+    "MQTT_BROKER_API_V1B1",
     "OpcuaResourceKinds",
     "OPCUA_API_V1",
     "OrcResourceKinds",

--- a/azext_edge/edge/providers/edge_api/mq.py
+++ b/azext_edge/edge/providers/edge_api/mq.py
@@ -21,18 +21,13 @@ class MqResourceKinds(ListableEnum):
     DATALAKE_CONNECTOR_TOPIC_MAP = "datalakeconnectortopicmap"
     KAFKA_CONNECTOR = "kafkaconnector"
     KAFKA_CONNECTOR_TOPIC_MAP = "kafkaconnectortopicmap"
-    IOT_HUB_CONNECTOR = "iothubconnector"
-    IOT_HUB_CONNECTOR_ROUTE_MAP = "iothubconnectorroutesmap"
 
 
-MQ_API_V1B1 = EdgeResourceApi(
-    group="mq.iotoperations.azure.com", version="v1beta1", moniker="mq", label="microsoft-iotoperations-mq"
-)
 MQTT_BROKER_API_V1B1 = EdgeResourceApi(
     group="mqttbroker.iotoperations.azure.com",
     version="v1beta1",
     moniker="mqttbroker",
-    label="microsoft-iotoperations-mqttbroker",
+    label="microsoft-iotoperations-mq",
 )
 
-MQ_ACTIVE_API = MQ_API_V1B1
+MQ_ACTIVE_API = MQTT_BROKER_API_V1B1

--- a/azext_edge/edge/providers/edge_api/mq.py
+++ b/azext_edge/edge/providers/edge_api/mq.py
@@ -28,5 +28,11 @@ class MqResourceKinds(ListableEnum):
 MQ_API_V1B1 = EdgeResourceApi(
     group="mq.iotoperations.azure.com", version="v1beta1", moniker="mq", label="microsoft-iotoperations-mq"
 )
+MQTT_BROKER_API_V1B1 = EdgeResourceApi(
+    group="mqttbroker.iotoperations.azure.com",
+    version="v1beta1",
+    moniker="mqttbroker",
+    label="microsoft-iotoperations-mqttbroker",
+)
 
 MQ_ACTIVE_API = MQ_API_V1B1

--- a/azext_edge/edge/providers/edge_api/mq.py
+++ b/azext_edge/edge/providers/edge_api/mq.py
@@ -26,7 +26,7 @@ class MqResourceKinds(ListableEnum):
 MQTT_BROKER_API_V1B1 = EdgeResourceApi(
     group="mqttbroker.iotoperations.azure.com",
     version="v1beta1",
-    moniker="mqttbroker",
+    moniker="broker",
     label="microsoft-iotoperations-mq",
 )
 

--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -140,7 +140,6 @@ def process_v1_pods(
 
 def process_deployments(
     directory_path: str,
-    return_namespaces: bool = False,
     field_selector: Optional[str] = None,
     label_selector: Optional[str] = None,
     prefix_names: Optional[List[str]] = None,
@@ -151,25 +150,13 @@ def process_deployments(
     deployments: V1DeploymentList = v1_apps.list_deployment_for_all_namespaces(
         label_selector=label_selector, field_selector=field_selector
     )
-    namespace_pods_work = {}
 
-    processed = _process_kubernetes_resources(
+    return _process_kubernetes_resources(
         directory_path=directory_path,
         resources=deployments,
         prefix_names=prefix_names,
         kind=BundleResourceKind.deployment.value,
     )
-
-    for deployment in deployments.items:
-        deployment_namespace: str = deployment.metadata.namespace
-
-        if deployment_namespace not in namespace_pods_work:
-            namespace_pods_work[deployment_namespace] = True
-
-    if return_namespaces:
-        return processed, namespace_pods_work
-
-    return processed
 
 
 def process_statefulset(

--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -174,6 +174,7 @@ def process_deployments(
 
 def process_statefulset(
     directory_path: str,
+    return_namespaces: bool = False,
     field_selector: Optional[str] = None,
     label_selector: Optional[str] = None,
 ) -> List[dict]:
@@ -183,12 +184,24 @@ def process_statefulset(
     statefulsets: V1StatefulSetList = v1_apps.list_stateful_set_for_all_namespaces(
         label_selector=label_selector, field_selector=field_selector
     )
+    namespace_pods_work = {}
 
-    return _process_kubernetes_resources(
+    processed = _process_kubernetes_resources(
         directory_path=directory_path,
         resources=statefulsets,
         kind=BundleResourceKind.statefulset.value,
     )
+
+    for statefulset in statefulsets.items:
+        statefulset_namespace: str = statefulset.metadata.namespace
+
+        if statefulset_namespace not in namespace_pods_work:
+            namespace_pods_work[statefulset_namespace] = True
+
+    if return_namespaces:
+        return processed, namespace_pods_work
+
+    return processed
 
 
 def process_services(

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -10,7 +10,7 @@ from zipfile import ZipInfo
 
 from knack.log import get_logger
 
-from azext_edge.edge.common import AIO_MQ_OPERATOR, AIO_MQ_RESOURCE_PREFIX
+from azext_edge.edge.common import AIO_MQ_RESOURCE_PREFIX
 from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
 
 from ..edge_api import MQ_ACTIVE_API, EdgeResourceApi
@@ -108,7 +108,7 @@ def fetch_statefulsets():
         )
         processed.extend(stateful_set)
         metrics_namespaces.extend(connector_namespaces)
-    
+
     for namespace in metrics_namespaces:
         metrics = fetch_diagnostic_metrics(namespace)
         if metrics:

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -13,7 +13,7 @@ from knack.log import get_logger
 from azext_edge.edge.common import AIO_MQ_OPERATOR, AIO_MQ_RESOURCE_PREFIX
 from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
 
-from ..edge_api import MQ_ACTIVE_API, EdgeResourceApi
+from ..edge_api import MQ_ACTIVE_API,  MQTT_BROKER_API_V1B1, EdgeResourceApi
 from ..stats import get_stats, get_traces
 from .base import (
     DAY_IN_SECONDS,
@@ -42,9 +42,10 @@ MQ_APP_LABELS = [
 ]
 
 MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
+MQ_CURRENT_API = MQ_ACTIVE_API if MQ_ACTIVE_API.is_deployed else MQTT_BROKER_API_V1B1
 
-MQ_NAME_LABEL = NAME_LABEL_FORMAT.format(label=MQ_ACTIVE_API.label)
-MQ_DIRECTORY_PATH = MQ_ACTIVE_API.moniker
+MQ_NAME_LABEL = NAME_LABEL_FORMAT.format(label=MQ_CURRENT_API.label)
+MQ_DIRECTORY_PATH = MQ_CURRENT_API.moniker
 
 
 def fetch_diagnostic_metrics(namespace: str):
@@ -140,7 +141,7 @@ def fetch_statefulsets():
         MqResourceKinds.KAFKA_CONNECTOR,
         MqResourceKinds.MQTT_BRIDGE_CONNECTOR,
     ]:
-        connectors.extend(MQ_ACTIVE_API.get_resources(kind=kind).get("items", []))
+        connectors.extend(MQ_CURRENT_API.get_resources(kind=kind).get("items", []))
 
     for connector in connectors:
         connector_name = connector.get("metadata", {}).get("name")

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -82,13 +82,11 @@ def fetch_diagnostic_traces():
 
 
 def fetch_statefulsets():
-    metrics_namespaces = []
     processed, namespaces = process_statefulset(
         directory_path=MQ_DIRECTORY_PATH,
         label_selector=MQ_NAME_LABEL,
         return_namespaces=True,
     )
-    metrics_namespaces.extend(namespaces)
 
     # bridge connector stateful sets have no labels
     connectors = []
@@ -101,15 +99,13 @@ def fetch_statefulsets():
 
     for connector in connectors:
         connector_name = connector.get("metadata", {}).get("name")
-        stateful_set, connector_namespaces = process_statefulset(
+        stateful_set = process_statefulset(
             directory_path=MQ_DIRECTORY_PATH,
             field_selector=f"metadata.name={AIO_MQ_RESOURCE_PREFIX}{connector_name}",
-            return_namespaces=True,
         )
         processed.extend(stateful_set)
-        metrics_namespaces.extend(connector_namespaces)
 
-    for namespace in metrics_namespaces:
+    for namespace in namespaces:
         metrics = fetch_diagnostic_metrics(namespace)
         if metrics:
             processed.append(metrics)

--- a/azext_edge/edge/providers/support/orc.py
+++ b/azext_edge/edge/providers/support/orc.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 
 ORC_APP_LABEL = "app in (aio-orc-api, cert-manager, cainjector, webhook)"
-ORC_CONTROLLER_LABEL = "control-plane in (aio-orc-controller-manager)"
+ORC_CONTROLLER_LABEL = "control-plane in (aio-plat-controller-manager)"
 ORC_DIRECTORY_PATH = ORC_API_V1.moniker
 
 # TODO: @jiacju - this label will be used near future for consistency

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -15,7 +15,6 @@ from ..common import OpsServiceType
 from ..providers.edge_api import (
     CLUSTER_CONFIG_API_V1,
     DATA_PROCESSOR_API_V1,
-    MQ_API_V1B1,
     MQTT_BROKER_API_V1B1,
     OPCUA_API_V1,
     ORC_API_V1,
@@ -29,7 +28,6 @@ logger = get_logger(__name__)
 console = Console()
 
 COMPAT_CLUSTER_CONFIG_APIS = EdgeApiManager(resource_apis=[CLUSTER_CONFIG_API_V1])
-COMPAT_MQ_APIS = EdgeApiManager(resource_apis=[MQ_API_V1B1])
 COMPAT_MQTT_BROKER_APIS = EdgeApiManager(resource_apis=[MQTT_BROKER_API_V1B1])
 COMPAT_OPCUA_APIS = EdgeApiManager(resource_apis=[OPCUA_API_V1])
 COMPAT_DATA_PROCESSOR_APIS = EdgeApiManager(resource_apis=[DATA_PROCESSOR_API_V1])
@@ -63,7 +61,7 @@ def build_bundle(
     api_map = {
         # TODO: re-enable billing once service is available post 0.6.0 release
         # OpsServiceType.billing.value: {"apis": COMPAT_CLUSTER_CONFIG_APIS, "prepare_bundle": prepare_billing_bundle},
-        OpsServiceType.mq.value: {"apis": COMPAT_MQ_APIS, "prepare_bundle": prepare_mq_bundle},
+        OpsServiceType.mq.value: {"apis": COMPAT_MQTT_BROKER_APIS, "prepare_bundle": prepare_mq_bundle},
         OpsServiceType.opcua.value: {
             "apis": COMPAT_OPCUA_APIS,
             "prepare_bundle": prepare_opcua_bundle,
@@ -87,14 +85,7 @@ def build_bundle(
 
     for service_moniker, api_info in api_map.items():
         if ops_service in [OpsServiceType.auto.value, service_moniker]:
-            try:
-                deployed_apis = api_info["apis"].get_deployed(raise_on_404)
-            except Exception as e:
-                if service_moniker == OpsServiceType.mq.value:
-                    # Fallback to check MQTT_BROKER_API_V1B1 if MQ_API_V1B1 is not found
-                    deployed_apis = COMPAT_MQTT_BROKER_APIS.get_deployed(raise_on_404)
-                else:
-                    raise e
+            deployed_apis = api_info["apis"].get_deployed(raise_on_404)
             if deployed_apis:
                 bundle_method = api_info["prepare_bundle"]
                 # Check if the function takes a second argument

--- a/azext_edge/tests/edge/checks/conftest.py
+++ b/azext_edge/tests/edge/checks/conftest.py
@@ -94,7 +94,7 @@ def mock_get_cluster_custom_api(mocker):
 def mock_resource_types(mocker, ops_service):
     patched = mocker.patch("azext_edge.edge.providers.check.base.deployment.enumerate_ops_service_resources")
 
-    if ops_service == "mq":
+    if ops_service == "mqttbroker":
         patched.return_value = (
             {},
             {

--- a/azext_edge/tests/edge/checks/conftest.py
+++ b/azext_edge/tests/edge/checks/conftest.py
@@ -94,7 +94,7 @@ def mock_get_cluster_custom_api(mocker):
 def mock_resource_types(mocker, ops_service):
     patched = mocker.patch("azext_edge.edge.providers.check.base.deployment.enumerate_ops_service_resources")
 
-    if ops_service == "mqttbroker":
+    if ops_service == "broker":
         patched.return_value = (
             {},
             {

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -57,7 +57,7 @@ from ...generators import generate_random_string
         ],
     ],
 )
-@pytest.mark.parametrize("ops_service", ["mq"])
+@pytest.mark.parametrize("ops_service", ["mqttbroker"])
 def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, resource_kinds):
     eval_lookup = {
         MqResourceKinds.BROKER.value: "azext_edge.edge.providers.check.mq.evaluate_brokers",

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -57,7 +57,7 @@ from ...generators import generate_random_string
         ],
     ],
 )
-@pytest.mark.parametrize("ops_service", ["mqttbroker"])
+@pytest.mark.parametrize("ops_service", ["broker"])
 def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, resource_kinds):
     eval_lookup = {
         MqResourceKinds.BROKER.value: "azext_edge.edge.providers.check.mq.evaluate_brokers",

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -84,8 +84,8 @@ def mocked_cluster_resources(request, mocker):
 
     from azext_edge.edge.providers.edge_api import (
         EdgeResourceApi,
-        MQ_API_V1B1,
         MQ_ACTIVE_API,
+        MQTT_BROKER_API_V1B1,
         OPCUA_API_V1,
         DATA_PROCESSOR_API_V1,
         ORC_API_V1,
@@ -105,7 +105,7 @@ def mocked_cluster_resources(request, mocker):
         r_key = r.as_str()
         v1_resources: List[V1APIResource] = []
 
-        if r == MQ_API_V1B1:
+        if r == MQTT_BROKER_API_V1B1:
             v1_resources.append(_get_api_resource("Broker"))
             v1_resources.append(_get_api_resource("BrokerListener"))
             v1_resources.append(_get_api_resource("BrokerDiagnostic"))

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -64,13 +64,13 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
 
     # Check and take out mq traces:
     if mq_traces and ops_service in [OpsServiceType.auto.value, OpsServiceType.mq.value]:
-        mq_level = walk_result.pop(path.join(BASE_ZIP_PATH, namespace, "mq", "traces"), {})
+        mq_level = walk_result.pop(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.mq.value, "traces"), {})
         if mq_level:
             assert not mq_level["folders"]
             assert_file_names(mq_level["files"])
             # make sure level 2 doesnt get messed up
-            assert walk_result[path.join(BASE_ZIP_PATH, namespace, "mq")]["folders"] == ["traces"]
-            walk_result[path.join(BASE_ZIP_PATH, namespace, "mq")]["folders"] = []
+            assert walk_result[path.join(BASE_ZIP_PATH, namespace, OpsServiceType.mq.value)]["folders"] == ["traces"]
+            walk_result[path.join(BASE_ZIP_PATH, namespace, OpsServiceType.mq.value)]["folders"] = []
 
     # Level 2 and 3 - bottom
     actual_walk_result = (len(expected_services) + int("clusterconfig" in expected_services))

--- a/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
@@ -40,7 +40,7 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
         resource_api=MQ_ACTIVE_API
     )
 
-    expected_workload_types = ["deployment", "pod", "replicaset", "service", "statefulset"]
+    expected_workload_types = ["pod", "replicaset", "service", "statefulset"]
     expected_types = set(expected_workload_types).union(MQ_ACTIVE_API.kinds)
     assert set(file_map.keys()).issubset(expected_types)
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -597,7 +597,7 @@ def test_create_bundle(
 
 def asset_raises_not_found_error(mocked_cluster_resources):
     for api, moniker in [
-        (MQTT_BROKER_API_V1B1, "mqttbroker"),
+        (MQTT_BROKER_API_V1B1, "broker"),
         (OPCUA_API_V1, "opcua"),
         (DATA_PROCESSOR_API_V1, "dataprocessor"),
         (ORC_API_V1, "orc"),
@@ -980,7 +980,7 @@ def test_mq_list_stateful_sets(
     # mock MQ support bundle to return connectors
     mocked_mq_support_active_api = mocker.patch("azext_edge.edge.providers.support.mq.MQ_ACTIVE_API")
     mocked_mq_support_active_api.get_resources.return_value = custom_objects
-    result = support_bundle(None, bundle_dir=a_bundle_dir, ops_service="mqttbroker")
+    result = support_bundle(None, bundle_dir=a_bundle_dir, ops_service="broker")
     assert result
 
     # assert initial call to list stateful sets

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -21,7 +21,7 @@ from azext_edge.edge.providers.edge_api import (
     DATA_PROCESSOR_API_V1,
     DEVICEREGISTRY_API_V1,
     MQ_ACTIVE_API,
-    MQ_API_V1B1,
+    MQTT_BROKER_API_V1B1,
     OPCUA_API_V1,
     ORC_API_V1,
     EdgeResourceApi,
@@ -66,7 +66,7 @@ from azext_edge.edge.providers.support.orc import (
 )
 from azext_edge.edge.providers.support.otel import OTEL_API, OTEL_NAME_LABEL
 from azext_edge.edge.providers.support.shared import NAME_LABEL_FORMAT
-from azext_edge.edge.providers.support_bundle import COMPAT_MQ_APIS
+from azext_edge.edge.providers.support_bundle import COMPAT_MQTT_BROKER_APIS
 
 from ...generators import generate_random_string
 from .conftest import add_pod_to_mocked_pods
@@ -78,14 +78,14 @@ a_bundle_dir = f"support_test_{generate_random_string()}"
     "mocked_cluster_resources",
     [
         [],
-        [MQ_API_V1B1],
-        [MQ_API_V1B1, MQ_ACTIVE_API],
-        [MQ_API_V1B1, OPCUA_API_V1],
-        [MQ_API_V1B1, DATA_PROCESSOR_API_V1],
-        [MQ_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1],
-        [MQ_API_V1B1, OPCUA_API_V1, DEVICEREGISTRY_API_V1],
-        [MQ_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1, ORC_API_V1],
-        [MQ_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1, ORC_API_V1, AKRI_API_V0],
+        [MQTT_BROKER_API_V1B1],
+        [MQTT_BROKER_API_V1B1, MQ_ACTIVE_API],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1],
+        [MQTT_BROKER_API_V1B1, DATA_PROCESSOR_API_V1],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, DEVICEREGISTRY_API_V1],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1, ORC_API_V1],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1, ORC_API_V1, AKRI_API_V0],
         # TODO: re-enable billing once service is available post 0.6.0 release
         # [MQ_API_V1B1, OPCUA_API_V1, DATA_PROCESSOR_API_V1, ORC_API_V1, CLUSTER_CONFIG_API_V1],
     ],
@@ -195,15 +195,8 @@ def test_create_bundle(
                 directory_path=ARC_BILLING_DIRECTORY_PATH,
             )
 
-        if api in COMPAT_MQ_APIS.resource_apis:
+        if api in COMPAT_MQTT_BROKER_APIS.resource_apis:
             # Assert runtime resources
-            assert_list_deployments(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=MQ_LABEL,
-                directory_path=MQ_DIRECTORY_PATH,
-                field_selector=f"metadata.name={AIO_MQ_OPERATOR}",
-            )
             assert_list_pods(
                 mocked_client,
                 mocked_zipfile,
@@ -228,13 +221,6 @@ def test_create_bundle(
             )
             assert_list_replica_sets(
                 mocked_client, mocked_zipfile, label_selector=MQ_NAME_LABEL, directory_path=MQ_DIRECTORY_PATH
-            )
-            assert_list_stateful_sets(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=MQ_LABEL,
-                field_selector=None,
-                directory_path=MQ_DIRECTORY_PATH
             )
             assert_list_stateful_sets(
                 mocked_client,
@@ -611,7 +597,7 @@ def test_create_bundle(
 
 def asset_raises_not_found_error(mocked_cluster_resources):
     for api, moniker in [
-        (MQ_API_V1B1, "mq"),
+        (MQTT_BROKER_API_V1B1, "mq"),
         (OPCUA_API_V1, "opcua"),
         (DATA_PROCESSOR_API_V1, "dataprocessor"),
         (ORC_API_V1, "orc"),
@@ -670,7 +656,7 @@ def assert_list_deployments(
     mock_names: List[str] = None,
 ):
     if MQ_DIRECTORY_PATH in directory_path:
-        # regardless of MQ API, MQ_ACTIVE_API.moniker is used for support/mq/fetch_diagnostic_metrics
+        # regardless of MQ API, MQ_ACTIVE_API.moniker is used for support/mqttbroker/fetch_diagnostic_metrics
         from unittest.mock import call
 
         mocked_client.AppsV1Api().list_deployment_for_all_namespaces.assert_has_calls(
@@ -878,7 +864,7 @@ def assert_list_daemon_sets(
 
 
 def assert_mq_stats(mocked_zipfile):
-    assert_zipfile_write(mocked_zipfile, zinfo="mock_namespace/mq/diagnostic_metrics.txt", data="metrics")
+    assert_zipfile_write(mocked_zipfile, zinfo="mock_namespace/mqttbroker/diagnostic_metrics.txt", data="metrics")
 
 
 def assert_otel_kpis(
@@ -960,7 +946,7 @@ def test_get_bundle_path(mocked_os_makedirs):
 # MQ connector stateful sets need labels based on connector names
 @pytest.mark.parametrize(
     "mocked_cluster_resources",
-    [[MQ_API_V1B1]],
+    [[MQTT_BROKER_API_V1B1]],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -999,7 +985,7 @@ def test_mq_list_stateful_sets(
 
     # assert initial call to list stateful sets
     mocked_client.AppsV1Api().list_stateful_set_for_all_namespaces.assert_any_call(
-        label_selector=MQ_LABEL, field_selector=None
+        label_selector=MQ_NAME_LABEL, field_selector=None
     )
 
     # TODO - assert zipfile write of generic statefulset
@@ -1022,7 +1008,7 @@ def test_mq_list_stateful_sets(
 @pytest.mark.parametrize(
     "mocked_cluster_resources",
     [
-        [MQ_API_V1B1],
+        [MQTT_BROKER_API_V1B1],
     ],
     indirect=True,
 )
@@ -1055,7 +1041,7 @@ def test_create_bundle_mq_traces(
 
     assert get_trace_kwargs["namespace"] == "mock_namespace"  # TODO: Not my favorite
     assert get_trace_kwargs["trace_ids"] == ["!support_bundle!"]  # TODO: Magic string
-    test_zipinfo = ZipInfo("mock_namespace/mq/traces/trace_key")
+    test_zipinfo = ZipInfo("mock_namespace/mqttbroker/traces/trace_key")
     test_zipinfo.file_size = 0
     test_zipinfo.compress_size = 0
     assert_zipfile_write(mocked_zipfile, zinfo=test_zipinfo, data="trace_data")

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -14,7 +14,7 @@ import pytest
 from azure.cli.core.azclierror import ResourceNotFoundError
 
 from azext_edge.edge.commands_edge import support_bundle
-from azext_edge.edge.common import AIO_MQ_OPERATOR, AIO_MQ_RESOURCE_PREFIX
+from azext_edge.edge.common import AIO_MQ_RESOURCE_PREFIX
 from azext_edge.edge.providers.edge_api import (
     AKRI_API_V0,
     CLUSTER_CONFIG_API_V1,

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -656,7 +656,7 @@ def assert_list_deployments(
     mock_names: List[str] = None,
 ):
     if MQ_DIRECTORY_PATH in directory_path:
-        # regardless of MQ API, MQ_ACTIVE_API.moniker is used for support/mqttbroker/fetch_diagnostic_metrics
+        # regardless of MQ API, MQ_ACTIVE_API.moniker is used for support/broker/fetch_diagnostic_metrics
         from unittest.mock import call
 
         mocked_client.AppsV1Api().list_deployment_for_all_namespaces.assert_has_calls(
@@ -864,7 +864,7 @@ def assert_list_daemon_sets(
 
 
 def assert_mq_stats(mocked_zipfile):
-    assert_zipfile_write(mocked_zipfile, zinfo="mock_namespace/mqttbroker/diagnostic_metrics.txt", data="metrics")
+    assert_zipfile_write(mocked_zipfile, zinfo="mock_namespace/broker/diagnostic_metrics.txt", data="metrics")
 
 
 def assert_otel_kpis(
@@ -1041,7 +1041,7 @@ def test_create_bundle_mq_traces(
 
     assert get_trace_kwargs["namespace"] == "mock_namespace"  # TODO: Not my favorite
     assert get_trace_kwargs["trace_ids"] == ["!support_bundle!"]  # TODO: Magic string
-    test_zipinfo = ZipInfo("mock_namespace/mqttbroker/traces/trace_key")
+    test_zipinfo = ZipInfo("mock_namespace/broker/traces/trace_key")
     test_zipinfo.file_size = 0
     test_zipinfo.compress_size = 0
     assert_zipfile_write(mocked_zipfile, zinfo=test_zipinfo, data="trace_data")

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -597,7 +597,7 @@ def test_create_bundle(
 
 def asset_raises_not_found_error(mocked_cluster_resources):
     for api, moniker in [
-        (MQTT_BROKER_API_V1B1, "mq"),
+        (MQTT_BROKER_API_V1B1, "mqttbroker"),
         (OPCUA_API_V1, "opcua"),
         (DATA_PROCESSOR_API_V1, "dataprocessor"),
         (ORC_API_V1, "orc"),
@@ -980,7 +980,7 @@ def test_mq_list_stateful_sets(
     # mock MQ support bundle to return connectors
     mocked_mq_support_active_api = mocker.patch("azext_edge.edge.providers.support.mq.MQ_ACTIVE_API")
     mocked_mq_support_active_api.get_resources.return_value = custom_objects
-    result = support_bundle(None, bundle_dir=a_bundle_dir, ops_service="mq")
+    result = support_bundle(None, bundle_dir=a_bundle_dir, ops_service="mqttbroker")
     assert result
 
     # assert initial call to list stateful sets


### PR DESCRIPTION
1. update support bundle from mq to mqttbroker, update api group and resource capture
2. int test also caught an error of orc label change, therefore also updated the label

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
