### PR TITLE
fix: add schema registry under --svc for support bundle

### DIFF
--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -149,6 +149,7 @@ class OpsServiceType(ListableEnum):
     deviceregistry = "deviceregistry"
     billing = "billing"
     dataflow = "dataflow"
+    schemaregistry = "schemaregistry"
 
     @classmethod
     def list_check_services(cls):
@@ -222,6 +223,7 @@ class FileType(ListableEnum):
     """
     Supported file types/extensions for bulk asset operations.
     """
+
     csv = "csv"
     json = "json"
     portal_csv = "portal-csv"

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -74,8 +74,8 @@ def build_bundle(
         deployed_meta_apis = COMPAT_META_APIS.get_deployed()
         pending_work["meta"] = prepare_meta_bundle(log_age_seconds, deployed_meta_apis)
 
-        # schema registry resources
-        pending_work["schemaregistry"] = prepare_schema_registry_bundle(log_age_seconds)
+        # # schema registry resources
+        # pending_work["schemaregistry"] = prepare_schema_registry_bundle(log_age_seconds)
 
     pending_work = {k: {} for k in OpsServiceType.list()}
     pending_work.pop(OpsServiceType.auto.value)
@@ -103,13 +103,17 @@ def build_bundle(
             "apis": COMPAT_DATAFLOW_APIS,
             "prepare_bundle": prepare_dataflow_bundle,
         },
+        OpsServiceType.schemaregistry.value: {
+            "apis": None,
+            "prepare_bundle": prepare_schema_registry_bundle,
+        },
     }
 
     for service_moniker, api_info in api_map.items():
         if ops_service in [OpsServiceType.auto.value, service_moniker]:
-            deployed_apis = api_info["apis"].get_deployed()
+            deployed_apis = api_info["apis"].get_deployed() if api_info["apis"] else None
 
-            if not deployed_apis:
+            if not deployed_apis and service_moniker != OpsServiceType.schemaregistry.value:
                 expected_api_version = api_info["apis"].as_str()
                 logger.warning(
                     f"The following API(s) were not detected {expected_api_version}. "
@@ -125,6 +129,8 @@ def build_bundle(
                 bundle = bundle_method(deployed_apis)
             elif service_moniker == OpsServiceType.mq.value:
                 bundle = bundle_method(log_age_seconds, deployed_apis, include_mq_traces)
+            elif service_moniker == OpsServiceType.schemaregistry.value:
+                bundle = bundle_method(log_age_seconds)
             else:
                 bundle = bundle_method(log_age_seconds, deployed_apis)
 

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -74,9 +74,6 @@ def build_bundle(
         deployed_meta_apis = COMPAT_META_APIS.get_deployed()
         pending_work["meta"] = prepare_meta_bundle(log_age_seconds, deployed_meta_apis)
 
-        # # schema registry resources
-        # pending_work["schemaregistry"] = prepare_schema_registry_bundle(log_age_seconds)
-
     pending_work = {k: {} for k in OpsServiceType.list()}
     pending_work.pop(OpsServiceType.auto.value)
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -112,5 +112,5 @@ def _get_expected_services(
         and OpsServiceType.deviceregistry.value in expected_services
     ):
         expected_services.remove(OpsServiceType.deviceregistry.value)
-    expected_services.extend(["meta", "schemaregistry"])
+    expected_services.append("schemaregistry")
     return expected_services

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -112,5 +112,5 @@ def _get_expected_services(
         and OpsServiceType.deviceregistry.value in expected_services
     ):
         expected_services.remove(OpsServiceType.deviceregistry.value)
-    expected_services.append("schemaregistry")
+    expected_services.append("meta")
     return expected_services

--- a/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 def test_create_bundle_schemas(init_setup, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
-    ops_service = OpsServiceType.akri.value
+    ops_service = OpsServiceType.schemaregistry.value
 
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -28,4 +28,5 @@ def test_create_bundle_schemas(init_setup, tracked_files):
         expected_workload_types=expected_workload_types,
         prefixes=["adr-schema-registry"],
         bundle_path=bundle_path,
+        expected_label=("app.kubernetes.io/name", "microsoft-iotoperations-schemas"),
     )

--- a/azext_edge/tests/edge/support/test_support_unit.py
+++ b/azext_edge/tests/edge/support/test_support_unit.py
@@ -1042,16 +1042,8 @@ def test_create_bundle_arc_agents(
             )
 
 
-@pytest.mark.parametrize(
-    "mocked_cluster_resources",
-    [
-        [DEVICEREGISTRY_API_V1],
-    ],
-    indirect=True,
-)
 def test_create_bundle_schemas(
     mocked_client,
-    mocked_cluster_resources,
     mocked_config,
     mocked_os_makedirs,
     mocked_zipfile,
@@ -1068,7 +1060,7 @@ def test_create_bundle_schemas(
     since_seconds = random.randint(86400, 172800)
     result = support_bundle(
         None,
-        ops_service=OpsServiceType.deviceregistry.value,
+        ops_service=OpsServiceType.schemaregistry.value,
         bundle_dir=a_bundle_dir,
         log_age_seconds=since_seconds,
     )

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from fnmatch import fnmatch
 from knack.log import get_logger
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from azure.cli.core.azclierror import CLIInternalError
 import pytest
 
@@ -29,12 +29,14 @@ def filter_resources(
     for item in kubectl_items.get("items", []):
         name = item["metadata"]["name"]
         # resources should not be added if
-        if not any([
-            # there is no valid resource match when looking for one
-            resource_match and not fnmatch(name, resource_match),
-            # or there is no valid prefix when looking for one
-            prefixes and not any(name.startswith(prefix) for prefix in prefixes)
-        ]):
+        if not any(
+            [
+                # there is no valid resource match when looking for one
+                resource_match and not fnmatch(name, resource_match),
+                # or there is no valid prefix when looking for one
+                prefixes and not any(name.startswith(prefix) for prefix in prefixes),
+            ]
+        ):
             filtered[name] = item
     return filtered
 
@@ -45,7 +47,7 @@ def find_extra_or_missing_names(
     expected_names: List[str],
     ignore_extras: bool = False,
     # TODO: remove once dynamic pods check logic is implemented
-    ignore_missing: bool = False
+    ignore_missing: bool = False,
 ):
     error_msg = []
     extra_names = [name for name in result_names if name not in expected_names]
@@ -61,9 +63,9 @@ def find_extra_or_missing_names(
 
     if error_msg:
         if ignore_missing:
-            logger.warning('\n '.join(error_msg))
+            logger.warning("\n ".join(error_msg))
         else:
-            raise AssertionError('\n '.join(error_msg))
+            raise AssertionError("\n ".join(error_msg))
 
 
 def get_plural_map(
@@ -84,7 +86,7 @@ def get_kubectl_custom_items(
     resource_api: EdgeResourceApi,
     namespace: Optional[str] = None,
     resource_match: Optional[str] = None,
-    include_plural: bool = False
+    include_plural: bool = False,
 ) -> Dict[str, Any]:
     """
     Gets all kubectl custom items for a resource api and sorts it by type.
@@ -105,10 +107,7 @@ def get_kubectl_custom_items(
         except CLIInternalError:
             # sub resource like lnm scales
             pass
-        resource_map[kind] = filter_resources(
-            kubectl_items=cluster_resources,
-            resource_match=resource_match
-        )
+        resource_map[kind] = filter_resources(kubectl_items=cluster_resources, resource_match=resource_match)
 
         if plural_map.get(kind):
             resource_map[kind][PLURAL_KEY] = plural_map[kind]
@@ -120,6 +119,7 @@ def get_kubectl_workload_items(
     service_type: str,
     namespace: Optional[str] = None,
     resource_match: Optional[str] = None,
+    label_match: Optional[Tuple[str, str]] = None,
 ) -> Dict[str, Any]:
     """Gets workload kubectl items for a specific type (ex: pods)."""
     if service_type == "pvc":
@@ -127,12 +127,9 @@ def get_kubectl_workload_items(
     if isinstance(prefixes, str):
         prefixes = [prefixes]
     namespace_param = f"-n {namespace}" if namespace else "-A"
-    kubectl_items = run(f"kubectl get {service_type} {namespace_param} -o json")
-    return filter_resources(
-        kubectl_items=kubectl_items,
-        prefixes=prefixes,
-        resource_match=resource_match
-    )
+    label_param = f"--selector {label_match[0]}={label_match[1]}" if label_match else ""
+    kubectl_items = run(f"kubectl get {service_type} {namespace_param} {label_param} -o json")
+    return filter_resources(kubectl_items=kubectl_items, prefixes=prefixes, resource_match=resource_match)
 
 
 def remove_file_or_folder(file_path):
@@ -156,9 +153,7 @@ def run(command: str, shell_mode: bool = True, expect_failure: bool = False):
     """
     import subprocess
 
-    result = subprocess.run(
-        command, check=False, shell=shell_mode, text=True, capture_output=True
-    )
+    result = subprocess.run(command, check=False, shell=shell_mode, text=True, capture_output=True)
     if expect_failure and result.returncode == 0:
         raise CLIInternalError(f"Command `{command}` did not fail as expected.")
     elif not expect_failure and result.returncode != 0:
@@ -174,8 +169,7 @@ def run(command: str, shell_mode: bool = True, expect_failure: bool = False):
 
 
 def sort_kubectl_items_by_namespace(
-    kubectl_items: Dict[str, Any],
-    include_all: bool = False
+    kubectl_items: Dict[str, Any], include_all: bool = False
 ) -> Dict[str, Dict[str, Any]]:
     """
     Transforms a list of kubectl items into a dictionary for easier access.


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
