### PR TITLE
fix: exclude meta resource job from billing support bundle using prefix name

### DIFF
--- a/azext_edge/edge/providers/support/billing.py
+++ b/azext_edge/edge/providers/support/billing.py
@@ -57,6 +57,7 @@ def fetch_jobs():
     processed = process_jobs(
         directory_path=BILLING_RESOURCE_KIND,
         label_selector=AIO_BILLING_USAGE_NAME_LABEL,
+        prefix_names=[AIO_USAGE_PREFIX],
     )
 
     return processed

--- a/azext_edge/edge/providers/support/dataflow.py
+++ b/azext_edge/edge/providers/support/dataflow.py
@@ -31,6 +31,14 @@ def fetch_deployments():
         label_selector=DATAFLOW_NAME_LABEL,
     )
 
+    # TODO: remove this once dataflow deployment label is fixed
+    processed.extend(
+        process_deployments(
+            directory_path=DATAFLOW_DIRECTORY_PATH,
+            label_selector=DATAFLOW_NAME_LABEL,
+        )
+    )
+
     return processed
 
 

--- a/azext_edge/edge/providers/support/dataflow.py
+++ b/azext_edge/edge/providers/support/dataflow.py
@@ -31,14 +31,6 @@ def fetch_deployments():
         label_selector=DATAFLOW_NAME_LABEL,
     )
 
-    # TODO: remove this once dataflow deployment label is fixed
-    processed.extend(
-        process_deployments(
-            directory_path=DATAFLOW_DIRECTORY_PATH,
-            label_selector=DATAFLOW_NAME_LABEL,
-        )
-    )
-
     return processed
 
 

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -334,13 +334,6 @@ def mocked_list_services(mocked_client):
                     "opcplc-0000000",
                 ]
             )
-        
-        if "label_selector" in kwargs and kwargs["label_selector"] == "app.kubernetes.io/name in (microsoft-iotoperations)":
-            service_names.extend(
-                [
-                    "aio-operator-service",
-                ]
-            )
 
         service_list = []
         for name in service_names:

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -241,8 +241,18 @@ def mocked_list_jobs(mocked_client):
     from kubernetes.client.models import V1JobList, V1Job, V1ObjectMeta
 
     def _handle_list_jobs(*args, **kwargs):
-        job = V1Job(metadata=V1ObjectMeta(namespace="mock_namespace", name="mock_job"))
-        job_list = V1JobList(items=[job])
+        names = ["mock_job"]
+        if "label_selector" in kwargs and kwargs["label_selector"] == "app.kubernetes.io/name in (microsoft-iotoperations)":
+            names.extend(
+                [
+                    "aio-usage-job",
+                ]
+            )
+
+        job_list = []
+        for name in names:
+            job_list.append(V1Job(metadata=V1ObjectMeta(namespace="mock_namespace", name=name)))
+        job_list = V1JobList(items=job_list)
 
         return job_list
 
@@ -322,6 +332,13 @@ def mocked_list_services(mocked_client):
             service_names.extend(
                 [
                     "opcplc-0000000",
+                ]
+            )
+        
+        if "label_selector" in kwargs and kwargs["label_selector"] == "app.kubernetes.io/name in (microsoft-iotoperations)":
+            service_names.extend(
+                [
+                    "aio-operator-service",
                 ]
             )
 

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -6,6 +6,8 @@
 
 from functools import partial
 from typing import List
+
+from azext_edge.edge.providers.support.billing import AIO_BILLING_USAGE_NAME_LABEL
 from ...generators import generate_random_string
 
 import pytest
@@ -242,7 +244,7 @@ def mocked_list_jobs(mocked_client):
 
     def _handle_list_jobs(*args, **kwargs):
         names = ["mock_job"]
-        if "label_selector" in kwargs and kwargs["label_selector"] == "app.kubernetes.io/name in (microsoft-iotoperations)":
+        if "label_selector" in kwargs and kwargs["label_selector"] == AIO_BILLING_USAGE_NAME_LABEL:
             names.extend(
                 [
                     "aio-usage-job",

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -245,11 +245,7 @@ def mocked_list_jobs(mocked_client):
     def _handle_list_jobs(*args, **kwargs):
         names = ["mock_job"]
         if "label_selector" in kwargs and kwargs["label_selector"] == AIO_BILLING_USAGE_NAME_LABEL:
-            names.extend(
-                [
-                    "aio-usage-job",
-                ]
-            )
+            names.append("aio-usage-job")
 
         job_list = []
         for name in names:

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -26,6 +26,7 @@ from azext_edge.edge.providers.edge_api import (
     DATAFLOW_API_V1B1,
     EdgeResourceApi,
 )
+from azext_edge.edge.providers.edge_api.meta import META_API_V1B1
 from azext_edge.edge.providers.support.akri import (
     AKRI_AGENT_LABEL,
     AKRI_APP_LABEL,
@@ -42,6 +43,7 @@ from azext_edge.edge.providers.support.billing import (
     ARC_BILLING_DIRECTORY_PATH,
     BILLING_RESOURCE_KIND,
 )
+from azext_edge.edge.providers.support.dataflow import DATAFLOW_NAME_LABEL
 from azext_edge.edge.providers.support.meta import META_NAME_LABEL
 from azext_edge.edge.providers.support.mq import MQ_DIRECTORY_PATH, MQ_K8S_LABEL, MQ_NAME_LABEL
 from azext_edge.edge.providers.support.opcua import (
@@ -77,6 +79,7 @@ a_bundle_dir = f"support_test_{generate_random_string()}"
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1],
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, AKRI_API_V0],
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, CLUSTER_CONFIG_API_V1],
+        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, DATAFLOW_API_V1B1],
     ],
     indirect=True,
 )
@@ -180,6 +183,7 @@ def test_create_bundle(
                 mocked_zipfile,
                 label_selector=AIO_BILLING_USAGE_NAME_LABEL,
                 directory_path=BILLING_RESOURCE_KIND,
+                mock_names=["aio-usage-job"],
             )
             assert_list_replica_sets(
                 mocked_client,
@@ -474,27 +478,20 @@ def test_create_bundle(
             assert_list_deployments(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=DATAFLOW_API_V1B1.label,
+                label_selector=DATAFLOW_NAME_LABEL,
                 directory_path=DATAFLOW_API_V1B1.moniker,
-            )
-            assert_list_deployments(
-                mocked_client,
-                mocked_zipfile,
-                label_selector=DATAFLOW_API_V1B1.label,
-                directory_path=DATAFLOW_API_V1B1.moniker,
-                mock_names=["aio-dataflow-operator"],
             )
             assert_list_replica_sets(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=DATAFLOW_API_V1B1.label,
+                label_selector=DATAFLOW_NAME_LABEL,
                 directory_path=DATAFLOW_API_V1B1.moniker,
             )
             assert_list_pods(
                 mocked_client,
                 mocked_zipfile,
                 mocked_list_pods,
-                label_selector=DATAFLOW_API_V1B1.label,
+                label_selector=DATAFLOW_NAME_LABEL,
                 directory_path=DATAFLOW_API_V1B1.moniker,
                 since_seconds=since_seconds,
             )
@@ -599,16 +596,19 @@ def assert_list_jobs(
     mocked_zipfile,
     label_selector: str,
     directory_path: str,
+    mock_names: List[str] = None,
 ):
     mocked_client.BatchV1Api().list_job_for_all_namespaces.assert_any_call(
         label_selector=label_selector, field_selector=None
     )
 
-    assert_zipfile_write(
-        mocked_zipfile,
-        zinfo=f"mock_namespace/{directory_path}/job.mock_job.yaml",
-        data="kind: Job\nmetadata:\n  name: mock_job\n  namespace: mock_namespace\n",
-    )
+    mock_names = mock_names or ["mock_job"]
+    for name in mock_names:
+        assert_zipfile_write(
+            mocked_zipfile,
+            zinfo=f"mock_namespace/{directory_path}/job.{name}.yaml",
+            data=f"kind: Job\nmetadata:\n  name: {name}\n  namespace: mock_namespace\n",
+        )
 
 
 def assert_list_pods(
@@ -792,10 +792,12 @@ def assert_meta_kpis(
             "mocked_client": mocked_client,
             "mocked_zipfile": mocked_zipfile,
             "label_selector": META_NAME_LABEL,
-            "directory_path": OTEL_API.moniker,
+            "directory_path": META_API_V1B1.moniker,
         }
         if assert_func == assert_list_pods:
             kwargs["mocked_list_pods"] = mocked_list_pods
+        if assert_func == assert_list_services:
+            kwargs["mock_names"] = ["aio-operator-service"]
 
         assert_func(**kwargs)
 

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -26,7 +26,6 @@ from azext_edge.edge.providers.edge_api import (
     DATAFLOW_API_V1B1,
     EdgeResourceApi,
 )
-from azext_edge.edge.providers.edge_api.meta import META_API_V1B1
 from azext_edge.edge.providers.support.akri import (
     AKRI_AGENT_LABEL,
     AKRI_APP_LABEL,
@@ -43,7 +42,6 @@ from azext_edge.edge.providers.support.billing import (
     ARC_BILLING_DIRECTORY_PATH,
     BILLING_RESOURCE_KIND,
 )
-from azext_edge.edge.providers.support.dataflow import DATAFLOW_NAME_LABEL
 from azext_edge.edge.providers.support.meta import META_NAME_LABEL
 from azext_edge.edge.providers.support.mq import MQ_DIRECTORY_PATH, MQ_K8S_LABEL, MQ_NAME_LABEL
 from azext_edge.edge.providers.support.opcua import (
@@ -79,7 +77,6 @@ a_bundle_dir = f"support_test_{generate_random_string()}"
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1],
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, AKRI_API_V0],
         [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, CLUSTER_CONFIG_API_V1],
-        [MQTT_BROKER_API_V1B1, OPCUA_API_V1, ORC_API_V1, DATAFLOW_API_V1B1],
     ],
     indirect=True,
 )
@@ -478,20 +475,27 @@ def test_create_bundle(
             assert_list_deployments(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=DATAFLOW_NAME_LABEL,
+                label_selector=DATAFLOW_API_V1B1.label,
                 directory_path=DATAFLOW_API_V1B1.moniker,
+            )
+            assert_list_deployments(
+                mocked_client,
+                mocked_zipfile,
+                label_selector=DATAFLOW_API_V1B1.label,
+                directory_path=DATAFLOW_API_V1B1.moniker,
+                mock_names=["aio-dataflow-operator"],
             )
             assert_list_replica_sets(
                 mocked_client,
                 mocked_zipfile,
-                label_selector=DATAFLOW_NAME_LABEL,
+                label_selector=DATAFLOW_API_V1B1.label,
                 directory_path=DATAFLOW_API_V1B1.moniker,
             )
             assert_list_pods(
                 mocked_client,
                 mocked_zipfile,
                 mocked_list_pods,
-                label_selector=DATAFLOW_NAME_LABEL,
+                label_selector=DATAFLOW_API_V1B1.label,
                 directory_path=DATAFLOW_API_V1B1.moniker,
                 since_seconds=since_seconds,
             )
@@ -596,7 +600,7 @@ def assert_list_jobs(
     mocked_zipfile,
     label_selector: str,
     directory_path: str,
-    mock_names: List[str] = None,
+    mock_names: Optional[List[str]] = None,
 ):
     mocked_client.BatchV1Api().list_job_for_all_namespaces.assert_any_call(
         label_selector=label_selector, field_selector=None
@@ -792,12 +796,10 @@ def assert_meta_kpis(
             "mocked_client": mocked_client,
             "mocked_zipfile": mocked_zipfile,
             "label_selector": META_NAME_LABEL,
-            "directory_path": META_API_V1B1.moniker,
+            "directory_path": OTEL_API.moniker,
         }
         if assert_func == assert_list_pods:
             kwargs["mocked_list_pods"] = mocked_list_pods
-        if assert_func == assert_list_services:
-            kwargs["mock_names"] = ["aio-operator-service"]
 
         assert_func(**kwargs)
 


### PR DESCRIPTION
Since billing and meta resource share the same label, billing needs to be exclusive about the prefix it's capturing since both billing and meta resource has jobs and pods under AIO namespace(pods are already capturing the pod with prefix names stated, this pr is to fix the job)
![image](https://github.com/user-attachments/assets/262e1c1b-bd4a-4fff-9800-36dc9ac9e38d)
---->
![image](https://github.com/user-attachments/assets/e7b45197-38ce-4a8f-8993-1cdd2dcde198)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
