### PR TITLE
feat: Capture azure cluster config in support bundle

### DIFF
--- a/azext_edge/edge/providers/support/base.py
+++ b/azext_edge/edge/providers/support/base.py
@@ -290,7 +290,7 @@ def process_storage_classes() -> List[dict]:
     storage_class_content.append(
         {
             "data": generic.sanitize_for_serialization(obj=storage_v1_api.list_storage_class()),
-            "zinfo": "storage_classes.yaml",
+            "zinfo": "storage-classes.yaml",
         }
     )
 

--- a/azext_edge/edge/providers/support/shared.py
+++ b/azext_edge/edge/providers/support/shared.py
@@ -24,7 +24,7 @@ def process_arc_kpis():
         result.append(
             {
                 "data": connect_config_map,
-                "zinfo": "azure_clusterconfig.yaml",
+                "zinfo": f"{ARC_CONFIG_MAP}.yaml",
             }
         )
     return result

--- a/azext_edge/edge/providers/support/shared.py
+++ b/azext_edge/edge/providers/support/shared.py
@@ -5,13 +5,37 @@
 # ----------------------------------------------------------------------------------------------
 
 from knack.log import get_logger
-from .base import process_nodes, process_events, process_storage_classes
 
+from ..k8s.config_map import get_config_map
+from ..orchestration.base import ARC_CONFIG_MAP, ARC_NAMESPACE
+from .base import process_events, process_nodes, process_storage_classes
+
+# TODO: This label format doesn't belong here :(
 NAME_LABEL_FORMAT = "app.kubernetes.io/name in ({label})"
 
 logger = get_logger(__name__)
 
-support_shared_elements = {"nodes": process_nodes, "events": process_events, "storageclasses": process_storage_classes}
+
+def process_arc_kpis():
+    result = []
+    connect_config_map = get_config_map(name=ARC_CONFIG_MAP, namespace=ARC_NAMESPACE)
+
+    if connect_config_map:
+        result.append(
+            {
+                "data": connect_config_map,
+                "zinfo": "azure_clusterconfig.yaml",
+            }
+        )
+    return result
+
+
+support_shared_elements = {
+    "nodes": process_nodes,
+    "events": process_events,
+    "storageclasses": process_storage_classes,
+    "arc": process_arc_kpis,
+}
 
 
 def prepare_bundle() -> dict:

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -12,10 +12,7 @@ import pytest
 
 
 def add_pod_to_mocked_pods(
-    mocked_client,
-    expected_pod_map,
-    mock_names: List[str] = None,
-    mock_init_containers: bool = False
+    mocked_client, expected_pod_map, mock_names: List[str] = None, mock_init_containers: bool = False
 ):
     from kubernetes.client.models import V1PodList, V1Pod, V1PodSpec, V1ObjectMeta, V1Container
 
@@ -220,14 +217,14 @@ def mocked_get_custom_objects(mocker):
 def mocked_namespaced_custom_objects(mocked_client):
     def _handle_namespaced_custom_object(*args, **kwargs):
         custom_object = {
-            'kind': 'PodMetrics',
-            'apiVersion': 'metrics.k8s.io/v1beta1',
-            'metadata': {
-                'name': 'mock_custom_object',
-                'namespace': 'namespace',
-                'creationTimestamp': '0000-00-00T00:00:00Z',
+            "kind": "PodMetrics",
+            "apiVersion": "metrics.k8s.io/v1beta1",
+            "metadata": {
+                "name": "mock_custom_object",
+                "namespace": "namespace",
+                "creationTimestamp": "0000-00-00T00:00:00Z",
             },
-            'timestamp': '0000-00-00T00:00:00Z'
+            "timestamp": "0000-00-00T00:00:00Z",
         }
 
         return custom_object
@@ -457,3 +454,10 @@ def mocked_mq_get_traces(mocker):
     patched_get_traces = mocker.patch("azext_edge.edge.providers.support.mq.get_traces")
     patched_get_traces.return_value = [(test_zipinfo, "trace_data")]
     yield patched_get_traces
+
+
+@pytest.fixture
+def mocked_get_config_map(mocker):
+    patched = mocker.patch("azext_edge.edge.providers.support.shared.get_config_map", autospec=True)
+    patched.return_value = {"configkey": "configvalue"}
+    yield patched

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -768,12 +768,12 @@ def assert_shared_kpis(mocked_client, mocked_zipfile):
     mocked_client.StorageV1Api().list_storage_class.assert_called_once()
     assert_zipfile_write(
         mocked_zipfile,
-        zinfo="storage_classes.yaml",
+        zinfo="storage-classes.yaml",
         data="items:\n- metadata:\n    name: mock_storage_class\n  provisioner: mock_provisioner\n",
     )
     assert_zipfile_write(
         mocked_zipfile,
-        zinfo="azure_clusterconfig.yaml",
+        zinfo="azure-clusterconfig.yaml",
         data='configkey: configvalue\n',
     )
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -9,6 +9,7 @@ import random
 from os.path import abspath, expanduser, join
 from typing import List, Optional, Union
 from zipfile import ZipInfo
+from unittest.mock import Mock
 
 import pytest
 from azure.cli.core.azclierror import ResourceNotFoundError
@@ -101,6 +102,7 @@ def test_create_bundle(
     mocked_root_logger,
     mocked_mq_active_api,
     mocked_namespaced_custom_objects,
+    mocked_get_config_map: Mock,
 ):
     # TODO: clean up label once all service labels become stable
     asset_raises_not_found_error(mocked_cluster_resources)
@@ -461,6 +463,8 @@ def test_create_bundle(
 
     # assert shared KPIs regardless of service
     assert_shared_kpis(mocked_client, mocked_zipfile)
+    # Using a divergent pattern for cluster config since its mock is at a higher level.
+    mocked_get_config_map.assert_called_with(name='azure-clusterconfig', namespace='azure-arc')
 
 
 def asset_raises_not_found_error(mocked_cluster_resources):
@@ -767,6 +771,11 @@ def assert_shared_kpis(mocked_client, mocked_zipfile):
         zinfo="storage_classes.yaml",
         data="items:\n- metadata:\n    name: mock_storage_class\n  provisioner: mock_provisioner\n",
     )
+    assert_zipfile_write(
+        mocked_zipfile,
+        zinfo="azure_clusterconfig.yaml",
+        data='configkey: configvalue\n',
+    )
 
 
 # TODO: base test class?
@@ -899,6 +908,7 @@ def test_create_bundle_mq_traces(
     mocked_root_logger,
     mocked_mq_active_api,
     mocked_mq_get_traces,
+    mocked_get_config_map,
 ):
     result = support_bundle(None, bundle_dir=a_bundle_dir, include_mq_traces=True)
 


### PR DESCRIPTION
* Captures azure-clusterconfig config map as a means to easily associate edge side with cloud side. Also useful details such as arc agent version.
* Also has a minor breaking change on renaming the archived storage_classes.yaml to storage-classes.yaml for consistency. 