### PR TITLE
test: separate instance lifecycle tests from init

### DIFF
--- a/azext_edge/tests/edge/init/int/test_init_int.py
+++ b/azext_edge/tests/edge/init/int/test_init_int.py
@@ -239,23 +239,6 @@ def assert_aio_instance(
     assert expected_custom_location in tree
     assert "azure-iot-operations-platform" in tree
 
-    # list failed to return collection response YAY
-    instance_rg_list = run(f"az iot ops list -g {resource_group}")
-    assert instance_name in [inst["name"] for inst in instance_rg_list]
-    instance_sub_list = run("az iot ops list")
-    assert instance_name in [inst["name"] for inst in instance_sub_list]
-
-    # update - ultimate sadness
-    description = generate_random_string()
-    tags = f"{generate_random_string()}={generate_random_string()}"
-    instance_update = run(
-        f"az iot ops update -n {instance_name} -g {resource_group} --description {description} "
-        f"--tags {tags}"
-    )
-    assert instance_update["properties"]["description"] == description
-    tag_key, tag_value = tags.split("=")
-    assert instance_update["tags"][tag_key] == tag_value
-
 
 def assert_broker_args(
     instance_name: str,

--- a/azext_edge/tests/edge/orchestration/resources/test_instance_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instance_int.py
@@ -52,19 +52,19 @@ def test_aio_instance(instance_test_setup, tracked_resources):
     # instance name should be one of the resources
     assert instance_name in tree
 
-    instance_show = run(f"az iot ops show -n {instance_name} -g {resource_group}")
-    if instance_show.get("properties", {}).get("provisioningState") == "Succeeded":
-        pytest.skip("Cannot update instance that is not ready.")
-
     # create random resource to ensure it shows up in show tree
-    aep_name = generate_random_string()
+    aep_name = generate_random_string(force_lower=True)
     aep = run(
-        f"az iot ops asset endpoint opcua create -n {aep_name} -g {resource_group} "
+        f"az iot ops asset endpoint create opcua -n {aep_name} -g {resource_group} "
         f"--instance {instance_name} --target-address opc.tcp://opcplc-000000.azure-iot-operations:50000"
     )
     tracked_resources.append(aep["id"])
     tree = run(f"az iot ops show -n {instance_name} -g {resource_group} --tree")
     assert aep_name in tree
+
+    instance_show = run(f"az iot ops show -n {instance_name} -g {resource_group}")
+    if instance_show.get("properties", {}).get("provisioningState") != "Succeeded":
+        pytest.skip("Cannot update instance that is not ready.")
 
     # update - ultimate sadness
     description = generate_random_string()

--- a/azext_edge/tests/edge/orchestration/resources/test_instance_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instance_int.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from azure.cli.core.azclierror import CLIInternalError
+import pytest
+from knack.log import get_logger
+
+from ....generators import generate_random_string
+from ....helpers import run
+
+logger = get_logger(__name__)
+
+
+@pytest.fixture(scope="function")
+def instance_test_setup(settings):
+    from ....settings import EnvironmentVariables
+    settings.add_to_config(EnvironmentVariables.rg.value)
+    settings.add_to_config(EnvironmentVariables.instance.value)
+    if not all([settings.env.azext_edge_instance, settings.env.azext_edge_rg]):
+        raise AssertionError(
+            "Cannot run instance tests without an instance and resource group. "
+            f"Current settings:\n {settings}"
+        )
+
+    yield {
+        "resourceGroup": settings.env.azext_edge_rg,
+        "instanceName": settings.env.azext_edge_instance
+    }
+
+
+def test_aio_instance(instance_test_setup, tracked_resources):
+    resource_group = instance_test_setup["resourceGroup"]
+    instance_name = instance_test_setup["instanceName"]
+    try:
+        instance_rg_list = run(f"az iot ops list -g {resource_group}")
+        assert instance_name in [inst["name"] for inst in instance_rg_list]
+    except CLIInternalError:
+        logger.error(f"Possible bad instance in resource group {resource_group}")
+
+    try:
+        instance_sub_list = run("az iot ops list")
+        assert instance_name in [inst["name"] for inst in instance_sub_list]
+    except CLIInternalError:
+        sub = run("az account show").get("id", "current")
+        logger.error(f"Possible bad instance in subscription `{sub}`.")
+
+    tree = run(f"az iot ops show -n {instance_name} -g {resource_group} --tree")
+    assert "azure-iot-operations-platform" in tree
+    # instance name should be one of the resources
+    assert instance_name in tree
+
+    instance_show = run(f"az iot ops show -n {instance_name} -g {resource_group}")
+    if instance_show.get("properties", {}).get("provisioningState") == "Succeeded":
+        pytest.skip("Cannot update instance that is not ready.")
+
+    # create random resource to ensure it shows up in show tree
+    aep_name = generate_random_string()
+    aep = run(
+        f"az iot ops asset endpoint opcua create -n {aep_name} -g {resource_group} "
+        f"--instance {instance_name} --target-address opc.tcp://opcplc-000000.azure-iot-operations:50000"
+    )
+    tracked_resources.append(aep["id"])
+    tree = run(f"az iot ops show -n {instance_name} -g {resource_group} --tree")
+    assert aep_name in tree
+
+    # update - ultimate sadness
+    description = generate_random_string()
+    tags = f"{generate_random_string()}={generate_random_string()}"
+    instance_update = run(
+        f"az iot ops update -n {instance_name} -g {resource_group} --description {description} "
+        f"--tags {tags}"
+    )
+    assert instance_update["properties"]["description"] == description
+    tag_key, tag_value = tags.split("=")
+    assert instance_update["tags"][tag_key] == tag_value


### PR DESCRIPTION
new test
![image](https://github.com/user-attachments/assets/e1176e49-ea27-4d53-84a4-0284a16e31d0)


init 
![image](https://github.com/user-attachments/assets/7adcce84-3440-40f6-8dbf-551e1a61bd58)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
