### PR TITLE
fix: update broker runtime status description structure in check for latest CRD

### DIFF
--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -279,9 +279,7 @@ def process_resource_property_by_type(
             return
 
         display_text = f"{display_name}:"
-        check_manager.add_display(
-            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
-        )
+        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
 
         for property in properties:
             display_text = f"- {display_name} {properties.index(property) + 1}"
@@ -308,14 +306,10 @@ def process_resource_property_by_type(
             display_text = f"[cyan]{properties}[/cyan]"
             padding = (0, 0, 0, padding_left + 4)
 
-        check_manager.add_display(
-            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
-        )
+        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
     elif isinstance(properties, dict):
         display_text = f"{display_name}:"
-        check_manager.add_display(
-            target_name=target_name, namespace=namespace, display=Padding(display_text, padding)
-        )
+        check_manager.add_display(target_name=target_name, namespace=namespace, display=Padding(display_text, padding))
         for prop, value in properties.items():
             display_text = f"{prop}: [cyan]{value}[/cyan]"
             check_manager.add_display(
@@ -363,9 +357,7 @@ def validate_one_of_conditions(
         eval_status = CheckTaskStatus.error.value
 
     one_of_condition = f"oneOf({conditions_names})"
-    check_manager.add_target_conditions(
-        target_name=target_name, namespace=namespace, conditions=[one_of_condition]
-    )
+    check_manager.add_target_conditions(target_name=target_name, namespace=namespace, conditions=[one_of_condition])
     check_manager.add_target_eval(
         target_name=target_name,
         namespace=namespace,
@@ -467,9 +459,7 @@ def process_custom_resource_status(
             if prop_value:
                 status_text = f"{prop_name} {{{decorate_resource_status(prop_value.get('status'))}}}."
                 if detail_level == ResourceOutputDetailLevel.verbose.value:
-                    status_description = prop_value.get("statusDescription") or prop_value.get(
-                        "output", {}
-                    ).get("message")
+                    status_description = prop_value.get("description") or prop_value.get("output", {}).get("message")
                     if status_description:
                         status_text = status_text.replace(".", f", [cyan]{status_description}[/cyan].")
 

--- a/azext_edge/tests/edge/checks/base/test_resource_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_resource_unit.py
@@ -857,7 +857,7 @@ def test_calculate_status(resource_state, expected_status):
         # Scenario 1: Both runtimeStatus and provisioningStatus are provided with summary detail level.
         (
             {
-                "runtimeStatus": {"status": "Running", "statusDescription": "All good"},
+                "runtimeStatus": {"status": "Running", "description": "All good"},
                 "provisioningStatus": {"status": "Success"},
             },
             ResourceOutputDetailLevel.summary.value,
@@ -870,7 +870,7 @@ def test_calculate_status(resource_state, expected_status):
                     status="success",
                     value={
                         "status": {
-                            "runtimeStatus": {"status": "Running", "statusDescription": "All good"},
+                            "runtimeStatus": {"status": "Running", "description": "All good"},
                             "provisioningStatus": {"status": "Success"},
                         }
                     },
@@ -897,7 +897,7 @@ def test_calculate_status(resource_state, expected_status):
         # Scenario 3: Both statuses, verbose detail level.
         (
             {
-                "runtimeStatus": {"status": "Running", "statusDescription": "All good"},
+                "runtimeStatus": {"status": "Running", "description": "All good"},
                 "provisioningStatus": {"status": "Success"},
             },
             ResourceOutputDetailLevel.verbose.value,
@@ -914,7 +914,7 @@ def test_calculate_status(resource_state, expected_status):
                     status="success",
                     value={
                         "status": {
-                            "runtimeStatus": {"status": "Running", "statusDescription": "All good"},
+                            "runtimeStatus": {"status": "Running", "description": "All good"},
                             "provisioningStatus": {"status": "Success"},
                         }
                     },

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -213,7 +213,7 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                 status={
                     "runtimeStatus": {
                         "status": ResourceState.running.value,
-                        "statusDescription": "All replicas are running.",
+                        "description": "All replicas are running.",
                     }
                 },
             ),
@@ -250,7 +250,7 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                         {
                             "runtimeStatus": {
                                 "status": ResourceState.running.value,
-                                "statusDescription": "All replicas are running.",
+                                "description": "All replicas are running.",
                             }
                         },
                     ),
@@ -309,7 +309,7 @@ def test_broker_checks(
                     "port": 8080,
                     "authenticationEnabled": "True",
                 },
-                status={"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                status={"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
             ),
             # service obj
             generate_resource_stub(
@@ -331,7 +331,7 @@ def test_broker_checks(
                     ("name", "mock-name"),
                     (
                         "value/status",
-                        {"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                        {"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
                     ),
                 ],
                 [
@@ -370,7 +370,7 @@ def test_broker_checks(
                     "port": 8080,
                     "authenticationEnabled": "True",
                 },
-                status={"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                status={"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
             ),
             # service obj
             generate_resource_stub(
@@ -392,7 +392,7 @@ def test_broker_checks(
                     ("name", "mock-name"),
                     (
                         "value/status",
-                        {"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                        {"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
                     ),
                 ],
                 [

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -66,7 +66,12 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     },
                     "mode": "distributed",
                 },
-                status={"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                status={
+                    "runtimeStatus": {
+                        "status": ResourceState.running.value,
+                        "description": "All replicas are running.",
+                    }
+                },
             ),
             # service obj
             generate_resource_stub(
@@ -98,7 +103,12 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     ("name", "mock-name"),
                     (
                         "value/status",
-                        {"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                        {
+                            "runtimeStatus": {
+                                "status": ResourceState.running.value,
+                                "description": "All replicas are running.",
+                            }
+                        },
                     ),
                 ],
                 [
@@ -129,7 +139,10 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     },
                 },
                 status={
-                    "runtimeStatus": {"status": ResourceState.starting.value, "statusDescription": ""},
+                    "runtimeStatus": {
+                        "status": ResourceState.starting.value,
+                        "description": "Waiting for all replicas to report ready.",
+                    },
                 },
             ),
             # service obj
@@ -157,7 +170,12 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     ("name", "mock-name"),
                     (
                         "value/status",
-                        {"runtimeStatus": {"status": ResourceState.starting.value, "statusDescription": ""}},
+                        {
+                            "runtimeStatus": {
+                                "status": ResourceState.starting.value,
+                                "description": "Waiting for all replicas to report ready.",
+                            }
+                        },
                     ),
                 ],
                 [
@@ -192,7 +210,12 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     },
                     "mode": "distributed",
                 },
-                status={"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                status={
+                    "runtimeStatus": {
+                        "status": ResourceState.running.value,
+                        "statusDescription": "All replicas are running.",
+                    }
+                },
             ),
             # service obj
             generate_resource_stub(
@@ -224,7 +247,12 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     ("name", "mock-name"),
                     (
                         "value/status",
-                        {"runtimeStatus": {"status": ResourceState.running.value, "statusDescription": ""}},
+                        {
+                            "runtimeStatus": {
+                                "status": ResourceState.running.value,
+                                "statusDescription": "All replicas are running.",
+                            }
+                        },
                     ),
                 ],
                 [


### PR DESCRIPTION

<img width="562" alt="image" src="https://github.com/user-attachments/assets/87774194-ab07-4cd9-939f-fb274f63ebbf">
note: description will only show in level 2

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
