### PR TITLE
feat: ensure endpoint profile existance for asset checks

### DIFF
--- a/azext_edge/edge/providers/check/deviceregistry.py
+++ b/azext_edge/edge/providers/check/deviceregistry.py
@@ -122,17 +122,22 @@ def evaluate_assets(
 
             asset_spec = asset["spec"]
             endpoint_profile_uri = asset_spec.get("assetEndpointProfileUri", "")
+            endpoint = get_resources_by_name(
+                api_info=DEVICEREGISTRY_API_V1,
+                kind=DeviceRegistryResourceKinds.ASSET,
+                resource_name=endpoint_profile_uri
+            )
             spec_padding = padding + PADDING_SIZE
 
             endpoint_profile_uri_value = {"spec.assetEndpointProfileUri": endpoint_profile_uri}
             endpoint_profile_uri_status = CheckTaskStatus.success.value
-            if endpoint_profile_uri:
+            if endpoint:
                 endpoint_profile_uri_text = (
                     f"Asset endpoint profile uri {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} property [green]detected[/green]."
                 )
             else:
                 endpoint_profile_uri_text = (
-                    "Asset endpoint profile uri [red]not detected[/red]."
+                    f"Asset endpoint profile uri {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} [red]not detected[/red]."
                 )
                 endpoint_profile_uri_status = CheckTaskStatus.error.value
 

--- a/azext_edge/edge/providers/check/deviceregistry.py
+++ b/azext_edge/edge/providers/check/deviceregistry.py
@@ -122,7 +122,7 @@ def evaluate_assets(
 
             asset_spec = asset["spec"]
             endpoint_profile_uri = asset_spec.get("assetEndpointProfileUri", "")
-            endpoint = get_resources_by_name(
+            endpoint_profile = get_resources_by_name(
                 api_info=DEVICEREGISTRY_API_V1,
                 kind=DeviceRegistryResourceKinds.ASSET,
                 resource_name=endpoint_profile_uri
@@ -131,7 +131,7 @@ def evaluate_assets(
 
             endpoint_profile_uri_value = {"spec.assetEndpointProfileUri": endpoint_profile_uri}
             endpoint_profile_uri_status = CheckTaskStatus.success.value
-            if endpoint:
+            if endpoint_profile:
                 endpoint_profile_uri_text = (
                     f"Asset endpoint profile uri {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} property [green]detected[/green]."
                 )

--- a/azext_edge/edge/providers/check/deviceregistry.py
+++ b/azext_edge/edge/providers/check/deviceregistry.py
@@ -124,7 +124,7 @@ def evaluate_assets(
             endpoint_profile_uri = asset_spec.get("assetEndpointProfileUri", "")
             endpoint_profile = get_resources_by_name(
                 api_info=DEVICEREGISTRY_API_V1,
-                kind=DeviceRegistryResourceKinds.ASSET,
+                kind=DeviceRegistryResourceKinds.ASSETENDPOINTPROFILE,
                 resource_name=endpoint_profile_uri
             )
             spec_padding = padding + PADDING_SIZE
@@ -133,11 +133,11 @@ def evaluate_assets(
             endpoint_profile_uri_status = CheckTaskStatus.success.value
             if endpoint_profile:
                 endpoint_profile_uri_text = (
-                    f"Asset endpoint profile uri {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} property [green]detected[/green]."
+                    f"Asset endpoint profile {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} property [green]detected[/green]."
                 )
             else:
                 endpoint_profile_uri_text = (
-                    f"Asset endpoint profile uri {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} [red]not detected[/red]."
+                    f"Asset endpoint profile {{[bright_blue]{endpoint_profile_uri}[/bright_blue]}} [red]not detected[/red]."
                 )
                 endpoint_profile_uri_status = CheckTaskStatus.error.value
 

--- a/azext_edge/tests/edge/checks/test_deviceregistry_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_deviceregistry_checks_unit.py
@@ -51,7 +51,7 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
     ]
 )
 @pytest.mark.parametrize(
-    "assets, namespace_conditions, namespace_evaluations",
+    "assets, asset_endpoint_profiles, namespace_conditions, namespace_evaluations",
     [
         (
             # assets
@@ -65,6 +65,17 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                     }
                 },
             ],
+            # asset_endpoint_profiles
+            [
+                {
+                    "metadata": {
+                        "name": "endpoint",
+                    },
+                    "spec": {
+                        "uuid": "1234",
+                    }
+                },
+            ],
             # namespace conditions str
             ["spec.assetEndpointProfileUri"],
             # namespace evaluations str
@@ -75,7 +86,7 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                 ],
             ]
         ),
-        # assetEndpointProfileUri not defined
+        # assetEndpointProfileUri not present
         (
             # assets
             [
@@ -87,6 +98,8 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                     }
                 },
             ],
+            # asset_endpoint_profiles
+            [],
             # namespace conditions str
             ["spec.assetEndpointProfileUri"],
             # namespace evaluations str
@@ -116,6 +129,17 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                     }
                 },
             ],
+            # asset_endpoint_profiles
+            [
+                {
+                    "metadata": {
+                        "name": "endpoint",
+                    },
+                    "spec": {
+                        "uuid": "1234",
+                    }
+                },
+            ],
             # namespace conditions str
             ["spec.assetEndpointProfileUri", 'len(spec.dataPoints)'],
             # namespace evaluations str
@@ -137,6 +161,8 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
         # no assets
         (
             # assets
+            [],
+            # asset_endpoint_profiles
             [],
             # namespace conditions str
             [],
@@ -166,6 +192,17 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                                 }
                             ]
                         }
+                    }
+                },
+            ],
+            # asset_endpoint_profiles
+            [
+                {
+                    "metadata": {
+                        "name": "endpoint",
+                    },
+                    "spec": {
+                        "uuid": "1234",
                     }
                 },
             ],
@@ -201,6 +238,17 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
                     }
                 },
             ],
+            # asset_endpoint_profiles
+            [
+                {
+                    "metadata": {
+                        "name": "endpoint",
+                    },
+                    "spec": {
+                        "uuid": "1234",
+                    }
+                },
+            ],
             # namespace conditions str
             ["spec.assetEndpointProfileUri", "len(spec.events)"],
             # namespace evaluations str
@@ -224,6 +272,7 @@ def test_check_deviceregistry_by_resource_types(ops_service, mocker, mock_resour
 def test_assets_checks(
     mocker,
     assets,
+    asset_endpoint_profiles,
     namespace_conditions,
     namespace_evaluations,
     mock_generate_deviceregistry_asset_target_resources,
@@ -232,7 +281,7 @@ def test_assets_checks(
 ):
     mocker = mocker.patch(
         "azext_edge.edge.providers.edge_api.base.EdgeResourceApi.get_resources",
-        side_effect=[{"items": assets}],
+        side_effect=[{"items": assets}, {"items": asset_endpoint_profiles}],
     )
 
     namespace = generate_random_string()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/afb9fba7-2307-456e-863f-dd6b2cba0f38)

endpoint should exist for the asset to be a thing
also endpoint profile uri -> endpoint profile

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
