### PR TITLE
fix: update cluster extension check for assets and endpoints

### DIFF
--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -201,7 +201,7 @@ class ClusterExtensionsMapping(Enum):
     Cluster extension mappings.
     """
 
-    asset = "microsoft.deviceregistry.assets"
+    asset = "adr"
 
 
 class AEPAuthModes(Enum):

--- a/azext_edge/edge/providers/rpsaas/adr/base.py
+++ b/azext_edge/edge/providers/rpsaas/adr/base.py
@@ -5,7 +5,6 @@
 # ----------------------------------------------------------------------------------------------
 
 from knack.log import get_logger
-
 from ..base_provider import RPSaaSBaseProvider
 from ....common import ClusterExtensionsMapping, ResourceProviderMapping
 

--- a/azext_edge/edge/providers/rpsaas/user_strings.py
+++ b/azext_edge/edge/providers/rpsaas/user_strings.py
@@ -11,7 +11,7 @@ CLUSTER_NOT_FOUND_MSG = "Cluster associated with the custom location {0} not fou
     "The command may fail."
 CLUSTER_OFFLINE_MSG = "Cluster {0} is not connected. The cluster may not update correctly."
 MISSING_CLUSTER_CUSTOM_LOCATION_ERROR = "Need to provide either cluster name or custom location"
-MISSING_EXTENSION_ERROR = "Cluster {0} is missing the {1} extension."
+MISSING_EXTENSION_ERROR = "Cluster {0} is missing the {1} extension with enabled features."
 MULTIPLE_CUSTOM_LOCATIONS_ERROR = "The following custom locations were found for cluster {0}: \n{1}. "\
     "Please specify which custom location to use."
 MULTIPLE_POSSIBLE_ITEMS_ERROR = "Found {0} {1}s with the name {2}. Please provide the resource group "\

--- a/azext_edge/edge/providers/rpsaas/user_strings.py
+++ b/azext_edge/edge/providers/rpsaas/user_strings.py
@@ -11,7 +11,7 @@ CLUSTER_NOT_FOUND_MSG = "Cluster associated with the custom location {0} not fou
     "The command may fail."
 CLUSTER_OFFLINE_MSG = "Cluster {0} is not connected. The cluster may not update correctly."
 MISSING_CLUSTER_CUSTOM_LOCATION_ERROR = "Need to provide either cluster name or custom location"
-MISSING_EXTENSION_ERROR = "Cluster {0} is missing the {1} extension with enabled features."
+MISSING_EXTENSION_ERROR = "Cluster {0} is missing the {1} extension with enabled {2} features."
 MULTIPLE_CUSTOM_LOCATIONS_ERROR = "The following custom locations were found for cluster {0}: \n{1}. "\
     "Please specify which custom location to use."
 MULTIPLE_POSSIBLE_ITEMS_ERROR = "Found {0} {1}s with the name {2}. Please provide the resource group "\

--- a/azext_edge/tests/edge/rpsaas/base/provider/test_check_cluster_and_custom_location_unit.py
+++ b/azext_edge/tests/edge/rpsaas/base/provider/test_check_cluster_and_custom_location_unit.py
@@ -58,7 +58,7 @@ def test_check_cluster_and_custom_location(
     from azext_edge.edge.providers.rpsaas.base_provider import RPSaaSBaseProvider
     extension_key = generate_random_string()
     ext_result = mocker.Mock()
-    ext_result.as_dict.return_value =  {
+    ext_result.as_dict.return_value = {
         "properties": {
             "configurationSettings": {f"{extension_key}.enabled": "true"},
             "extensionType": "microsoft.iotoperations"
@@ -236,7 +236,7 @@ def test_check_cluster_and_custom_location_no_extension_error(
     from azext_edge.edge.providers.rpsaas.base_provider import RPSaaSBaseProvider
     extension_key = generate_random_string()
     ext_result = mocker.Mock()
-    ext_result.as_dict.return_value =  {
+    ext_result.as_dict.return_value = {
         "properties": {
             "configurationSettings": {f"{extension_key}.enabled": str(extension_enabled).lower()},
             "extensionType": generate_random_string() if extension_enabled else "microsoft.iotoperations"

--- a/azext_edge/tests/edge/rpsaas/base/provider/test_check_cluster_connectivity_unit.py
+++ b/azext_edge/tests/edge/rpsaas/base/provider/test_check_cluster_connectivity_unit.py
@@ -80,8 +80,12 @@ def test_check_cluster_connectivity_no_location(mocked_cmd, mocked_build_query):
     "offline cluster"
 ], indirect=True)
 def test_check_cluster_connectivity(mocked_cmd, mocked_build_query):
-    from azext_edge.edge.providers.rpsaas.adr.base import ADRBaseProvider
-    provider = ADRBaseProvider(mocked_cmd, generate_random_string())
+    from azext_edge.edge.providers.rpsaas.base_provider import RPSaaSBaseProvider
+    provider = RPSaaSBaseProvider(
+        mocked_cmd,
+        generate_random_string(),
+        generate_random_string()
+    )
     custom_location_id = generate_random_string()
     provider.check_cluster_connectivity(custom_location_id)
     assert mocked_build_query.call_count == 2


### PR DESCRIPTION
Changed the RPSAAS extension check to see if "microsoft.iotoperations" is present and if "adr.enabled" is true.

quick and easy
![image](https://github.com/Azure/azure-iot-ops-cli-extension/assets/73560279/be786329-681b-4143-a4a3-75ea63b93728)



---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
