### PR TITLE
test: update schema registry integration tests to use the resource group region

### DIFF
--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_int.py
@@ -29,7 +29,6 @@ def test_schema_registry_lifecycle(settings_with_rg, tracked_resources):
     registry = run(
         f"az iot ops schema registry create -n {registry_name} -g {registry_rg} "
         f"--rn {registry_namespace1} --sa-resource-id {storage_account['id']} "
-        "--location eastus2euap"  # TODO: remove once avaliable in all regions
     )
     tracked_resources.append(registry["id"])
     assert_schema_registry(
@@ -77,7 +76,6 @@ def test_schema_registry_lifecycle(settings_with_rg, tracked_resources):
         f"--rn {registry_namespace2} --sa-resource-id {storage_account['id']} "
         f"--sa-container {sa_container} --desc {description} --display-name {display_name} "
         f"--tags {tags_str} --custom-role-id {role_id} "
-        "--location eastus2euap"  # TODO: remove once avaliable in all regions
     )
     tracked_resources.append(alt_registry["id"])
     assert_schema_registry(

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_int.py
@@ -110,6 +110,7 @@ def test_schema_registry_lifecycle(settings_with_rg, tracked_resources):
         # delete does not return correct status code - remove once fixed
         if "ERROR: Operation returned an invalid status 'OK'" not in e.error_msg:
             raise e
+    tracked_resources.remove(registry["id"])
 
     list_registry_rg = run(f"az iot ops schema registry list -g {registry_rg}")
     list_registry_names = [reg["name"] for reg in list_registry_rg]
@@ -123,6 +124,7 @@ def test_schema_registry_lifecycle(settings_with_rg, tracked_resources):
         # delete does not return correct status code - remove once fixed
         if "ERROR: Operation returned an invalid status 'OK'" not in e.error_msg:
             raise e
+    tracked_resources.remove(alt_registry["id"])
 
 
 def assert_schema_registry(registry: dict, **expected):


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/d4bc371a-082a-4cd3-8c8f-a36301e3be98)

Note the error is from delete in schema registry returning a weird value

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
