### PR TITLE
fix: secretstore support bundle test when there is no crd

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -280,7 +280,7 @@ def get_file_map(
         ssc_path = path.join(BASE_ZIP_PATH, ssc_namespace, OpsServiceType.secretstore.value)
         if ops_path not in walk_result:
             # no crd created in aio namespace
-            # since crd is the only resource type uner aio, skip the rest assertions
+            # since crd is the only resource type under aio, skip the rest assertions
             assert len(walk_result) == 1 + expected_default_walk_result
             pytest.skip(f"No bundles created for {ops_service}.")
         else:

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -280,7 +280,9 @@ def get_file_map(
         ssc_path = path.join(BASE_ZIP_PATH, ssc_namespace, OpsServiceType.secretstore.value)
         if ops_path not in walk_result:
             # no crd created in aio namespace
+            # since crd is the only resource type uner aio, skip the rest assertions
             assert len(walk_result) == 1 + expected_default_walk_result
+            pytest.skip(f"No bundles created for {ops_service}.")
         else:
             assert len(walk_result) == 2 + expected_default_walk_result
         file_map[OpsServiceType.secretstore.value] = convert_file_names(walk_result[ssc_path]["files"])

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -279,8 +279,8 @@ def get_file_map(
         ops_path = path.join(BASE_ZIP_PATH, aio_namespace, OpsServiceType.secretstore.value)
         ssc_path = path.join(BASE_ZIP_PATH, ssc_namespace, OpsServiceType.secretstore.value)
         if ops_path not in walk_result:
-            # no crd created in aio namespace
-            # since crd is the only resource type under aio, skip the rest assertions
+            # no CR created in aio namespace
+            # since CR is the only resource type under aio, skip the rest assertions
             assert len(walk_result) == 1 + expected_default_walk_result
             pytest.skip(f"No bundles created for {ops_service}.")
         else:


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
