### PR TITLE
chore: improve clean up pipeline

### DIFF
--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -31,8 +31,8 @@ on:
         required: true
         default: ops-cli-int-test-rg
   # Run every night at midnight (Pacific) to cleanup resources
-  schedule:
-    - cron: '0 8 * * *'
+  # schedule:
+  #   - cron: '0 8 * * *'
 
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}
@@ -72,7 +72,13 @@ jobs:
       - name: Delete keyvaults
         run: |
           for vault in $(az keyvault list --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
+            # we can get the recently deleted ones next run
             az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }} --no-wait
+          done
+      - name: Purge keyvaults
+        run: |
+          for vault in $(az keyvault list-deleted --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
+            az keyvault purge -n $vault --no-wait
           done
   resource-cleanup:
     needs: [arc-cleanup]
@@ -110,7 +116,7 @@ jobs:
         run: |
           mq_type="Microsoft.IoTOperationsMQ/mq"
           in_cluster_ext_loc="contains(to_string(extendedLocation.name), '${{ env.CLUSTER_PREFIX }}')"
-          
+
           # MQ instance cannot be deleted until all child resources have successfully deleted
           sleep 15s
 

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -30,6 +30,10 @@ on:
         description: "Resource group to clean up"
         required: true
         default: ops-cli-int-test-rg
+      keyvault_prefix:
+          type: string
+          description: "Prefix of keyvault to delete"
+          required: false
   # Run every night at midnight (Pacific) to cleanup resources
   # schedule:
   #   - cron: '0 8 * * *'

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -36,8 +36,8 @@ on:
         default: "opskv"
         required: false
   # Run every night at midnight (Pacific) to cleanup resources
-  # schedule:
-  #   - cron: '0 8 * * *'
+  schedule:
+    - cron: '0 8 * * *'
 
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Delete keyvaults
         run: |
           for vault in $(az keyvault list --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
-            # we can get the recently deleted ones next run
-            az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }} --no-wait
+            az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }}
           done
       - name: Purge keyvaults
         run: |

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -42,6 +42,7 @@ on:
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}
   CLUSTER_PREFIX: ${{ inputs.cluster_prefix || 'az-iot-ops-test-cluster' }}
+  KEYVAULT_PREFIX: ${{ inputs.keyvault_prefix || 'opskv' }}
 
 permissions:
   # required for OpenID federation
@@ -75,12 +76,12 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Delete keyvaults
         run: |
-          for vault in $(az keyvault list --query "[?starts_with(name, '${{ inputs.keyvault_prefix }}')].name" -o tsv); do
+          for vault in $(az keyvault list -g ${{ env.RESOURCE_GROUP }} --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
             az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }}
           done
       - name: Purge keyvaults
         run: |
-          for vault in $(az keyvault list-deleted --query "[?starts_with(name, '${{ inputs.keyvault_prefix }}')].name" -o tsv); do
+          for vault in $(az keyvault list-deleted --query "[?contains(properties.vaultId, '${{ env.RESOURCE_GROUP }}')] | [?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
             az keyvault purge -n $vault --no-wait
           done
   resource-cleanup:

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -31,9 +31,10 @@ on:
         required: true
         default: ops-cli-int-test-rg
       keyvault_prefix:
-          type: string
-          description: "Prefix of keyvault to delete"
-          required: false
+        type: string
+        description: "Prefix of keyvault to delete"
+        default: "opskv"
+        required: false
   # Run every night at midnight (Pacific) to cleanup resources
   # schedule:
   #   - cron: '0 8 * * *'
@@ -41,7 +42,6 @@ on:
 env:
   RESOURCE_GROUP: ${{ inputs.resource_group || 'ops-cli-int-test-rg' }}
   CLUSTER_PREFIX: ${{ inputs.cluster_prefix || 'az-iot-ops-test-cluster' }}
-  KEYVAULT_PREFIX: ${{ inputs.keyvault_prefix || 'opskv' }}
 
 permissions:
   # required for OpenID federation
@@ -75,12 +75,12 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Delete keyvaults
         run: |
-          for vault in $(az keyvault list --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
+          for vault in $(az keyvault list --query "[?starts_with(name, '${{ inputs.keyvault_prefix }}')].name" -o tsv); do
             az keyvault delete -n $vault -g ${{ env.RESOURCE_GROUP }}
           done
       - name: Purge keyvaults
         run: |
-          for vault in $(az keyvault list-deleted --query "[?starts_with(name, '${{ env.KEYVAULT_PREFIX }}')].name" -o tsv); do
+          for vault in $(az keyvault list-deleted --query "[?starts_with(name, '${{ inputs.keyvault_prefix }}')].name" -o tsv); do
             az keyvault purge -n $vault --no-wait
           done
   resource-cleanup:


### PR DESCRIPTION
Ensure clean up pipeline also purges keyvaults. Purge allows us to reuse keyvault names (and avoid clashing between pipeline runs).

To allow purging, the no-wait for keyvault deletion has been removed. 

The general clean-up is kept as a backup for missed resources from `az iot ops delete` (ex: the command fails).
 
 Keyvaults after the cleanup pipeline:
![image](https://github.com/user-attachments/assets/4c300104-1f58-42ee-8e02-3796bb9f5632)

 Note: the extra keyvault prefix input is temporary and will be removed once we have all keyvaults using the same one again (we had to diverge and use different ones due to clashes)

Note 2: Since the purge has a --no-wait, the purge may take some time and the results are not instantaneous.


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
