### PR TITLE
fix: fix status matching for check

### DIFF
--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -58,16 +58,17 @@ class ResourceState(Enum):
     K8s resource state.
     """
 
-    starting = "Starting"
-    running = "Running"
-    recovering = "Recovering"
-    succeeded = "Succeeded"
-    failed = "Failed"
-    waiting = "Waiting"
-    ok = "OK"
+    starting = "starting"
+    running = "running"
+    recovering = "recovering"
+    succeeded = "succeeded"
+    failed = "failed"
+    waiting = "waiting"
+    warning = "warning"
+    ok = "ok"
     warn = "warn"
-    error = "Error"
-    n_a = "N/A"
+    error = "error"
+    n_a = "n/a"
 
     @classmethod
     def map_to_color(cls, value) -> str:
@@ -75,6 +76,7 @@ class ResourceState(Enum):
 
     @classmethod
     def map_to_status(cls, value) -> CheckTaskStatus:
+        value = value.lower()
         status_map = {
             cls.starting.value: CheckTaskStatus.warning,
             cls.recovering.value: CheckTaskStatus.warning,
@@ -83,6 +85,7 @@ class ResourceState(Enum):
             cls.failed.value: CheckTaskStatus.error,
             cls.error.value: CheckTaskStatus.error,
             cls.waiting.value: CheckTaskStatus.warning,
+            cls.warning.value: CheckTaskStatus.warning,
         }
         return status_map.get(value, CheckTaskStatus.success)
 
@@ -92,14 +95,15 @@ class PodState(Enum):
     K8s pod state.
     """
 
-    pending = "Pending"
-    running = "Running"
-    succeeded = "Succeeded"
-    failed = "Failed"
-    unknown = "Unknown"
+    pending = "pending"
+    running = "running"
+    succeeded = "succeeded"
+    failed = "failed"
+    unknown = "unknown"
 
     @classmethod
     def map_to_status(cls, value) -> CheckTaskStatus:
+        value = value.lower()
         status_map = {
             cls.pending.value: CheckTaskStatus.warning,
             cls.unknown.value: CheckTaskStatus.warning,
@@ -222,6 +226,7 @@ class FileType(ListableEnum):
     """
     Supported file types/extensions for bulk asset operations.
     """
+
     csv = "csv"
     json = "json"
     portal_csv = "portal-csv"

--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -21,7 +21,7 @@ from ...base import get_cluster_custom_api
 from ...edge_api import EdgeResourceApi
 from ....common import CheckTaskStatus, ResourceState
 
-# TODO: unit test + refactor
+# TODO: refactor
 logger = get_logger(__name__)
 
 
@@ -160,7 +160,9 @@ def process_dict_resource(
 
             display_text = f"{key}:"
             check_manager.add_display(
-                target_name=target_name, namespace=namespace, display=Padding(display_text, (0, 0, 0, padding))
+                target_name=target_name,
+                namespace=namespace,
+                display=Padding(display_text, (0, 0, 0, padding)),
             )
 
             process_list_resource(
@@ -175,7 +177,9 @@ def process_dict_resource(
             value_padding = padding
             if isinstance(value, str) and len(value) > 50:
                 check_manager.add_display(
-                    target_name=target_name, namespace=namespace, display=Padding(display_text, (0, 0, 0, padding))
+                    target_name=target_name,
+                    namespace=namespace,
+                    display=Padding(display_text, (0, 0, 0, padding)),
                 )
                 value_padding += PADDING_SIZE
                 display_text = ""
@@ -183,7 +187,9 @@ def process_dict_resource(
                 check_manager=check_manager, target_name=target_name, key=key, value=value
             )
             check_manager.add_display(
-                target_name=target_name, namespace=namespace, display=Padding(display_text, (0, 0, 0, value_padding))
+                target_name=target_name,
+                namespace=namespace,
+                display=Padding(display_text, (0, 0, 0, value_padding)),
             )
 
 
@@ -260,7 +266,12 @@ def process_resource_properties(
 
 
 def process_resource_property_by_type(
-    check_manager: CheckManager, target_name: str, properties: Any, display_name: str, namespace: str, padding: tuple
+    check_manager: CheckManager,
+    target_name: str,
+    properties: Any,
+    display_name: str,
+    namespace: str,
+    padding: tuple,
 ) -> None:
     padding_left = padding[3]
     if isinstance(properties, list):
@@ -268,7 +279,9 @@ def process_resource_property_by_type(
             return
 
         display_text = f"{display_name}:"
-        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
+        check_manager.add_display(
+            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
+        )
 
         for property in properties:
             display_text = f"- {display_name} {properties.index(property) + 1}"
@@ -295,10 +308,14 @@ def process_resource_property_by_type(
             display_text = f"[cyan]{properties}[/cyan]"
             padding = (0, 0, 0, padding_left + 4)
 
-        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
+        check_manager.add_display(
+            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
+        )
     elif isinstance(properties, dict):
         display_text = f"{display_name}:"
-        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
+        check_manager.add_display(
+            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
+        )
         for prop, value in properties.items():
             display_text = f"{prop}: [cyan]{value}[/cyan]"
             check_manager.add_display(
@@ -346,9 +363,15 @@ def validate_one_of_conditions(
         eval_status = CheckTaskStatus.error.value
 
     one_of_condition = f"oneOf({conditions_names})"
-    check_manager.add_target_conditions(target_name=target_name, namespace=namespace, conditions=[one_of_condition])
+    check_manager.add_target_conditions(
+        target_name=target_name, namespace=namespace, conditions=[one_of_condition]
+    )
     check_manager.add_target_eval(
-        target_name=target_name, namespace=namespace, status=eval_status, value=eval_value, resource_name=resource_name
+        target_name=target_name,
+        namespace=namespace,
+        status=eval_status,
+        value=eval_value,
+        resource_name=resource_name,
     )
 
 
@@ -444,7 +467,9 @@ def process_custom_resource_status(
             if prop_value:
                 status_text = f"{prop_name} {{{decorate_resource_status(prop_value.get('status'))}}}."
                 if detail_level == ResourceOutputDetailLevel.verbose.value:
-                    status_description = prop_value.get("statusDescription") or prop_value.get("output", {}).get("message")
+                    status_description = prop_value.get("statusDescription") or prop_value.get(
+                        "output", {}
+                    ).get("message")
                     if status_description:
                         status_text = status_text.replace(".", f", [cyan]{status_description}[/cyan].")
 


### PR DESCRIPTION
"Warning" was not found in ResourceState cause it to be matched as an unknown status
![image](https://github.com/user-attachments/assets/ae308a82-8045-4c29-89c9-41483cc54562)

1. therefore adding warning under ResourceState 
2. make everything lowercased before doing the status matching
3. Added unitest to make sure things working as expected
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
