### PR TITLE
fix(test): allow warning status for summary int test status via dataflows

### DIFF
--- a/azext_edge/tests/edge/checks/int/test_summary_int.py
+++ b/azext_edge/tests/edge/checks/int/test_summary_int.py
@@ -26,11 +26,17 @@ def test_summary_checks():
     assert len(post) == 1
     checks = post[0]
     assert checks["description"] == "Service summary checks"
-    assert checks["status"] in ["success", "skipped"]
+    # TODO - remove "warning" once dataflow profile no longer displays warning status by default for missing dataflows
+    assert checks["status"] in ["success", "skipped", "warning"]
 
     # assert each service check is either success or skipped
     for api in ["Akri", MQ_ACTIVE_API, OPCUA_API_V1, DATAFLOW_API_V1B1, DEVICEREGISTRY_API_V1]:
         api_target = api.as_str() if api != "Akri" else "Akri"
         assert api_target in checks["targets"]
         service_checks = checks["targets"][api_target]
-        assert service_checks.get(ALL_NAMESPACES_TARGET, {}).get("status") in ["success", "skipped"]
+
+        valid_statuses = ["success", "skipped"]
+        # TODO - remove once dataflow profile no longer displays warning status by default for missing dataflows
+        if api == DATAFLOW_API_V1B1:
+            valid_statuses.append("warning")
+        assert service_checks.get(ALL_NAMESPACES_TARGET, {}).get("status") in valid_statuses


### PR DESCRIPTION
Allows the summary check int test to pass with an overall "warning" status, and allows dataflow check summary to have a "warning" status.

This should be temporary until dataflow profile CRs do not warn for having no referenced dataflows.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
