### PR TITLE
test: fix pre-check integration test

### DIFF
--- a/azext_edge/tests/edge/checks/int/test_pre_post_int.py
+++ b/azext_edge/tests/edge/checks/int/test_pre_post_int.py
@@ -81,12 +81,9 @@ def test_check_pre_post(init_setup, post, pre):
     assert "_all_" in node_result["targets"]["cluster/nodes"]
     node_count_target = node_result["targets"]["cluster/nodes"]["_all_"]
     assert node_count_target["conditions"] == ["len(cluster/nodes)>=1"]
-    assert node_count_target["evaluations"][0]["value"] == len(kubectl_nodes)
-    final_status = expected_status(
-        success_or_fail=len(kubectl_nodes) >= 1,
-        success_or_warning=len(kubectl_nodes) == 1
-    )
-    assert node_count_target["evaluations"][0]["status"] == node_count_target["status"] == final_status
+    assert not node_count_target["evaluations"]
+    final_status = expected_status(success_or_fail=len(kubectl_nodes) >= 1)
+    assert node_count_target["status"] == final_status
 
     # node eval
     for node in kubectl_nodes:


### PR DESCRIPTION
idk what to say
![image](https://github.com/user-attachments/assets/7c7dfb65-a103-4a53-91c7-d821a0c26e9d)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
