### PR TITLE
fix: Update support bundle for broker and dataflow

### DIFF
--- a/azext_edge/edge/providers/support/dataflow.py
+++ b/azext_edge/edge/providers/support/dataflow.py
@@ -23,7 +23,6 @@ logger = get_logger(__name__)
 
 DATAFLOW_NAME_LABEL = NAME_LABEL_FORMAT.format(label=DATAFLOW_API_V1B1.label)
 DATAFLOW_DIRECTORY_PATH = DATAFLOW_API_V1B1.moniker
-DATAFLOW_DEPLOYMENT_FIELD_SELECTOR = "metadata.name=aio-dataflow-operator"
 
 
 def fetch_deployments():
@@ -36,7 +35,7 @@ def fetch_deployments():
     processed.extend(
         process_deployments(
             directory_path=DATAFLOW_DIRECTORY_PATH,
-            field_selector=DATAFLOW_DEPLOYMENT_FIELD_SELECTOR,
+            label_selector=DATAFLOW_NAME_LABEL,
         )
     )
 

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -20,6 +20,7 @@ from .base import (
     process_services,
     process_statefulset,
     process_v1_pods,
+    process_daemonsets,
 )
 from .shared import NAME_LABEL_FORMAT
 
@@ -86,6 +87,13 @@ def fetch_statefulsets():
     return processed
 
 
+def fetch_daemonsets():
+    return process_daemonsets(
+        directory_path=MQ_DIRECTORY_PATH,
+        label_selector=MQ_NAME_LABEL,
+    )
+
+
 def fetch_services():
     return process_services(
         directory_path=MQ_DIRECTORY_PATH,
@@ -123,6 +131,7 @@ support_runtime_elements = {
     "statefulsets": fetch_statefulsets,
     "replicasets": fetch_replicasets,
     "services": fetch_services,
+    "daemonsets": fetch_daemonsets,
 }
 
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
@@ -40,7 +40,7 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
         resource_api=MQ_ACTIVE_API
     )
 
-    expected_workload_types = ["pod", "replicaset", "service", "statefulset"]
+    expected_workload_types = ["pod", "daemonset", "replicaset", "service", "statefulset"]
     expected_types = set(expected_workload_types).union(MQ_ACTIVE_API.kinds)
     assert set(file_map.keys()).issubset(expected_types)
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -228,6 +228,12 @@ def test_create_bundle(
                 label_selector=MQ_NAME_LABEL,
                 directory_path=MQ_DIRECTORY_PATH
             )
+            assert_list_daemon_sets(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=MQ_NAME_LABEL,
+                directory_path=MQ_DIRECTORY_PATH,
+            )
             assert_mq_stats(mocked_zipfile)
 
         if api in [OPCUA_API_V1]:
@@ -474,7 +480,7 @@ def test_create_bundle(
             assert_list_deployments(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=None,
+                label_selector=DATAFLOW_API_V1B1.label,
                 directory_path=DATAFLOW_API_V1B1.moniker,
                 mock_names=["aio-dataflow-operator"],
             )


### PR DESCRIPTION
1. update dataflow deployment to use the common label
2. update broker to capture fluent bit daemonset

verified all runtime resources are captured for broker and dataflow with latest image version

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
