### PR TITLE
fix: Use meta operator API for precheck AIO discovery

### DIFF
--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -14,7 +14,7 @@ from knack.log import get_logger
 from .common import OpsServiceType
 from .providers.base import DEFAULT_NAMESPACE, load_config_context
 from .providers.check.common import ResourceOutputDetailLevel
-from .providers.edge_api.orc import ORC_API_V1
+from .providers.edge_api.mq import MQ_ACTIVE_API
 from .providers.orchestration.common import (
     KubernetesDistroType,
     TrustSourceType,
@@ -61,9 +61,11 @@ def check(
     load_config_context(context_name=context_name)
     from .providers.checks import run_checks
 
-    # by default - run prechecks if AIO is not deployed
-    run_pre = not ORC_API_V1.is_deployed() if pre_deployment_checks is None else pre_deployment_checks
-    run_post = True if post_deployment_checks is None else post_deployment_checks
+    aio_deployed = MQ_ACTIVE_API.is_deployed()
+    # by default - run prechecks if AIO is not deployed, otherwise use argument
+    run_pre = not aio_deployed if pre_deployment_checks is None else pre_deployment_checks
+    # by default - run postchecks if AIO is deployed, otherwise use argument
+    run_post = aio_deployed if post_deployment_checks is None else post_deployment_checks
 
     # only one of pre or post is explicity set to True
     if pre_deployment_checks and not post_deployment_checks:

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -14,7 +14,7 @@ from knack.log import get_logger
 from .common import OpsServiceType
 from .providers.base import DEFAULT_NAMESPACE, load_config_context
 from .providers.check.common import ResourceOutputDetailLevel
-from .providers.edge_api.mq import MQ_ACTIVE_API
+from .providers.edge_api.meta import META_API_V1B1
 from .providers.orchestration.common import (
     KubernetesDistroType,
     TrustSourceType,
@@ -61,7 +61,7 @@ def check(
     load_config_context(context_name=context_name)
     from .providers.checks import run_checks
 
-    aio_deployed = MQ_ACTIVE_API.is_deployed()
+    aio_deployed = META_API_V1B1.is_deployed()
     # by default - run prechecks if AIO is not deployed, otherwise use argument
     run_pre = not aio_deployed if pre_deployment_checks is None else pre_deployment_checks
     # by default - run postchecks if AIO is deployed, otherwise use argument

--- a/azext_edge/tests/edge/checks/int/test_pre_post_int.py
+++ b/azext_edge/tests/edge/checks/int/test_pre_post_int.py
@@ -42,8 +42,8 @@ def test_check_pre_post(init_setup, post, pre):
             aio_check = run("kubectl api-resources --api-group=iotoperations.azure.com")
             expected_pre = "iotoperations.azure.com" not in aio_check
         except CLIInternalError:
-            from azext_edge.edge.providers.edge_api.orc import ORC_API_V1
-            expected_pre = not ORC_API_V1.is_deployed()
+            from azext_edge.edge.providers.edge_api.meta import META_API_V1B1
+            expected_pre = not META_API_V1B1.is_deployed()
 
     assert bool(result.get("preDeployment")) == expected_pre
     assert bool(result.get("postDeployment")) == expected_post

--- a/azext_edge/tests/edge/checks/int/test_pre_post_int.py
+++ b/azext_edge/tests/edge/checks/int/test_pre_post_int.py
@@ -39,8 +39,8 @@ def test_check_pre_post(init_setup, post, pre):
 
     if pre is None and not post:
         try:
-            aio_check = run("kubectl api-resources --api-group=orchestrator.iotoperations.azure.com")
-            expected_pre = "orchestrator.iotoperations.azure.com" not in aio_check
+            aio_check = run("kubectl api-resources --api-group=mqttbroker.iotoperations.azure.com")
+            expected_pre = "mqttbroker.iotoperations.azure.com" not in aio_check
         except CLIInternalError:
             from azext_edge.edge.providers.edge_api.orc import ORC_API_V1
             expected_pre = not ORC_API_V1.is_deployed()

--- a/azext_edge/tests/edge/checks/int/test_pre_post_int.py
+++ b/azext_edge/tests/edge/checks/int/test_pre_post_int.py
@@ -39,8 +39,8 @@ def test_check_pre_post(init_setup, post, pre):
 
     if pre is None and not post:
         try:
-            aio_check = run("kubectl api-resources --api-group=mqttbroker.iotoperations.azure.com")
-            expected_pre = "mqttbroker.iotoperations.azure.com" not in aio_check
+            aio_check = run("kubectl api-resources --api-group=iotoperations.azure.com")
+            expected_pre = "iotoperations.azure.com" not in aio_check
         except CLIInternalError:
             from azext_edge.edge.providers.edge_api.orc import ORC_API_V1
             expected_pre = not ORC_API_V1.is_deployed()


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
