### PR TITLE
fix: check ingress rule for load balancer typed service not showing correct value

### DIFF
--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -605,7 +605,7 @@ def _evaluate_listener_service(
         )
 
         if listener_spec_service_type.lower() == "loadbalancer":
-            check_manager.set_target_conditions(
+            check_manager.add_target_conditions(
                 target_name=target_listener_service,
                 namespace=namespace,
                 conditions=[
@@ -616,7 +616,7 @@ def _evaluate_listener_service(
             ingress_rules_desc = "- Expecting [bright_blue]>=1[/bright_blue] ingress rule. {}"
 
             service_status = associated_service.get("status", {})
-            load_balancer = service_status.get("c", {})
+            load_balancer = service_status.get("loadBalancer", {})
             ingress_rules: List[dict] = load_balancer.get("ingress", [])
 
             if not ingress_rules:
@@ -659,10 +659,10 @@ def _evaluate_listener_service(
                 target_name=target_listener_service,
                 namespace=namespace,
                 status=listener_service_eval_status,
-                value=service_status,
+                value={"status": service_status},
             )
         elif listener_spec_service_type.lower() == "clusterip":
-            check_manager.set_target_conditions(
+            check_manager.add_target_conditions(
                 target_name=target_listener_service,
                 namespace=namespace,
                 conditions=["spec.clusterIP"],

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -326,7 +326,6 @@ def test_broker_checks(
                 [
                     ("status", "success"),
                     ("value/listener_service", "service/name"),
-                    # ("value/status", {"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}}),
                 ],
                 [
                     ("status", "success"),

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -270,7 +270,7 @@ def test_broker_checks(
 @pytest.mark.parametrize("detail_level", ResourceOutputDetailLevel.list())
 @pytest.mark.parametrize("resource_name", [None, "mock*", "mock-name"])
 @pytest.mark.parametrize(
-    "listener, service, conditions, evaluations",
+    "listener, service, listener_conditions, listener_evaluations, service_conditions, service_evaluations",
     [
         (
             # listener
@@ -288,7 +288,7 @@ def test_broker_checks(
                 status={"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}},
                 spec={"clusterIP": "127.0.0.1"},
             ),
-            # conditions str
+            # listener conditions str
             [
                 "len(brokerlisteners)>=1",
                 "status",
@@ -296,7 +296,7 @@ def test_broker_checks(
                 "spec.serviceName",
                 "status",
             ],
-            # evaluations
+            # listener evaluations
             [
                 [
                     ("status", "success"),
@@ -313,6 +313,24 @@ def test_broker_checks(
                     ("value/spec/serviceType", "loadbalancer"),
                     ("value/spec/port", 8080),
                     ("value/spec/authenticationEnabled", "True"),
+                ],
+            ],
+            # service conditions str
+            [
+                "listener_service",
+                "status",
+                "len(status.loadBalancer.ingress[*].ip)>=1",
+            ],
+            # service evaluations
+            [
+                [
+                    ("status", "success"),
+                    ("value/listener_service", "service/name"),
+                    # ("value/status", {"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}}),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/status", {"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}}),
                 ],
             ],
         ),
@@ -332,7 +350,7 @@ def test_broker_checks(
                 status={"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}},
                 spec={"clusterIP": "127.0.0.1"},
             ),
-            # conditions str
+            # listener conditions str
             [
                 "len(brokerlisteners)>=1",
                 "status",
@@ -340,7 +358,7 @@ def test_broker_checks(
                 "spec.serviceName",
                 "status",
             ],
-            # evaluations
+            # listener evaluations
             [
                 [
                     ("status", "success"),
@@ -359,6 +377,22 @@ def test_broker_checks(
                     ("value/spec/authenticationEnabled", "True"),
                 ],
             ],
+            # service conditions str
+            [
+                "listener_service",
+                "spec.clusterIP",
+            ],
+            # service evaluations
+            [
+                [
+                    ("status", "success"),
+                    ("value/listener_service", "service/name"),
+                ],
+                [
+                    ("status", "success"),
+                    ("value/spec.clusterIP", "127.0.0.1"),
+                ],
+            ],
         ),
     ],
 )
@@ -367,8 +401,10 @@ def test_broker_listener_checks(
     mock_evaluate_mq_pod_health,
     listener,
     service,
-    conditions,
-    evaluations,
+    listener_conditions,
+    listener_evaluations,
+    service_conditions,
+    service_evaluations,
     detail_level,
     resource_name,
 ):
@@ -388,9 +424,20 @@ def test_broker_listener_checks(
     result = evaluate_broker_listeners(detail_level=detail_level, resource_name=resource_name)
 
     assert result["name"] == "evalBrokerListeners"
+
+    # check listener target
     assert namespace in result["targets"]["brokerlisteners.mqttbroker.iotoperations.azure.com"]
     target = result["targets"]["brokerlisteners.mqttbroker.iotoperations.azure.com"][namespace]
 
     # conditions
-    assert_conditions(target, conditions)
-    assert_evaluations(target, evaluations)
+    assert_conditions(target, listener_conditions)
+    assert_evaluations(target, listener_evaluations)
+
+    # check service target
+    service_name = listener["spec"]["serviceName"]
+    assert namespace in result["targets"][f"service/{service_name}"]
+    target = result["targets"][f"service/{service_name}"][namespace]
+
+    # conditions
+    assert_conditions(target, service_conditions)
+    assert_evaluations(target, service_evaluations)


### PR DESCRIPTION
bug fixed and added missing test for service check

before:
![image](https://github.com/user-attachments/assets/68c2bcc9-b8c4-4aaf-b0ff-01b8548b0e0f)
after:
<img width="263" alt="image" src="https://github.com/user-attachments/assets/b0b9b757-4aa6-4b49-9319-2c04dccc3fca">

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
