### PR TITLE
fix: eliminate repeated target conditions in device registry check

### DIFF
--- a/azext_edge/tests/edge/checks/test_deviceregistry_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_deviceregistry_checks_unit.py
@@ -117,7 +117,7 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                 },
             ],
             # namespace conditions str
-            ["spec.assetEndpointProfileUri", 'len(spec.dataPoints)', "spec.dataPoints.[0].dataSource"],
+            ["spec.assetEndpointProfileUri", 'len(spec.dataPoints)'],
             # namespace evaluations str
             [
                 [
@@ -202,7 +202,7 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                 },
             ],
             # namespace conditions str
-            ["spec.assetEndpointProfileUri", "len(spec.events)", "spec.events.[0].eventNotifier"],
+            ["spec.assetEndpointProfileUri", "len(spec.events)"],
             # namespace evaluations str
             [
                 [


### PR DESCRIPTION
Added flag to prevent conditions to be add repeatedly everytime a new CRD instance is being iterated

example: when there are more than one CRD instance, now the repeat conditions got fixed:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/56517c58-0ad1-4aab-be56-f09faae100a1">
<img width="364" alt="image" src="https://github.com/user-attachments/assets/2613de50-587a-4562-b0cb-135063395e4c">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
