### PR TITLE
fix: Broker statefulsets support bundle fix

### DIFF
--- a/azext_edge/edge/providers/base.py
+++ b/azext_edge/edge/providers/base.py
@@ -75,7 +75,7 @@ _namespaced_pods_cache: dict = {}
 def get_namespaced_pods_by_prefix(
     prefix: str,
     namespace: str,
-    label_selector: str = None,
+    label_selector: Optional[str] = None,
     as_dict: bool = False,
 ) -> Union[List[V1Pod], List[dict], None]:
     def filter_pods_by_prefix(pods: List[V1Pod], prefix: str) -> List[V1Pod]:

--- a/azext_edge/edge/providers/check/base/pod.py
+++ b/azext_edge/edge/providers/check/base/pod.py
@@ -7,7 +7,7 @@
 from knack.log import get_logger
 from rich.padding import Padding
 from kubernetes.client.models import V1Pod
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from .check_manager import CheckManager
 from .display import add_display_and_eval
@@ -32,7 +32,7 @@ def evaluate_pod_health(
     target: str,
     pod: str,
     display_padding: int,
-    service_label: str = None,
+    service_label: Optional[str] = None,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
 ) -> None:
     target_service_pod = f"pod/{pod}"

--- a/azext_edge/edge/providers/check/base/pod.py
+++ b/azext_edge/edge/providers/check/base/pod.py
@@ -32,7 +32,7 @@ def evaluate_pod_health(
     target: str,
     pod: str,
     display_padding: int,
-    service_label: str,
+    service_label: str = None,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
 ) -> None:
     target_service_pod = f"pod/{pod}"

--- a/azext_edge/edge/providers/check/cloud_connectors.py
+++ b/azext_edge/edge/providers/check/cloud_connectors.py
@@ -10,7 +10,6 @@ from rich.padding import Padding
 
 from ...common import AIO_MQ_RESOURCE_PREFIX, CheckTaskStatus
 from ...providers.edge_api import MQ_ACTIVE_API, MqResourceKinds
-from ..support.mq import MQ_LABEL
 from .base import (
     CheckManager,
     evaluate_pod_health,
@@ -257,7 +256,6 @@ def _display_connector_runtime_health(
                 namespace=namespace,
                 pod=pod,
                 display_padding=padding,
-                service_label=MQ_LABEL,
                 detail_level=detail_level,
             )
 

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -87,21 +87,17 @@ def fetch_statefulsets():
 
 
 def fetch_services():
-    processed = process_services(
+    return process_services(
         directory_path=MQ_DIRECTORY_PATH,
         label_selector=MQ_NAME_LABEL,
     )
-
-    return processed
 
 
 def fetch_replicasets():
-    processed = process_replicasets(
+    return process_replicasets(
         directory_path=MQ_DIRECTORY_PATH,
         label_selector=MQ_NAME_LABEL,
     )
-
-    return processed
 
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -10,9 +10,6 @@ from zipfile import ZipInfo
 
 from knack.log import get_logger
 
-from azext_edge.edge.common import AIO_MQ_RESOURCE_PREFIX
-from azext_edge.edge.providers.edge_api.mq import MqResourceKinds
-
 from ..edge_api import MQ_ACTIVE_API, EdgeResourceApi
 from ..stats import get_stats, get_traces
 from .base import (
@@ -28,14 +25,6 @@ from .shared import NAME_LABEL_FORMAT
 
 logger = get_logger(__name__)
 
-# TODO: @jiacju - will remove old labels once new labels are stabled
-MQ_APP_LABELS = [
-    "aio-mq-mqttbridge",
-    "aio-mq-datalake",
-    "aio-mq-kafka-connector",
-]
-
-MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
 MQ_K8S_LABEL = "k8s-app in (aio-mq-fluent-bit)"
 
 MQ_NAME_LABEL = NAME_LABEL_FORMAT.format(label=MQ_ACTIVE_API.label)
@@ -89,23 +78,6 @@ def fetch_statefulsets():
         return_namespaces=True,
     )
 
-    # bridge connector stateful sets have no labels
-    connectors = []
-    for kind in [
-        MqResourceKinds.DATALAKE_CONNECTOR,
-        MqResourceKinds.KAFKA_CONNECTOR,
-        MqResourceKinds.MQTT_BRIDGE_CONNECTOR,
-    ]:
-        connectors.extend(MQ_ACTIVE_API.get_resources(kind=kind).get("items", []))
-
-    for connector in connectors:
-        connector_name = connector.get("metadata", {}).get("name")
-        stateful_set = process_statefulset(
-            directory_path=MQ_DIRECTORY_PATH,
-            field_selector=f"metadata.name={AIO_MQ_RESOURCE_PREFIX}{connector_name}",
-        )
-        processed.extend(stateful_set)
-
     for namespace in namespaces:
         metrics = fetch_diagnostic_metrics(namespace)
         if metrics:
@@ -117,13 +89,7 @@ def fetch_statefulsets():
 def fetch_services():
     processed = process_services(
         directory_path=MQ_DIRECTORY_PATH,
-        label_selector=MQ_LABEL,
-    )
-    processed.extend(
-        process_services(
-            directory_path=MQ_DIRECTORY_PATH,
-            label_selector=MQ_NAME_LABEL,
-        )
+        label_selector=MQ_NAME_LABEL,
     )
 
     return processed
@@ -132,13 +98,7 @@ def fetch_services():
 def fetch_replicasets():
     processed = process_replicasets(
         directory_path=MQ_DIRECTORY_PATH,
-        label_selector=MQ_LABEL,
-    )
-    processed.extend(
-        process_replicasets(
-            directory_path=MQ_DIRECTORY_PATH,
-            label_selector=MQ_NAME_LABEL,
-        )
+        label_selector=MQ_NAME_LABEL,
     )
 
     return processed
@@ -147,15 +107,8 @@ def fetch_replicasets():
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
     processed = process_v1_pods(
         directory_path=MQ_DIRECTORY_PATH,
-        label_selector=MQ_LABEL,
+        label_selector=MQ_NAME_LABEL,
         since_seconds=since_seconds,
-    )
-    processed.extend(
-        process_v1_pods(
-            directory_path=MQ_DIRECTORY_PATH,
-            label_selector=MQ_NAME_LABEL,
-            since_seconds=since_seconds,
-        )
     )
 
     # TODO: @jiacju - will remove once label decision is finalized


### PR DESCRIPTION
This fixes broker support bundles not capturing stateful sets because of an error in processing legacy connector resources.

Also removed the legacy connector labels from other broker support bundle collectors

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
