### PR TITLE
feat: register required resource providers in `az iot ops schema registry create`

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1205,6 +1205,9 @@ def load_iotops_help():
 
                       If the indicated storage account container does not exist it will be created with default
                       settings.
+
+                      If the required Resource Providers for IoT Operations are not registered, this will
+                      register them.
         examples:
         - name: Create a schema registry called 'myregistry' with minimum inputs.
           text: >

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1206,8 +1206,8 @@ def load_iotops_help():
                       If the indicated storage account container does not exist it will be created with default
                       settings.
 
-                      If the required Resource Providers for IoT Operations are not registered, this will
-                      register them.
+                      This operation will also register the Microsoft.DeviceRegistry resource provider if it is
+                      not registered.
         examples:
         - name: Create a schema registry called 'myregistry' with minimum inputs.
           text: >

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -69,7 +69,7 @@ class SchemaRegistries(Queryable):
     ) -> dict:
         from ..rp_namespace import register_providers, ADR_PROVIDER
         with console.status("Working...") as c:
-            # Register providers
+            # Register the schema (ADR) provider
             register_providers(self.default_subscription_id, ADR_PROVIDER)
 
             if not location:

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -11,6 +11,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from knack.log import get_logger
 from rich.console import Console
 
+
 from ....util.az_client import (
     get_registry_mgmt_client,
     get_storage_mgmt_client,
@@ -66,7 +67,11 @@ class SchemaRegistries(Queryable):
         custom_role_id: Optional[str] = None,
         **kwargs,
     ) -> dict:
+        from ..rp_namespace import register_providers
         with console.status("Working...") as c:
+            # Register providers - may as well do all for AIO
+            register_providers(self.default_subscription_id)
+
             if not location:
                 location = self.get_resource_group(name=resource_group_name)["location"]
 

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -67,10 +67,10 @@ class SchemaRegistries(Queryable):
         custom_role_id: Optional[str] = None,
         **kwargs,
     ) -> dict:
-        from ..rp_namespace import register_providers
+        from ..rp_namespace import register_providers, ADR_PROVIDER
         with console.status("Working...") as c:
             # Register providers - may as well do all for AIO
-            register_providers(self.default_subscription_id)
+            register_providers(self.default_subscription_id, ADR_PROVIDER)
 
             if not location:
                 location = self.get_resource_group(name=resource_group_name)["location"]

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -69,7 +69,7 @@ class SchemaRegistries(Queryable):
     ) -> dict:
         from ..rp_namespace import register_providers, ADR_PROVIDER
         with console.status("Working...") as c:
-            # Register providers - may as well do all for AIO
+            # Register providers
             register_providers(self.default_subscription_id, ADR_PROVIDER)
 
             if not location:

--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+from typing import Optional
 from knack.log import get_logger
 
 from ...util.az_client import get_resource_client
@@ -11,20 +12,22 @@ from ...util.az_client import get_resource_client
 logger = get_logger(__name__)
 
 
+ADR_PROVIDER = "Microsoft.DeviceRegistry"
 RP_NAMESPACE_SET = frozenset(
     [
         "Microsoft.IoTOperations",
-        "Microsoft.DeviceRegistry",
         "Microsoft.SecretSyncController",
+        ADR_PROVIDER
     ]
 )
 
 
-def register_providers(subscription_id: str):
+def register_providers(subscription_id: str, resource_provider: Optional[str] = None):
     resource_client = get_resource_client(subscription_id=subscription_id)
     providers_list = resource_client.providers.list()
+    required_providers = [resource_provider] if resource_provider else RP_NAMESPACE_SET
     for provider in providers_list:
-        if "namespace" in provider and provider["namespace"] in RP_NAMESPACE_SET:
+        if "namespace" in provider and provider["namespace"] in required_providers:
             if provider["registrationState"] == "Registered":
                 logger.debug("RP %s is already registered.", provider["namespace"])
                 continue

--- a/azext_edge/tests/edge/conftest.py
+++ b/azext_edge/tests/edge/conftest.py
@@ -35,6 +35,12 @@ def mocked_urlopen(mocker):
 
 
 @pytest.fixture
+def mocked_register_providers(mocker):
+    patched = mocker.patch("azext_edge.edge.providers.orchestration.rp_namespace.register_providers", autospec=True)
+    yield patched
+
+
+@pytest.fixture
 def mocked_resource_management_client(request, mocker):
     request_results = getattr(request, "param", {})
     resource_mgmt_client = mocker.Mock()

--- a/azext_edge/tests/edge/init/conftest.py
+++ b/azext_edge/tests/edge/init/conftest.py
@@ -49,12 +49,6 @@ def mocked_verify_cli_client_connections(mocker):
 
 
 @pytest.fixture
-def mocked_register_providers(mocker):
-    patched = mocker.patch("azext_edge.edge.providers.orchestration.rp_namespace.register_providers", autospec=True)
-    yield patched
-
-
-@pytest.fixture
 def mocked_edge_api_keyvault_api_v1(mocker):
     patched = mocker.patch("azext_edge.edge.providers.edge_api.keyvault.KEYVAULT_API_V1", autospec=False)
     yield patched

--- a/azext_edge/tests/edge/init/test_base_unit.py
+++ b/azext_edge/tests/edge/init/test_base_unit.py
@@ -324,7 +324,8 @@ def test_verify_custom_location_namespace(
         "NotRegistered",
     ],
 )
-def test_register_providers(mocker, registration_state):
+@pytest.mark.parametrize("input_rp", [None, "Microsoft.DeviceRegistry"])
+def test_register_providers(mocker, registration_state, input_rp):
     mocked_get_resource_client: Mock = mocker.patch(
         "azext_edge.edge.providers.orchestration.rp_namespace.get_resource_client"
     )
@@ -338,6 +339,8 @@ def test_register_providers(mocker, registration_state):
         "Microsoft.DeviceRegistry",
         "Microsoft.SecretSyncController",
     ]
+    if input_rp:
+        iot_ops_rps = [input_rp]
     mocked_get_resource_client().providers.list.return_value = [
         {"namespace": namespace, "registrationState": registration_state} for namespace in iot_ops_rps
     ]

--- a/azext_edge/tests/edge/init/test_base_unit.py
+++ b/azext_edge/tests/edge/init/test_base_unit.py
@@ -347,7 +347,7 @@ def test_register_providers(mocker, registration_state, input_rp):
 
     for rp in iot_ops_rps:
         assert rp in RP_NAMESPACE_SET
-    assert len(iot_ops_rps) == len(RP_NAMESPACE_SET)
+    assert len(iot_ops_rps) == (1 if input_rp else len(RP_NAMESPACE_SET))
 
     register_providers(ZEROED_SUB)
     mocked_get_resource_client().providers.list.assert_called_once()

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
@@ -22,6 +22,7 @@ from azext_edge.edge.providers.orchestration.resources.schema_registries import 
     ROLE_DEF_FORMAT_STR,
     STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE_ID,
 )
+from azext_edge.edge.providers.orchestration.rp_namespace import ADR_PROVIDER
 
 from ....generators import generate_random_string
 from .conftest import get_base_endpoint, get_mock_resource, get_resource_id, find_request_by_url, ZEROED_SUBSCRIPTION
@@ -344,7 +345,7 @@ def test_schema_registry_create(
         == f"{mock_storage_record['properties']['primaryEndpoints']['blob']}{storage_container_name}"
     )
 
-    mocked_register_providers.assert_called_with(ZEROED_SUBSCRIPTION)
+    mocked_register_providers.assert_called_with(ZEROED_SUBSCRIPTION, ADR_PROVIDER)
     mock_permission_manager.assert_called_with(ZEROED_SUBSCRIPTION)
     target_role_id = custom_role_id or ROLE_DEF_FORMAT_STR.format(
         subscription_id=ZEROED_SUBSCRIPTION, role_id=STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE_ID

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
@@ -218,8 +218,9 @@ def test_schema_registry_delete(mocked_cmd, mocked_responses: responses):
 )
 def test_schema_registry_create(
     mocked_cmd,
-    mocked_responses: responses,
     mocker,
+    mocked_register_providers,
+    mocked_responses: responses,
     location: Optional[str],
     display_name: Optional[str],
     description: Optional[str],
@@ -343,6 +344,7 @@ def test_schema_registry_create(
         == f"{mock_storage_record['properties']['primaryEndpoints']['blob']}{storage_container_name}"
     )
 
+    mocked_register_providers.assert_called_with(ZEROED_SUBSCRIPTION)
     mock_permission_manager.assert_called_with(ZEROED_SUBSCRIPTION)
     target_role_id = custom_role_id or ROLE_DEF_FORMAT_STR.format(
         subscription_id=ZEROED_SUBSCRIPTION, role_id=STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE_ID


### PR DESCRIPTION
Add in the rp register helper into create before everything else. Registering just the ADR for good security practices.

I am keeping the init rp register JUST in case something gets unregistered.
![image](https://github.com/user-attachments/assets/cb2c8c0c-1814-44aa-8924-962591a99aa3)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
