### PR TITLE
refactor: Refresh embedded aio client doc strings

### DIFF
--- a/azext_edge/edge/vendor/clients/iotopsmgmt/_client.py
+++ b/azext_edge/edge/vendor/clients/iotopsmgmt/_client.py
@@ -35,23 +35,23 @@ class MicrosoftIoTOperationsManagementService:  # pylint: disable=client-accepts
     """Microsoft.IoTOperations Resource Provider management API.
 
     :ivar operations: Operations operations
-    :vartype operations: storage.mgmt.operations.Operations
+    :vartype operations: aziotops.mgmt.operations.Operations
     :ivar instance: InstanceOperations operations
-    :vartype instance: storage.mgmt.operations.InstanceOperations
+    :vartype instance: aziotops.mgmt.operations.InstanceOperations
     :ivar broker: BrokerOperations operations
-    :vartype broker: storage.mgmt.operations.BrokerOperations
+    :vartype broker: aziotops.mgmt.operations.BrokerOperations
     :ivar broker_authentication: BrokerAuthenticationOperations operations
-    :vartype broker_authentication: storage.mgmt.operations.BrokerAuthenticationOperations
+    :vartype broker_authentication: aziotops.mgmt.operations.BrokerAuthenticationOperations
     :ivar broker_authorization: BrokerAuthorizationOperations operations
-    :vartype broker_authorization: storage.mgmt.operations.BrokerAuthorizationOperations
+    :vartype broker_authorization: aziotops.mgmt.operations.BrokerAuthorizationOperations
     :ivar broker_listener: BrokerListenerOperations operations
-    :vartype broker_listener: storage.mgmt.operations.BrokerListenerOperations
+    :vartype broker_listener: aziotops.mgmt.operations.BrokerListenerOperations
     :ivar dataflow_endpoint: DataflowEndpointOperations operations
-    :vartype dataflow_endpoint: storage.mgmt.operations.DataflowEndpointOperations
+    :vartype dataflow_endpoint: aziotops.mgmt.operations.DataflowEndpointOperations
     :ivar dataflow_profile: DataflowProfileOperations operations
-    :vartype dataflow_profile: storage.mgmt.operations.DataflowProfileOperations
+    :vartype dataflow_profile: aziotops.mgmt.operations.DataflowProfileOperations
     :ivar dataflow: DataflowOperations operations
-    :vartype dataflow: storage.mgmt.operations.DataflowOperations
+    :vartype dataflow: aziotops.mgmt.operations.DataflowOperations
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
     :param credential: Credential needed for the client to connect to Azure. Required.

--- a/azext_edge/edge/vendor/clients/iotopsmgmt/operations/_operations.py
+++ b/azext_edge/edge/vendor/clients/iotopsmgmt/operations/_operations.py
@@ -1426,7 +1426,7 @@ class Operations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`operations` attribute.
     """
 
@@ -1547,7 +1547,7 @@ class InstanceOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`instance` attribute.
     """
 
@@ -3256,7 +3256,7 @@ class BrokerOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`broker` attribute.
     """
 
@@ -6081,7 +6081,7 @@ class BrokerAuthenticationOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`broker_authentication` attribute.
     """
 
@@ -7192,7 +7192,7 @@ class BrokerAuthorizationOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`broker_authorization` attribute.
     """
 
@@ -8485,7 +8485,7 @@ class BrokerListenerOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`broker_listener` attribute.
     """
 
@@ -9771,7 +9771,7 @@ class DataflowEndpointOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`dataflow_endpoint` attribute.
     """
 
@@ -9939,6 +9939,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -9959,7 +9960,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -9981,8 +9981,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -10011,8 +10011,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -10286,6 +10285,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -10306,7 +10306,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -10328,8 +10327,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -10358,8 +10357,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -10710,6 +10708,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -10730,7 +10729,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -10752,8 +10750,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -10782,8 +10780,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -10972,6 +10969,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -10992,7 +10990,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -11014,8 +11011,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -11044,8 +11041,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -11274,6 +11270,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -11294,7 +11291,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -11316,8 +11312,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -11346,8 +11342,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -11574,6 +11569,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -11594,7 +11590,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -11616,8 +11611,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -11646,8 +11641,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -11836,6 +11830,7 @@ class DataflowEndpointOperations:
                                       X.509 certificate. Required.
                                 }
                             },
+                            "host": "str",  # Kafka endpoint host. Required.
                             "batching": {
                                 "latencyMs": 5,  # Optional. Default value is 5.
                                   Batching latency in milliseconds.
@@ -11856,7 +11851,6 @@ class DataflowEndpointOperations:
                               properties. No effect if the endpoint is used as a source or if the
                               dataflow doesn't have an Broker source. Known values are: "Enabled" and
                               "Disabled".
-                            "host": "str",  # Optional. Kafka endpoint host.
                             "kafkaAcks": "str",  # Optional. Kafka acks. Can be all, one,
                               or zero. No effect if the endpoint is used as a source. Known values are:
                               "Zero", "One", and "All".
@@ -11878,8 +11872,8 @@ class DataflowEndpointOperations:
                             "authentication": {
                                 "method": "str",  # Mode of Authentication. Required.
                                   Known values are: "SystemAssignedManagedIdentity",
-                                  "UserAssignedManagedIdentity", "Sasl", "X509Certificate", and
-                                  "Anonymous".
+                                  "UserAssignedManagedIdentity", "ServiceAccountToken",
+                                  "X509Certificate", and "Anonymous".
                                 "serviceAccountTokenSettings": {
                                     "audience": "str"  # Audience of the service
                                       account. Optional, defaults to the broker internal service
@@ -11908,8 +11902,7 @@ class DataflowEndpointOperations:
                               prefix if omitted.
                             "cloudEventAttributes": "str",  # Optional. Cloud event
                               mapping config. Known values are: "Propagate" and "CreateOrRemap".
-                            "host": "aio-mq-dmqtt-frontend:8883",  # Optional. Default
-                              value is "aio-mq-dmqtt-frontend:8883". Host of the Broker in the form of
+                            "host": "str",  # Optional. Host of the Broker in the form of
                               :code:`<hostname>`::code:`<port>`. Optional; connects to Broker if
                               omitted.
                             "keepAliveSeconds": 60,  # Optional. Default value is 60.
@@ -12123,7 +12116,7 @@ class DataflowProfileOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`dataflow_profile` attribute.
     """
 
@@ -13096,7 +13089,7 @@ class DataflowOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~storage.mgmt.MicrosoftIoTOperationsManagementService`'s
+        :class:`~aziotops.mgmt.MicrosoftIoTOperationsManagementService`'s
         :attr:`dataflow` attribute.
     """
 

--- a/azext_edge/edge/vendor/clients/resourcesmgmt/operations/_operations.py
+++ b/azext_edge/edge/vendor/clients/resourcesmgmt/operations/_operations.py
@@ -22810,7 +22810,7 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
          None.
         :paramtype filter: str
         :keyword expand: Comma-separated list of additional properties to be included in the response.
-         Valid values include ``createdTime``\ , ``changedTime`` and ``provisioningState``. For example,
+         Valid values include ``createdTime``, ``changedTime`` and ``provisioningState``. For example,
          ``$expand=createdTime,changedTime``. Default value is None.
         :paramtype expand: str
         :keyword top: The number of results to return. If null is passed, returns all resources.
@@ -23381,16 +23381,16 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
 
         :keyword filter: The filter to apply on the operation.:code:`<br>`:code:`<br>`Filter comparison
          operators include ``eq`` (equals) and ``ne`` (not equals) and may be used with the following
-         properties: ``location``\ , ``resourceType``\ , ``name``\ , ``resourceGroup``\ , ``identity``\
-         , ``identity/principalId``\ , ``plan``\ , ``plan/publisher``\ , ``plan/product``\ ,
-         ``plan/name``\ , ``plan/version``\ , and ``plan/promotionCode``.:code:`<br>`:code:`<br>`For
+         properties: ``location``, ``resourceType``, ``name``, ``resourceGroup``, ``identity``
+         , ``identity/principalId``, ``plan``, ``plan/publisher``, ``plan/product``,
+         ``plan/name``, ``plan/version``, and ``plan/promotionCode``.:code:`<br>`:code:`<br>`For
          example, to filter by a resource type, use ``$filter=resourceType eq
-         'Microsoft.Network/virtualNetworks'``\ :code:`<br>`:code:`<br>`:code:`<br>`\
+         'Microsoft.Network/virtualNetworks'``:code:`<br>`:code:`<br>`:code:`<br>`
          ``substringof(value, property)`` can  be used to filter for substrings of the following
-         currently-supported properties: ``name`` and ``resourceGroup``\ :code:`<br>`:code:`<br>`For
+         currently-supported properties: ``name`` and ``resourceGroup`` :code:`<br>`:code:`<br>`For
          example, to get all resources with 'demo' anywhere in the resource name, use
-         ``$filter=substringof('demo', name)``\ :code:`<br>`:code:`<br>`Multiple substring operations
-         can also be combined using ``and``\ /\ ``or`` operators.:code:`<br>`:code:`<br>`Note that any
+         ``$filter=substringof('demo', name)`` :code:`<br>`:code:`<br>`Multiple substring operations
+         can also be combined using ``and``/``or`` operators.:code:`<br>`:code:`<br>`Note that any
          truncated number of results queried via ``$top`` may also not be compatible when using a
          filter.:code:`<br>`:code:`<br>`:code:`<br>`Resources can be filtered by tag names and values.
          For example, to filter for a tag name and value, use ``$filter=tagName eq 'tag1' and tagValue
@@ -23399,14 +23399,14 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
          additional properties queried via ``$expand`` may also not be compatible when filtering by tag
          names/values. :code:`<br>`:code:`<br>`For tag names only, resources can be filtered by prefix
          using the following syntax: ``$filter=startswith(tagName, 'depart')``. This query will return
-         all resources with a tag name prefixed by the phrase ``depart`` (i.e.\ ``department``\ ,
-         ``departureDate``\ , ``departureTime``\ , etc.):code:`<br>`:code:`<br>`:code:`<br>`Note that
+         all resources with a tag name prefixed by the phrase ``depart`` (i.e.``department``,
+         ``departureDate``, ``departureTime``, etc.):code:`<br>`:code:`<br>`:code:`<br>`Note that
          some properties can be combined when filtering resources, which include the following:
-         ``substringof() and/or resourceType``\ , ``plan and plan/publisher and plan/name``\ , and
+         ``substringof() and/or resourceType``, ``plan and plan/publisher and plan/name``, and
          ``identity and identity/principalId``. Default value is None.
         :paramtype filter: str
         :keyword expand: Comma-separated list of additional properties to be included in the response.
-         Valid values include ``createdTime``\ , ``changedTime`` and ``provisioningState``. For example,
+         Valid values include ``createdTime``, ``changedTime`` and ``provisioningState``. For example,
          ``$expand=createdTime,changedTime``. Default value is None.
         :paramtype expand: str
         :keyword top: The number of recommendations per page if a paged version of this API is being

--- a/azext_edge/edge/vendor/clients/resourcesmgmt/operations/_operations.py
+++ b/azext_edge/edge/vendor/clients/resourcesmgmt/operations/_operations.py
@@ -22810,7 +22810,7 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
          None.
         :paramtype filter: str
         :keyword expand: Comma-separated list of additional properties to be included in the response.
-         Valid values include ``createdTime``, ``changedTime`` and ``provisioningState``. For example,
+         Valid values include ``createdTime`` , ``changedTime`` and ``provisioningState``. For example,
          ``$expand=createdTime,changedTime``. Default value is None.
         :paramtype expand: str
         :keyword top: The number of results to return. If null is passed, returns all resources.
@@ -23381,16 +23381,16 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
 
         :keyword filter: The filter to apply on the operation.:code:`<br>`:code:`<br>`Filter comparison
          operators include ``eq`` (equals) and ``ne`` (not equals) and may be used with the following
-         properties: ``location``, ``resourceType``, ``name``, ``resourceGroup``, ``identity``
-         , ``identity/principalId``, ``plan``, ``plan/publisher``, ``plan/product``,
-         ``plan/name``, ``plan/version``, and ``plan/promotionCode``.:code:`<br>`:code:`<br>`For
+         properties: ``location`` , ``resourceType`` , ``name`` , ``resourceGroup`` , ``identity``
+         , ``identity/principalId`` , ``plan`` , ``plan/publisher`` , ``plan/product`` ,
+         ``plan/name`` , ``plan/version`` , and ``plan/promotionCode``.:code:`<br>`:code:`<br>`For
          example, to filter by a resource type, use ``$filter=resourceType eq
-         'Microsoft.Network/virtualNetworks'``:code:`<br>`:code:`<br>`:code:`<br>`
+         'Microsoft.Network/virtualNetworks'`` :code:`<br>`:code:`<br>`:code:`<br>`
          ``substringof(value, property)`` can  be used to filter for substrings of the following
          currently-supported properties: ``name`` and ``resourceGroup`` :code:`<br>`:code:`<br>`For
          example, to get all resources with 'demo' anywhere in the resource name, use
          ``$filter=substringof('demo', name)`` :code:`<br>`:code:`<br>`Multiple substring operations
-         can also be combined using ``and``/``or`` operators.:code:`<br>`:code:`<br>`Note that any
+         can also be combined using ``and`` / ``or`` operators.:code:`<br>`:code:`<br>`Note that any
          truncated number of results queried via ``$top`` may also not be compatible when using a
          filter.:code:`<br>`:code:`<br>`:code:`<br>`Resources can be filtered by tag names and values.
          For example, to filter for a tag name and value, use ``$filter=tagName eq 'tag1' and tagValue
@@ -23399,14 +23399,14 @@ class ResourcesOperations:  # pylint: disable=too-many-public-methods
          additional properties queried via ``$expand`` may also not be compatible when filtering by tag
          names/values. :code:`<br>`:code:`<br>`For tag names only, resources can be filtered by prefix
          using the following syntax: ``$filter=startswith(tagName, 'depart')``. This query will return
-         all resources with a tag name prefixed by the phrase ``depart`` (i.e.``department``,
-         ``departureDate``, ``departureTime``, etc.):code:`<br>`:code:`<br>`:code:`<br>`Note that
+         all resources with a tag name prefixed by the phrase ``depart`` (i.e. ``department`` ,
+         ``departureDate`` , ``departureTime`` , etc.):code:`<br>`:code:`<br>`:code:`<br>`Note that
          some properties can be combined when filtering resources, which include the following:
-         ``substringof() and/or resourceType``, ``plan and plan/publisher and plan/name``, and
+         ``substringof() and/or resourceType`` , ``plan and plan/publisher and plan/name`` , and
          ``identity and identity/principalId``. Default value is None.
         :paramtype filter: str
         :keyword expand: Comma-separated list of additional properties to be included in the response.
-         Valid values include ``createdTime``, ``changedTime`` and ``provisioningState``. For example,
+         Valid values include ``createdTime`` , ``changedTime`` and ``provisioningState``. For example,
          ``$expand=createdTime,changedTime``. Default value is None.
         :paramtype expand: str
         :keyword top: The number of recommendations per page if a paged version of this API is being


### PR DESCRIPTION
* Since spec changed for same API.
* Remove deprecated escape sequence from resource client.