### PR TITLE
feat: Add dataflow capture in support bundle and update mqtt common label

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -17,6 +17,7 @@ from .providers.support_bundle import (
     COMPAT_MQTT_BROKER_APIS,
     COMPAT_OPCUA_APIS,
     COMPAT_ORC_APIS,
+    COMPAT_DATAFLOW_APIS,
 )
 
 
@@ -56,6 +57,7 @@ def load_iotops_help():
             - {COMPAT_AKRI_APIS.as_str()}
             - {COMPAT_DEVICEREGISTRY_APIS.as_str()}
             - {COMPAT_CLUSTER_CONFIG_APIS.as_str()}
+            - {COMPAT_DATAFLOW_APIS.as_str()}
 
         examples:
         - name: Basic usage with default options. This form of the command will auto detect IoT Operations APIs and build a suitable bundle

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -145,6 +145,7 @@ class OpsServiceType(ListableEnum):
     orc = "orc"
     akri = "akri"
     deviceregistry = "deviceregistry"
+    dataflow = "dataflow"
     # TODO: re-enable billing once service is available post 0.6.0 release
     # billing = "billing"
 

--- a/azext_edge/edge/providers/edge_api/__init__.py
+++ b/azext_edge/edge/providers/edge_api/__init__.py
@@ -12,6 +12,7 @@ from .orc import ORC_API_V1, OrcResourceKinds
 from .akri import AKRI_API_V0, AkriResourceKinds
 from .keyvault import KEYVAULT_API_V1, KeyVaultResourceKinds
 from .deviceregistry import DEVICEREGISTRY_API_V1, DeviceRegistryResourceKinds
+from .dataflow import DATAFLOW_API_V1B1, DataflowResourceKinds
 
 __all__ = [
     "CLUSTER_CONFIG_API_V1",
@@ -30,4 +31,6 @@ __all__ = [
     "KEYVAULT_API_V1",
     "DeviceRegistryResourceKinds",
     "DEVICEREGISTRY_API_V1",
+    "DATAFLOW_API_V1B1",
+    "DataflowResourceKinds",
 ]

--- a/azext_edge/edge/providers/edge_api/dataflow.py
+++ b/azext_edge/edge/providers/edge_api/dataflow.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from .base import EdgeResourceApi
+from ...common import ListableEnum
+
+
+class DataflowResourceKinds(ListableEnum):
+    DATAFLOWENDPOINT = "dataflowendpoint"
+    DATAFLOWPROFILE = "dataflowprofile"
+    DATAFLOW = "dataflow"
+
+
+DATAFLOW_API_V1B1 = EdgeResourceApi(
+    group="connectivity.iotoperations.azure.com", version="v1beta1", moniker="dataflow", label="microsoft-iotoperations-dataflows"
+)

--- a/azext_edge/edge/providers/edge_api/dataflow.py
+++ b/azext_edge/edge/providers/edge_api/dataflow.py
@@ -15,5 +15,8 @@ class DataflowResourceKinds(ListableEnum):
 
 
 DATAFLOW_API_V1B1 = EdgeResourceApi(
-    group="connectivity.iotoperations.azure.com", version="v1beta1", moniker="dataflow", label="microsoft-iotoperations-dataflows"
+    group="connectivity.iotoperations.azure.com",
+    version="v1beta1",
+    moniker="dataflow",
+    label="microsoft-iotoperations-dataflows"
 )

--- a/azext_edge/edge/providers/edge_api/mq.py
+++ b/azext_edge/edge/providers/edge_api/mq.py
@@ -27,7 +27,7 @@ MQTT_BROKER_API_V1B1 = EdgeResourceApi(
     group="mqttbroker.iotoperations.azure.com",
     version="v1beta1",
     moniker="broker",
-    label="microsoft-iotoperations-mq",
+    label="microsoft-iotoperations-mqttbroker",
 )
 
 MQ_ACTIVE_API = MQTT_BROKER_API_V1B1

--- a/azext_edge/edge/providers/support/dataflow.py
+++ b/azext_edge/edge/providers/support/dataflow.py
@@ -5,23 +5,16 @@
 # ----------------------------------------------------------------------------------------------
 
 from functools import partial
-from typing import Iterable, Optional
-from zipfile import ZipInfo
+from typing import Iterable
 
 from knack.log import get_logger
 
-from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
-
 from ..edge_api import DATAFLOW_API_V1B1, EdgeResourceApi
-from ..stats import get_stats, get_traces
 from .base import (
     DAY_IN_SECONDS,
     assemble_crd_work,
-    get_mq_namespaces,
     process_deployments,
     process_replicasets,
-    process_services,
-    process_statefulset,
     process_v1_pods,
 )
 from .shared import NAME_LABEL_FORMAT
@@ -41,7 +34,7 @@ def fetch_deployments():
 
     # TODO: remove this once dataflow deployment label is fixed
     processed.extend(
-            process_deployments(
+        process_deployments(
             directory_path=DATAFLOW_DIRECTORY_PATH,
             field_selector=DATAFLOW_DEPLOYMENT_FIELD_SELECTOR,
         )

--- a/azext_edge/edge/providers/support/dataflow.py
+++ b/azext_edge/edge/providers/support/dataflow.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from functools import partial
+from typing import Iterable, Optional
+from zipfile import ZipInfo
+
+from knack.log import get_logger
+
+from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
+
+from ..edge_api import DATAFLOW_API_V1B1, EdgeResourceApi
+from ..stats import get_stats, get_traces
+from .base import (
+    DAY_IN_SECONDS,
+    assemble_crd_work,
+    get_mq_namespaces,
+    process_deployments,
+    process_replicasets,
+    process_services,
+    process_statefulset,
+    process_v1_pods,
+)
+from .shared import NAME_LABEL_FORMAT
+
+logger = get_logger(__name__)
+
+DATAFLOW_NAME_LABEL = NAME_LABEL_FORMAT.format(label=DATAFLOW_API_V1B1.label)
+DATAFLOW_DIRECTORY_PATH = DATAFLOW_API_V1B1.moniker
+DATAFLOW_DEPLOYMENT_FIELD_SELECTOR = "metadata.name=aio-dataflow-operator"
+
+
+def fetch_deployments():
+    processed = process_deployments(
+        directory_path=DATAFLOW_DIRECTORY_PATH,
+        label_selector=DATAFLOW_NAME_LABEL,
+    )
+
+    # TODO: remove this once dataflow deployment label is fixed
+    processed.extend(
+            process_deployments(
+            directory_path=DATAFLOW_DIRECTORY_PATH,
+            field_selector=DATAFLOW_DEPLOYMENT_FIELD_SELECTOR,
+        )
+    )
+
+    return processed
+
+
+def fetch_replicasets():
+    return process_replicasets(
+        directory_path=DATAFLOW_DIRECTORY_PATH,
+        label_selector=DATAFLOW_NAME_LABEL,
+    )
+
+
+def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
+    return process_v1_pods(
+        directory_path=DATAFLOW_DIRECTORY_PATH,
+        label_selector=DATAFLOW_NAME_LABEL,
+        since_seconds=since_seconds,
+    )
+
+
+support_runtime_elements = {
+    "deployments": fetch_deployments,
+    "replicasets": fetch_replicasets,
+}
+
+
+def prepare_bundle(
+    apis: Iterable[EdgeResourceApi], log_age_seconds: int = DAY_IN_SECONDS
+) -> dict:
+    dataflow_to_run = {}
+    dataflow_to_run.update(assemble_crd_work(apis))
+
+    support_runtime_elements["pods"] = partial(fetch_pods, since_seconds=log_age_seconds)
+    dataflow_to_run.update(support_runtime_elements)
+
+    return dataflow_to_run

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -36,6 +36,7 @@ MQ_APP_LABELS = [
 ]
 
 MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
+MQ_K8S_LABEL = "k8s-app in (aio-mq-fluent-bit)"
 
 MQ_NAME_LABEL = NAME_LABEL_FORMAT.format(label=MQ_ACTIVE_API.label)
 MQ_DIRECTORY_PATH = MQ_ACTIVE_API.moniker
@@ -153,6 +154,15 @@ def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
         process_v1_pods(
             directory_path=MQ_DIRECTORY_PATH,
             label_selector=MQ_NAME_LABEL,
+            since_seconds=since_seconds,
+        )
+    )
+
+    # TODO: @jiacju - will remove once label decision is finalized
+    processed.extend(
+        process_v1_pods(
+            directory_path=MQ_DIRECTORY_PATH,
+            label_selector=MQ_K8S_LABEL,
             since_seconds=since_seconds,
         )
     )

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -19,6 +19,7 @@ from ..providers.edge_api import (
     ORC_API_V1,
     AKRI_API_V0,
     DEVICEREGISTRY_API_V1,
+    DATAFLOW_API_V1B1,
     EdgeApiManager,
 )
 
@@ -32,6 +33,7 @@ COMPAT_OPCUA_APIS = EdgeApiManager(resource_apis=[OPCUA_API_V1])
 COMPAT_ORC_APIS = EdgeApiManager(resource_apis=[ORC_API_V1])
 COMPAT_AKRI_APIS = EdgeApiManager(resource_apis=[AKRI_API_V0])
 COMPAT_DEVICEREGISTRY_APIS = EdgeApiManager(resource_apis=[DEVICEREGISTRY_API_V1])
+COMPAT_DATAFLOW_APIS = EdgeApiManager(resource_apis=[DATAFLOW_API_V1B1])
 
 
 def build_bundle(
@@ -47,6 +49,7 @@ def build_bundle(
     from .support.mq import prepare_bundle as prepare_mq_bundle
     from .support.opcua import prepare_bundle as prepare_opcua_bundle
     from .support.orc import prepare_bundle as prepare_symphony_bundle
+    from .support.dataflow import prepare_bundle as prepare_dataflow_bundle
     from .support.deviceregistry import prepare_bundle as prepare_deviceregistry_bundle
     from .support.shared import prepare_bundle as prepare_shared_bundle
     from .support.akri import prepare_bundle as prepare_akri_bundle
@@ -72,6 +75,7 @@ def build_bundle(
             "apis": COMPAT_DEVICEREGISTRY_APIS,
             "prepare_bundle": prepare_deviceregistry_bundle,
         },
+        OpsServiceType.dataflow.value: {"apis": COMPAT_DATAFLOW_APIS, "prepare_bundle": prepare_dataflow_bundle},
     }
 
     raise_on_404 = not (ops_service == OpsServiceType.auto.value)

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -229,7 +229,7 @@ def process_top_levels(
     walk_result: Dict[str, Dict[str, List[str]]], ops_service: str
 ) -> NamespaceTuple:
     level_0 = walk_result.pop(BASE_ZIP_PATH)
-    for file in ["events.yaml", "nodes.yaml", "storage_classes.yaml"]:
+    for file in ["events.yaml", "nodes.yaml", "storage-classes.yaml", "azure-clusterconfig.yaml"]:
         assert file in level_0["files"]
     if not level_0["folders"]:
         pytest.skip(f"No bundles created for {ops_service}.")

--- a/azext_edge/tests/edge/support/create_bundle_int/test_dataflow_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_dataflow_int.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from knack.log import get_logger
+from azext_edge.edge.common import OpsServiceType
+from azext_edge.edge.providers.edge_api import DATAFLOW_API_V1B1
+from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, run_bundle_command
+
+logger = get_logger(__name__)
+
+
+def test_create_bundle_dataflow(init_setup, tracked_files):
+    """Test for ensuring file names and content. ONLY CHECKS dataflow."""
+    ops_service = OpsServiceType.dataflow.value
+    command = f"az iot ops support create-bundle --ops-service {ops_service}"
+    walk_result = run_bundle_command(command=command, tracked_files=tracked_files)
+    file_map = get_file_map(walk_result, ops_service)["aio"]
+
+    check_custom_resource_files(
+        file_objs=file_map,
+        resource_api=DATAFLOW_API_V1B1
+    )
+
+    expected_workload_types = ["deployment", "pod", "replicaset"]
+    expected_types = set(expected_workload_types).union(DATAFLOW_API_V1B1.kinds)
+    assert set(file_map.keys()).issubset(expected_types)
+    check_workload_resource_files(
+        file_objs=file_map,
+        expected_workload_types=expected_workload_types,
+        prefixes=["aio-dataflow"],
+    )

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -24,6 +24,7 @@ from azext_edge.edge.providers.edge_api import (
     MQTT_BROKER_API_V1B1,
     OPCUA_API_V1,
     ORC_API_V1,
+    DATAFLOW_API_V1B1,
     EdgeResourceApi,
 )
 from azext_edge.edge.providers.support.akri import (
@@ -42,7 +43,7 @@ from azext_edge.edge.providers.support.billing import (
     ARC_BILLING_DIRECTORY_PATH,
     BILLING_RESOURCE_KIND,
 )
-from azext_edge.edge.providers.support.mq import MQ_DIRECTORY_PATH, MQ_LABEL, MQ_NAME_LABEL
+from azext_edge.edge.providers.support.mq import MQ_DIRECTORY_PATH, MQ_K8S_LABEL, MQ_LABEL, MQ_NAME_LABEL
 from azext_edge.edge.providers.support.opcua import (
     OPC_APP_LABEL,
     OPC_DIRECTORY_PATH,
@@ -191,6 +192,14 @@ def test_create_bundle(
                 mocked_zipfile,
                 mocked_list_pods,
                 label_selector=MQ_NAME_LABEL,
+                directory_path=MQ_DIRECTORY_PATH,
+                since_seconds=since_seconds,
+            )
+            assert_list_pods(
+                mocked_client,
+                mocked_zipfile,
+                mocked_list_pods,
+                label_selector=MQ_K8S_LABEL,
                 directory_path=MQ_DIRECTORY_PATH,
                 since_seconds=since_seconds,
             )
@@ -456,6 +465,35 @@ def test_create_bundle(
                 mocked_zipfile,
                 label_selector=AKRI_NAME_LABEL_V2,
                 directory_path=AKRI_DIRECTORY_PATH,
+            )
+        
+        if api in [DATAFLOW_API_V1B1]:
+            assert_list_deployments(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=DATAFLOW_API_V1B1.label,
+                directory_path=DATAFLOW_API_V1B1.moniker,
+            )
+            assert_list_deployments(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=None,
+                directory_path=DATAFLOW_API_V1B1.moniker,
+                mock_names=["aio-dataflow-operator"],
+            )
+            assert_list_replica_sets(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=DATAFLOW_API_V1B1.label,
+                directory_path=DATAFLOW_API_V1B1.moniker,
+            )
+            assert_list_pods(
+                mocked_client,
+                mocked_zipfile,
+                mocked_list_pods,
+                label_selector=DATAFLOW_API_V1B1.label,
+                directory_path=DATAFLOW_API_V1B1.moniker,
+                since_seconds=since_seconds,
             )
 
     if expected_resources:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -466,7 +466,7 @@ def test_create_bundle(
                 label_selector=AKRI_NAME_LABEL_V2,
                 directory_path=AKRI_DIRECTORY_PATH,
             )
-        
+
         if api in [DATAFLOW_API_V1B1]:
             assert_list_deployments(
                 mocked_client,


### PR DESCRIPTION
1. Update mqttbroker common label
2. Add dataflow capture in support bundle
3. Fix int failure for previous PR

Issue found on service side:
1. mqttbroker missing common label for aio-mq-fluent-bit pod
2. mqttbroker didn't remove old connecter resources
3. dataflow missing common label for aio-dataflow operator
1 pending on response, 2 will be fixed later. before the decision made I will capture them using other label/field
3 will be removed soon as well, before that I will keep support bundle as it is

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
