### PR TITLE
feat: update init and create flows with M3 template

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.7.0b2"
+VERSION = "0.8.0a1"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -478,15 +478,14 @@ def load_iotops_help():
         examples:
         - name: Usage with minimum input. This form will deploy the IoT Operations foundation layer.
           text: >
-             az iot ops init --cluster mycluster -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
+             az iot ops init --cluster mycluster -g myresourcegroup
         - name: Similar to the prior example but with Arc Container Storage fault-tolerance enabled (requires at least 3 nodes).
           text: >
-             az iot ops init --cluster mycluster -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
-             --enable-fault-tolerance
+             az iot ops init --cluster mycluster -g myresourcegroup --enable-fault-tolerance
         - name: This example highlights trust settings for a user provided cert manager config.
           text: >
-             az iot ops init --cluster mycluster -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
-             --trust-settings configMapName=example-bundle configMapKey=trust-bundle.pem issuerKind=ClusterIssuer
+             az iot ops init --cluster mycluster -g myresourcegroup --trust-settings 
+             configMapName=example-bundle configMapKey=trust-bundle.pem issuerKind=ClusterIssuer
              issuerName=trust-manager-selfsigned-issuer
 
     """
@@ -505,23 +504,23 @@ def load_iotops_help():
         examples:
         - name: Create the target instance with minimum input.
           text: >
-            az iot ops create --cluster mycluster -g myresourcegroup --name myinstance
+            az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
         - name: The following example adds customization to the default broker instance resource
             as well as an instance description and tags.
           text: >
-             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance
+             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
              --broker-mem-profile High --broker-backend-workers 4 --description 'Contoso Factory'
              --tags tier=testX1
         - name: This example shows deploying an additional insecure (no authn or authz) broker listener
             configured for port 1883 of service type load balancer. Useful for testing and/or demos.
             Do not use the insecure option in production.
           text: >
-             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance
+             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
              --add-insecure-listener
         - name: This form shows how to enable resource sync for the instance deployment.
             To enable resource sync role assignment write is necessary on the target resource group.
           text: >
-             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance
+             az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
              --enable-rsync
     """
 

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -484,7 +484,7 @@ def load_iotops_help():
              az iot ops init --cluster mycluster -g myresourcegroup --enable-fault-tolerance
         - name: This example highlights trust settings for a user provided cert manager config.
           text: >
-             az iot ops init --cluster mycluster -g myresourcegroup --trust-settings 
+             az iot ops init --cluster mycluster -g myresourcegroup --trust-settings
              configMapName=example-bundle configMapKey=trust-bundle.pem issuerKind=ClusterIssuer
              issuerName=trust-manager-selfsigned-issuer
 

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -109,7 +109,6 @@ def init(
     cmd,
     cluster_name: str,
     resource_group_name: str,
-    schema_registry_resource_id: str,
     container_runtime_socket: Optional[str] = None,
     kubernetes_distro: str = KubernetesDistroType.k8s.value,
     trust_settings: Optional[List[str]] = None,
@@ -140,7 +139,6 @@ def init(
         ops_config=ops_config,
         ops_version=ops_version,
         trust_settings=trust_settings,
-        schema_registry_resource_id=schema_registry_resource_id,
     )
 
 
@@ -149,6 +147,7 @@ def create_instance(
     cluster_name: str,
     resource_group_name: str,
     instance_name: str,
+    schema_registry_resource_id: str,
     cluster_namespace: str = DEFAULT_NAMESPACE,
     location: Optional[str] = None,
     custom_location_name: Optional[str] = None,
@@ -196,6 +195,7 @@ def create_instance(
         cluster_name=cluster_name,
         resource_group_name=resource_group_name,
         cluster_namespace=cluster_namespace,
+        schema_registry_resource_id=schema_registry_resource_id,
         location=location,
         custom_location_name=custom_location_name,
         enable_rsync_rules=enable_rsync_rules,

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -109,12 +109,8 @@ def init(
     cmd,
     cluster_name: str,
     resource_group_name: str,
-    container_runtime_socket: Optional[str] = None,
-    kubernetes_distro: str = KubernetesDistroType.k8s.value,
     trust_settings: Optional[List[str]] = None,
     enable_fault_tolerance: Optional[bool] = None,
-    ops_config: Optional[List[str]] = None,
-    ops_version: Optional[str] = None,
     no_progress: Optional[bool] = None,
     ensure_latest: Optional[bool] = None,
     **kwargs,
@@ -133,11 +129,7 @@ def init(
         pre_flight=not no_pre_flight,
         cluster_name=cluster_name,
         resource_group_name=resource_group_name,
-        container_runtime_socket=container_runtime_socket,
-        kubernetes_distro=kubernetes_distro,
         enable_fault_tolerance=enable_fault_tolerance,
-        ops_config=ops_config,
-        ops_version=ops_version,
         trust_settings=trust_settings,
     )
 
@@ -154,6 +146,11 @@ def create_instance(
     enable_rsync_rules: Optional[bool] = None,
     instance_description: Optional[str] = None,
     dataflow_profile_instances: int = 1,
+    # Ops extension
+    container_runtime_socket: Optional[str] = None,
+    kubernetes_distro: str = KubernetesDistroType.k8s.value,
+    ops_config: Optional[List[str]] = None,
+    ops_version: Optional[str] = None,
     # Broker
     custom_broker_config_file: Optional[str] = None,
     broker_memory_profile: str = MqMemoryProfile.medium.value,
@@ -203,6 +200,11 @@ def create_instance(
         instance_description=instance_description,
         add_insecure_listener=add_insecure_listener,
         dataflow_profile_instances=dataflow_profile_instances,
+        # Ops Extension
+        container_runtime_socket=container_runtime_socket,
+        kubernetes_distro=kubernetes_distro,
+        ops_config=ops_config,
+        ops_version=ops_version,
         # Broker
         custom_broker_config=custom_broker_config,
         broker_memory_profile=broker_memory_profile,

--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -141,15 +141,18 @@ class DeletionManager:
 
     def _process(self, force: bool = False):
         # instance delete should always delete the extension too
+        # TODO - @c-ryan-k - fix this and update unit tests
         aio_ext = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
             IOT_OPS_EXTENSION_TYPE
         )
-        aio_ext_id = aio_ext["id"] if aio_ext else None
-        aio_ext_obj = next((_ for _ in self.resource_map.extensions if _.resource_id == aio_ext_id), None)
+        # aio_ext_obj = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
+        #     IOT_OPS_EXTENSION_TYPE
+        # )
+        # aio_ext_id = aio_ext["id"] if aio_ext else None
+        # aio_ext = next((_ for _ in self.resource_map.extensions if _.resource_id == aio_ext_id), None)
         todo_extensions = []
-        # TODO - @c-ryan-k see if we can add extensions to delete tree output
-        if aio_ext_obj:
-            todo_extensions.append(aio_ext_obj)  # delete aio extension even if no dependencies
+        if aio_ext:
+            todo_extensions.append(aio_ext)  # delete aio extension even if no dependencies
         if self.include_dependencies:
             todo_extensions.extend(self.resource_map.extensions)
         todo_custom_locations = self.resource_map.custom_locations

--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -144,10 +144,12 @@ class DeletionManager:
         aio_ext = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
             IOT_OPS_EXTENSION_TYPE
         )
-        # TODO - @c-ryan-k this should always be true, right?
+        aio_ext_id = aio_ext["id"] if aio_ext else None
+        aio_ext_obj = next((_ for _ in self.resource_map.extensions if _.resource_id == aio_ext_id), None)
         todo_extensions = []
-        if aio_ext:
-            todo_extensions.append(aio_ext)  # delete aio extension even if no dependencies
+        # TODO - @c-ryan-k see if we can add extensions to delete tree output
+        if aio_ext_obj:
+            todo_extensions.append(aio_ext_obj)  # delete aio extension even if no dependencies
         if self.include_dependencies:
             todo_extensions.extend(self.resource_map.extensions)
         todo_custom_locations = self.resource_map.custom_locations

--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -16,6 +16,8 @@ from rich.live import Live
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 from rich.table import Table
 
+from azext_edge.edge.providers.orchestration.work import IOT_OPS_EXTENSION_TYPE
+
 from ...util.az_client import get_resource_client, wait_for_terminal_states
 from ...util.common import should_continue_prompt
 from .resource_map import IoTOperationsResource, IoTOperationsResourceMap
@@ -138,7 +140,14 @@ class DeletionManager:
             self._live.stop()
 
     def _process(self, force: bool = False):
+        # instance delete should always delete the extension too
+        aio_ext = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
+            IOT_OPS_EXTENSION_TYPE
+        )
+        # TODO - @c-ryan-k this should always be true, right?
         todo_extensions = []
+        if aio_ext:
+            todo_extensions.append(aio_ext)  # delete aio extension even if no dependencies
         if self.include_dependencies:
             todo_extensions.extend(self.resource_map.extensions)
         todo_custom_locations = self.resource_map.custom_locations

--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -140,19 +140,15 @@ class DeletionManager:
             self._live.stop()
 
     def _process(self, force: bool = False):
-        # instance delete should always delete the extension too
-        # TODO - @c-ryan-k - fix this and update unit tests
-        aio_ext = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
+        # instance delete should delete AIO extension too
+        aio_ext_obj = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
             IOT_OPS_EXTENSION_TYPE
         )
-        # aio_ext_obj = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
-        #     IOT_OPS_EXTENSION_TYPE
-        # )
-        # aio_ext_id = aio_ext["id"] if aio_ext else None
-        # aio_ext = next((_ for _ in self.resource_map.extensions if _.resource_id == aio_ext_id), None)
         todo_extensions = []
-        if aio_ext:
-            todo_extensions.append(aio_ext)  # delete aio extension even if no dependencies
+        if aio_ext_obj and not self.include_dependencies:
+            aio_ext_id = aio_ext_obj.get("id") if aio_ext_obj else None
+            aio_ext = next((_ for _ in self.resource_map.extensions if _.resource_id == aio_ext_id), None)
+            todo_extensions.append(aio_ext)  # delete aio extension with instance
         if self.include_dependencies:
             todo_extensions.extend(self.resource_map.extensions)
         todo_custom_locations = self.resource_map.custom_locations

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -156,22 +156,7 @@ class InitTargets:
 
     def get_ops_instance_template(
         self, cl_extension_ids: List[str],
-        # ops_extension_config: Dict[str, str]
     ) -> Tuple[dict, dict]:
-        # TODO - @c-ryan-k figure out wtf to do with this
-        # trust_source = ops_extension_config.get("trustSource")
-
-        # if trust_source == "CustomerManaged":
-        #     trust_issuer_name = ops_extension_config.get("trustBundleSettings.issuer.name")
-        #     trust_issuer_kind = ops_extension_config.get("trustBundleSettings.issuer.kind")
-        #     trust_configmap_name = ops_extension_config.get("trustBundleSettings.configMap.name")
-        #     trust_configmap_key = ops_extension_config.get("trustBundleSettings.configMap.key")
-        #     self.trust_settings = {
-        #         "issuerName": trust_issuer_name,
-        #         "issuerKind": trust_issuer_kind,
-        #         "configMapName": trust_configmap_name,
-        #         "configMapKey": trust_configmap_key,
-        #     }
         self.trust_config = self.get_trust_settings_target_map()
 
         template, parameters = self._handle_apply_targets(

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -148,7 +148,6 @@ class InitTargets:
                 "kubernetesDistro": self.kubernetes_distro,
                 "containerRuntimeSocket": self.container_runtime_socket,
                 "trustConfig": self.trust_config,
-                "schemaRegistryId": self.schema_registry_resource_id,
                 "advancedConfig": self.advanced_config,
             },
             template_blueprint=M2_ENABLEMENT_TEMPLATE,

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -155,21 +155,23 @@ class InitTargets:
         return template.content, parameters
 
     def get_ops_instance_template(
-        self, cl_extension_ids: List[str], ops_extension_config: Dict[str, str]
+        self, cl_extension_ids: List[str],
+        # ops_extension_config: Dict[str, str]
     ) -> Tuple[dict, dict]:
-        trust_source = ops_extension_config.get("trustSource")
+        # TODO - @c-ryan-k figure out wtf to do with this
+        # trust_source = ops_extension_config.get("trustSource")
 
-        if trust_source == "CustomerManaged":
-            trust_issuer_name = ops_extension_config.get("trustBundleSettings.issuer.name")
-            trust_issuer_kind = ops_extension_config.get("trustBundleSettings.issuer.kind")
-            trust_configmap_name = ops_extension_config.get("trustBundleSettings.configMap.name")
-            trust_configmap_key = ops_extension_config.get("trustBundleSettings.configMap.key")
-            self.trust_settings = {
-                "issuerName": trust_issuer_name,
-                "issuerKind": trust_issuer_kind,
-                "configMapName": trust_configmap_name,
-                "configMapKey": trust_configmap_key,
-            }
+        # if trust_source == "CustomerManaged":
+        #     trust_issuer_name = ops_extension_config.get("trustBundleSettings.issuer.name")
+        #     trust_issuer_kind = ops_extension_config.get("trustBundleSettings.issuer.kind")
+        #     trust_configmap_name = ops_extension_config.get("trustBundleSettings.configMap.name")
+        #     trust_configmap_key = ops_extension_config.get("trustBundleSettings.configMap.key")
+        #     self.trust_settings = {
+        #         "issuerName": trust_issuer_name,
+        #         "issuerKind": trust_issuer_kind,
+        #         "configMapName": trust_configmap_name,
+        #         "configMapKey": trust_configmap_key,
+        #     }
         self.trust_config = self.get_trust_settings_target_map()
 
         template, parameters = self._handle_apply_targets(

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -145,20 +145,11 @@ class InitTargets:
         template, parameters = self._handle_apply_targets(
             param_to_target={
                 "clusterName": self.cluster_name,
-                "kubernetesDistro": self.kubernetes_distro,
-                "containerRuntimeSocket": self.container_runtime_socket,
                 "trustConfig": self.trust_config,
                 "advancedConfig": self.advanced_config,
             },
             template_blueprint=M2_ENABLEMENT_TEMPLATE,
         )
-
-        if self.ops_config:
-            aio_default_config: Dict[str, str] = template.content["variables"]["defaultAioConfigurationSettings"]
-            aio_default_config.update(self.ops_config)
-
-        if self.ops_version:
-            template.content["variables"]["VERSIONS"]["aio"] = self.ops_version
 
         # TODO - @digimaun - expand trustSource for self managed & trustBundleSettings
         return template.content, parameters
@@ -186,6 +177,8 @@ class InitTargets:
                 "clusterName": self.cluster_name,
                 "clusterNamespace": self.cluster_namespace,
                 "clusterLocation": self.location,
+                "kubernetesDistro": self.kubernetes_distro,
+                "containerRuntimeSocket": self.container_runtime_socket,
                 "customLocationName": self.custom_location_name,
                 "clExtentionIds": cl_extension_ids,
                 "deployResourceSyncRules": self.deploy_resource_sync_rules,
@@ -196,6 +189,14 @@ class InitTargets:
             },
             template_blueprint=M2_INSTANCE_TEMPLATE,
         )
+
+        if self.ops_config:
+            aio_default_config: Dict[str, str] = template.content["variables"]["defaultAioConfigurationSettings"]
+            aio_default_config.update(self.ops_config)
+
+        if self.ops_version:
+            template.content["variables"]["VERSIONS"]["iotOperations"] = self.ops_version
+
         instance = template.get_resource_by_key("aioInstance")
         instance["properties"]["description"] = self.instance_description
 

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -203,9 +203,9 @@ class InitTargets:
         instance["properties"]["description"] = self.instance_description
 
         # TODO: this is temporary for this milestone. Next milestone it should change.
-        instance["properties"][
-            "schemaRegistryNamespace"
-        ] = f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').namespace]"
+        instance["properties"]["schemaRegistryRef"] = {
+            "resourceId": f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').id]"
+        }
 
         if self.tags:
             instance["tags"] = self.tags

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -24,8 +24,8 @@ from ..orchestration.common import (
 from .common import KubernetesDistroType
 from .template import (
     IOT_OPERATIONS_VERSION_MONIKER,
-    M2_ENABLEMENT_TEMPLATE,
-    M2_INSTANCE_TEMPLATE,
+    M3_ENABLEMENT_TEMPLATE,
+    M3_INSTANCE_TEMPLATE,
     TemplateBlueprint,
     get_insecure_listener,
 )
@@ -137,7 +137,7 @@ class InitTargets:
 
     def get_extension_versions(self) -> dict:
         # Don't need a deep copy here.
-        return M2_ENABLEMENT_TEMPLATE.content["variables"]["VERSIONS"].copy()
+        return M3_ENABLEMENT_TEMPLATE.content["variables"]["VERSIONS"].copy()
 
     def get_ops_enablement_template(
         self,
@@ -148,7 +148,7 @@ class InitTargets:
                 "trustConfig": self.trust_config,
                 "advancedConfig": self.advanced_config,
             },
-            template_blueprint=M2_ENABLEMENT_TEMPLATE,
+            template_blueprint=M3_ENABLEMENT_TEMPLATE,
         )
 
         # TODO - @digimaun - expand trustSource for self managed & trustBundleSettings
@@ -189,7 +189,7 @@ class InitTargets:
                 "brokerConfig": self.broker_config,
                 "trustConfig": self.trust_config,
             },
-            template_blueprint=M2_INSTANCE_TEMPLATE,
+            template_blueprint=M3_INSTANCE_TEMPLATE,
         )
 
         if self.ops_config:
@@ -249,7 +249,7 @@ class InitTargets:
         processed_config_map = {}
 
         validation_errors = []
-        broker_config_def = M2_INSTANCE_TEMPLATE.get_type_definition("_1.BrokerConfig")["properties"]
+        broker_config_def = M3_INSTANCE_TEMPLATE.get_type_definition("_1.BrokerConfig")["properties"]
         for config in to_process_config_map:
             if to_process_config_map[config] is None:
                 continue
@@ -293,7 +293,7 @@ class InitTargets:
         if self.trust_settings:
             target_settings: Dict[str, str] = {}
             result["source"] = "CustomerManaged"
-            trust_bundle_def = M2_ENABLEMENT_TEMPLATE.get_type_definition("_1.TrustBundleSettings")["properties"]
+            trust_bundle_def = M3_ENABLEMENT_TEMPLATE.get_type_definition("_1.TrustBundleSettings")["properties"]
             allowed_issuer_kinds: Optional[List[str]] = trust_bundle_def.get(TRUST_ISSUER_KIND_KEY, {}).get(
                 "allowedValues"
             )

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -16,7 +16,7 @@ from ...common import (
     DEFAULT_DATAFLOW_PROFILE,
 )
 from ...util import assemble_nargs_to_dict
-from ...util.az_client import parse_resource_id, REGISTRY_API_VERSION
+from ...util.az_client import parse_resource_id
 from ..orchestration.common import (
     TRUST_ISSUER_KIND_KEY,
     TRUST_SETTING_KEYS,
@@ -166,8 +166,6 @@ class InitTargets:
     def get_ops_instance_template(
         self, cl_extension_ids: List[str], ops_extension_config: Dict[str, str]
     ) -> Tuple[dict, dict]:
-        # Set the schema registry resource Id from the extension config
-        self.schema_registry_resource_id = ops_extension_config.get("schemaRegistry.values.resourceId")
         trust_source = ops_extension_config.get("trustSource")
 
         if trust_source == "CustomerManaged":
@@ -201,9 +199,8 @@ class InitTargets:
         instance = template.get_resource_by_key("aioInstance")
         instance["properties"]["description"] = self.instance_description
 
-        # TODO: this is temporary for this milestone. Next milestone it should change.
         instance["properties"]["schemaRegistryRef"] = {
-            "resourceId": f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').id]"
+            "resourceId": "[parameters('schemaRegistryId')]"
         }
 
         if self.tags:

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -49,7 +49,7 @@ class TemplateBlueprint(NamedTuple):
 
 IOT_OPERATIONS_VERSION_MONIKER = "v0.8.0-preview"
 
-M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
+M3_ENABLEMENT_TEMPLATE = TemplateBlueprint(
     commit_id="78864ae529f698cf1c9bf0be0a6957e6c9f3cf38",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -348,7 +348,7 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
     },
 )
 
-M2_INSTANCE_TEMPLATE = TemplateBlueprint(
+M3_INSTANCE_TEMPLATE = TemplateBlueprint(
     commit_id="373335547851df70d512b7ec81aedfba0d660ae5",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -355,7 +355,7 @@ M3_INSTANCE_TEMPLATE = TemplateBlueprint(
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "4431973576934377606"}
+            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "8789011211011918491"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -527,7 +527,7 @@ M3_INSTANCE_TEMPLATE = TemplateBlueprint(
         "variables": {
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "AIO_EXTENSION_SCOPE": {"cluster": {"releaseNamespace": "azure-iot-operations"}},
-            "VERSIONS": {"iotOperations": "0.8.3"},
+            "VERSIONS": {"iotOperations": "0.8.16"},
             "TRAINS": {"iotOperations": "integration"},
             "MQTT_SETTINGS": {
                 "brokerListenerServiceName": "aio-broker",

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -56,7 +56,7 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "12202254502014934933"}
+            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "2952065196343262420"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -208,66 +208,25 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
         },
         "parameters": {
             "clusterName": {"type": "string"},
-            "kubernetesDistro": {"type": "string", "defaultValue": "K8s", "allowedValues": ["K3s", "K8s", "MicroK8s"]},
-            "containerRuntimeSocket": {"type": "string", "defaultValue": ""},
             "trustConfig": {"$ref": "#/definitions/_1.TrustConfig", "defaultValue": {"source": "SelfSigned"}},
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "AIO_EXTENSION_SCOPE": {"cluster": {"releaseNamespace": "azure-iot-operations"}},
-            "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "VERSIONS": {
                 "platform": "0.7.6",
-                "iotOperations": "0.8.3",
                 "secretStore": "0.6.4",
                 "containerStorage": "2.1.1-preview",
                 "openServiceMesh": "1.2.9",
             },
             "TRAINS": {
                 "platform": "preview",
-                "iotOperations": "integration",
                 "secretStore": "preview",
                 "containerStorage": "stable",
                 "openServiceMesh": "stable",
             },
-            "MQTT_SETTINGS": {
-                "brokerListenerServiceName": "aio-broker",
-                "brokerListenerPort": 18883,
-                "serviceAccountAudience": "aio-internal",
-                "selfSignedIssuerName": "[format('{0}-aio-certificate-issuer', variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace)]",
-            },
             "faultTolerantStorageClass": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'edgeStorageAccelerator'), 'diskStorageClass'), 'acstor-arccontainerstorage-storage-pool')]",
             "nonFaultTolerantStorageClass": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'edgeStorageAccelerator'), 'diskStorageClass'), 'default,local-path')]",
             "kubernetesStorageClass": "[if(equals(tryGet(tryGet(parameters('advancedConfig'), 'edgeStorageAccelerator'), 'faultToleranceEnabled'), true()), variables('faultTolerantStorageClass'), variables('nonFaultTolerantStorageClass'))]",
-            "defaultAioConfigurationSettings": {
-                "AgentOperationTimeoutInMinutes": 120,
-                "connectors.values.mqttBroker.address": "[format('mqtts://{0}.{1}:{2}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace, variables('MQTT_SETTINGS').brokerListenerPort)]",
-                "connectors.values.mqttBroker.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
-                "connectors.values.opcPlcSimulation.deploy": "false",
-                "connectors.values.opcPlcSimulation.autoAcceptUntrustedCertificates": "false",
-                "connectors.values.discoveryHandler.enabled": "false",
-                "adr.values.Microsoft.CustomLocation.ServiceAccount": "default",
-                "akri.values.webhookConfiguration.enabled": "false",
-                "akri.values.certManagerWebhookCertificate.enabled": "false",
-                "akri.values.agent.extensionService.mqttBroker.hostName": "[format('{0}.{1}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace)]",
-                "akri.values.agent.extensionService.mqttBroker.port": "[variables('MQTT_SETTINGS').brokerListenerPort]",
-                "akri.values.agent.extensionService.mqttBroker.serviceAccountAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
-                "akri.values.agent.host.containerRuntimeSocket": "[parameters('containerRuntimeSocket')]",
-                "akri.values.kubernetesDistro": "[toLower(parameters('kubernetesDistro'))]",
-                "mqttBroker.values.global.quickstart": "false",
-                "mqttBroker.values.operator.firstPartyMetricsOn": "true",
-                "observability.metrics.enabled": "[format('{0}', coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'enabled'), false()))]",
-                "observability.metrics.openTelemetryCollectorAddress": "[if(coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'enabled'), false()), format('{0}', tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'otelCollectorAddress')), '')]",
-                "observability.metrics.exportIntervalSeconds": "[format('{0}', coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'otelExportIntervalSeconds'), 60))]",
-                "trustSource": "[parameters('trustConfig').source]",
-                "trustBundleSettings.issuer.name": "[if(equals(parameters('trustConfig').source, 'CustomerManaged'), parameters('trustConfig').settings.issuerName, variables('MQTT_SETTINGS').selfSignedIssuerName)]",
-                "trustBundleSettings.issuer.kind": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'issuerKind'), '')]",
-                "trustBundleSettings.configMap.name": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'configMapName'), '')]",
-                "trustBundleSettings.configMap.key": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'configMapKey'), '')]",
-                "schemaRegistry.values.mqttBroker.host": "[format('mqtts://{0}.{1}:{2}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace, variables('MQTT_SETTINGS').brokerListenerPort)]",
-                "schemaRegistry.values.mqttBroker.tlsEnabled": True,
-                "schemaRegistry.values.mqttBroker.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
-            },
         },
         "resources": {
             "cluster": {
@@ -280,7 +239,7 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
                 "type": "Microsoft.KubernetesConfiguration/extensions",
                 "apiVersion": "2023-05-01",
                 "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
-                "name": "[format('azure-iot-operations-platform-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                "name": "azure-iot-operations-platform",
                 "identity": {"type": "SystemAssigned"},
                 "properties": {
                     "extensionType": "microsoft.iotoperations.platform",
@@ -317,7 +276,7 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
                 "type": "Microsoft.KubernetesConfiguration/extensions",
                 "apiVersion": "2023-05-01",
                 "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
-                "name": "[format('open-service-mesh-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                "name": "open-service-mesh",
                 "properties": {
                     "extensionType": "microsoft.openservicemesh",
                     "autoUpgradeMinorVersion": False,
@@ -346,50 +305,22 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
                 },
                 "dependsOn": ["aio_platform_extension", "cluster", "open_service_mesh_extension"],
             },
-            "aio_extension": {
-                "type": "Microsoft.KubernetesConfiguration/extensions",
-                "apiVersion": "2023-05-01",
-                "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
-                "name": "[format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
-                "identity": {"type": "SystemAssigned"},
-                "properties": {
-                    "extensionType": "microsoft.iotoperations",
-                    "version": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'version'), variables('VERSIONS').iotOperations)]",
-                    "releaseTrain": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'train'), variables('TRAINS').iotOperations)]",
-                    "autoUpgradeMinorVersion": False,
-                    "scope": "[variables('AIO_EXTENSION_SCOPE')]",
-                    "configurationSettings": "[union(variables('defaultAioConfigurationSettings'), coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'configurationSettingsOverride'), createObject()))]",
-                },
-                "dependsOn": ["aio_platform_extension", "cluster"],
-            },
         },
         "outputs": {
             "clExtensionIds": {
                 "type": "array",
                 "items": {"type": "string"},
                 "value": [
-                    "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-platform-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
-                    "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
+                    "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', 'azure-iot-operations-platform')]",
                     "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', 'azure-secret-store')]",
                 ],
             },
             "extensions": {
                 "type": "object",
                 "value": {
-                    "aio": {
-                        "name": "[format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
-                        "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
-                        "version": "[reference('aio_extension').version]",
-                        "releaseTrain": "[reference('aio_extension').releaseTrain]",
-                        "config": {
-                            "brokerListenerName": "[variables('MQTT_SETTINGS').brokerListenerServiceName]",
-                            "brokerListenerPort": "[variables('MQTT_SETTINGS').brokerListenerPort]",
-                        },
-                        "identityPrincipalId": "[reference('aio_extension', '2023-05-01', 'full').identity.principalId]",
-                    },
                     "platform": {
-                        "name": "[format('azure-iot-operations-platform-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
-                        "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-platform-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
+                        "name": "azure-iot-operations-platform",
+                        "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', 'azure-iot-operations-platform')]",
                         "version": "[reference('aio_platform_extension').version]",
                         "releaseTrain": "[reference('aio_platform_extension').releaseTrain]",
                     },
@@ -400,8 +331,8 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
                         "releaseTrain": "[reference('secret_store_extension').releaseTrain]",
                     },
                     "openServiceMesh": {
-                        "name": "[format('open-service-mesh-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
-                        "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('open-service-mesh-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
+                        "name": "open-service-mesh",
+                        "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', 'open-service-mesh')]",
                         "version": "[reference('open_service_mesh_extension').version]",
                         "releaseTrain": "[reference('open_service_mesh_extension').releaseTrain]",
                     },
@@ -424,7 +355,7 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "10409843909996696107"}
+            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "4431973576934377606"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -578,6 +509,8 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
             "clusterName": {"type": "string"},
             "clusterNamespace": {"type": "string", "defaultValue": "azure-iot-operations"},
             "clusterLocation": {"type": "string", "defaultValue": "[resourceGroup().location]"},
+            "kubernetesDistro": {"type": "string", "defaultValue": "K8s", "allowedValues": ["K3s", "K8s", "MicroK8s"]},
+            "containerRuntimeSocket": {"type": "string", "defaultValue": ""},
             "customLocationName": {
                 "type": "string",
                 "defaultValue": "[format('location-{0}', coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5)))]",
@@ -592,6 +525,10 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
+            "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
+            "AIO_EXTENSION_SCOPE": {"cluster": {"releaseNamespace": "azure-iot-operations"}},
+            "VERSIONS": {"iotOperations": "0.8.3"},
+            "TRAINS": {"iotOperations": "integration"},
             "MQTT_SETTINGS": {
                 "brokerListenerServiceName": "aio-broker",
                 "brokerListenerPort": 18883,
@@ -608,6 +545,35 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
                 "memoryProfile": "[coalesce(tryGet(parameters('brokerConfig'), 'memoryProfile'), 'Medium')]",
                 "serviceType": "[coalesce(tryGet(parameters('brokerConfig'), 'serviceType'), 'ClusterIp')]",
             },
+            "defaultAioConfigurationSettings": {
+                "AgentOperationTimeoutInMinutes": 120,
+                "connectors.values.mqttBroker.address": "[format('mqtts://{0}.{1}:{2}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace, variables('MQTT_SETTINGS').brokerListenerPort)]",
+                "connectors.values.mqttBroker.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
+                "connectors.values.opcPlcSimulation.deploy": "false",
+                "connectors.values.opcPlcSimulation.autoAcceptUntrustedCertificates": "false",
+                "connectors.values.discoveryHandler.enabled": "false",
+                "adr.values.Microsoft.CustomLocation.ServiceAccount": "default",
+                "akri.values.webhookConfiguration.enabled": "false",
+                "akri.values.certManagerWebhookCertificate.enabled": "false",
+                "akri.values.agent.extensionService.mqttBroker.hostName": "[format('{0}.{1}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace)]",
+                "akri.values.agent.extensionService.mqttBroker.port": "[variables('MQTT_SETTINGS').brokerListenerPort]",
+                "akri.values.agent.extensionService.mqttBroker.serviceAccountAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
+                "akri.values.agent.host.containerRuntimeSocket": "[parameters('containerRuntimeSocket')]",
+                "akri.values.kubernetesDistro": "[toLower(parameters('kubernetesDistro'))]",
+                "mqttBroker.values.global.quickstart": "false",
+                "mqttBroker.values.operator.firstPartyMetricsOn": "true",
+                "observability.metrics.enabled": "[format('{0}', coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'enabled'), false()))]",
+                "observability.metrics.openTelemetryCollectorAddress": "[if(coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'enabled'), false()), format('{0}', tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'otelCollectorAddress')), '')]",
+                "observability.metrics.exportIntervalSeconds": "[format('{0}', coalesce(tryGet(tryGet(parameters('advancedConfig'), 'observability'), 'otelExportIntervalSeconds'), 60))]",
+                "trustSource": "[parameters('trustConfig').source]",
+                "trustBundleSettings.issuer.name": "[if(equals(parameters('trustConfig').source, 'CustomerManaged'), parameters('trustConfig').settings.issuerName, variables('MQTT_SETTINGS').selfSignedIssuerName)]",
+                "trustBundleSettings.issuer.kind": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'issuerKind'), '')]",
+                "trustBundleSettings.configMap.name": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'configMapName'), '')]",
+                "trustBundleSettings.configMap.key": "[coalesce(tryGet(tryGet(parameters('trustConfig'), 'settings'), 'configMapKey'), '')]",
+                "schemaRegistry.values.mqttBroker.host": "[format('mqtts://{0}.{1}:{2}', variables('MQTT_SETTINGS').brokerListenerServiceName, variables('AIO_EXTENSION_SCOPE').cluster.releaseNamespace, variables('MQTT_SETTINGS').brokerListenerPort)]",
+                "schemaRegistry.values.mqttBroker.tlsEnabled": True,
+                "schemaRegistry.values.mqttBroker.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
+            },
         },
         "resources": {
             "cluster": {
@@ -615,6 +581,22 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
                 "type": "Microsoft.Kubernetes/connectedClusters",
                 "apiVersion": "2021-03-01",
                 "name": "[parameters('clusterName')]",
+            },
+            "aio_extension": {
+                "type": "Microsoft.KubernetesConfiguration/extensions",
+                "apiVersion": "2023-05-01",
+                "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
+                "name": "[format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                "identity": {"type": "SystemAssigned"},
+                "properties": {
+                    "extensionType": "microsoft.iotoperations",
+                    "version": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'version'), variables('VERSIONS').iotOperations)]",
+                    "releaseTrain": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'train'), variables('TRAINS').iotOperations)]",
+                    "autoUpgradeMinorVersion": False,
+                    "scope": "[variables('AIO_EXTENSION_SCOPE')]",
+                    "configurationSettings": "[union(variables('defaultAioConfigurationSettings'), coalesce(tryGet(tryGet(parameters('advancedConfig'), 'aio'), 'configurationSettingsOverride'), createObject()))]",
+                },
+                "dependsOn": ["cluster"],
             },
             "customLocation": {
                 "type": "Microsoft.ExtendedLocation/customLocations",
@@ -625,11 +607,11 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
                     "hostResourceId": "[resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))]",
                     "namespace": "[parameters('clusterNamespace')]",
                     "displayName": "[parameters('customLocationName')]",
-                    "clusterExtensionIds": "[parameters('clExtentionIds')]",
+                    "clusterExtensionIds": "[flatten(createArray(parameters('clExtentionIds'), createArray(extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX'))))))]",
                 },
-                "dependsOn": ["cluster"],
+                "dependsOn": ["aio_extension", "cluster"],
             },
-            "broker_syncRule": {
+            "aio_syncRule": {
                 "condition": "[parameters('deployResourceSyncRules')]",
                 "type": "Microsoft.ExtendedLocation/customLocations/resourceSyncRules",
                 "apiVersion": "2021-08-31-preview",
@@ -653,7 +635,7 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
                     "selector": {"matchLabels": {"management.azure.com/provider-name": "Microsoft.DeviceRegistry"}},
                     "targetResourceGroup": "[resourceGroup().id]",
                 },
-                "dependsOn": ["broker_syncRule", "customLocation"],
+                "dependsOn": ["aio_syncRule", "customLocation"],
             },
             "aioInstance": {
                 "type": "Microsoft.IoTOperations/instances",
@@ -785,6 +767,20 @@ M2_INSTANCE_TEMPLATE = TemplateBlueprint(
             },
         },
         "outputs": {
+            "aioExtension": {
+                "type": "object",
+                "value": {
+                    "name": "[format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                    "id": "[extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', format('azure-iot-operations-{0}', variables('AIO_EXTENSION_SUFFIX')))]",
+                    "version": "[reference('aio_extension').version]",
+                    "releaseTrain": "[reference('aio_extension').releaseTrain]",
+                    "config": {
+                        "brokerListenerName": "[variables('MQTT_SETTINGS').brokerListenerServiceName]",
+                        "brokerListenerPort": "[variables('MQTT_SETTINGS').brokerListenerPort]",
+                    },
+                    "identityPrincipalId": "[reference('aio_extension', '2023-05-01', 'full').identity.principalId]",
+                },
+            },
             "aio": {
                 "type": "object",
                 "value": {

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -56,7 +56,7 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "2952065196343262420"}
+            "_generator": {"name": "bicep", "version": "0.30.23.60470", "templateHash": "17597461722386619555"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -215,13 +215,13 @@ M2_ENABLEMENT_TEMPLATE = TemplateBlueprint(
             "VERSIONS": {
                 "platform": "0.7.6",
                 "secretStore": "0.6.4",
-                "containerStorage": "2.1.1-preview",
-                "openServiceMesh": "1.2.9",
+                "containerStorage": "2.2.0",
+                "openServiceMesh": "1.2.10",
             },
             "TRAINS": {
                 "platform": "preview",
                 "secretStore": "preview",
-                "containerStorage": "stable",
+                "containerStorage": "preview",
                 "openServiceMesh": "stable",
             },
             "faultTolerantStorageClass": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'edgeStorageAccelerator'), 'diskStorageClass'), 'acstor-arccontainerstorage-storage-pool')]",

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -286,6 +286,7 @@ class WorkManager:
                 )
 
             # Enable IoT Ops workflow
+            # TODO - @c-ryan-k - move aio extension to instance
             if self._apply_foundation:
                 enablement_work_name = self._work_format_str.format(op="enablement")
                 self.render_display(

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -24,6 +24,7 @@ from rich.table import Table
 from ...util.az_client import (
     REGISTRY_API_VERSION,
     get_resource_client,
+    parse_resource_id,
     wait_for_terminal_state,
 )
 from .permissions import ROLE_DEF_FORMAT_STR, PermissionManager
@@ -365,12 +366,13 @@ class WorkManager:
                 )
                 role_assignment_error = None
                 try:
+                    schema_registry_id_parts = parse_resource_id(self._targets.schema_registry_resource_id)
                     self.permission_manager.apply_role_assignment(
                         scope=self._targets.schema_registry_resource_id,
                         principal_id=self._extension_map[IOT_OPS_EXTENSION_TYPE]["identity"]["principalId"],
                         role_def_id=ROLE_DEF_FORMAT_STR.format(
-                            subscription_id=self.subscription_id,
-                            role_id=CONTRIBUTOR_ROLE_ID,  # TODO - @digimaun use schema registry subscription.
+                            subscription_id=schema_registry_id_parts.subscription_id,
+                            role_id=CONTRIBUTOR_ROLE_ID,
                         ),
                     )
                 except Exception as e:

--- a/azext_edge/tests/edge/init/int/test_init_int.py
+++ b/azext_edge/tests/edge/init/int/test_init_int.py
@@ -93,7 +93,7 @@ def test_init_scenario(
     registry_id = init_test_setup["schemaRegistryId"]
     instance_name = init_test_setup["instanceName"]
     command = f"az iot ops init -g {resource_group} --cluster {cluster_name} "\
-        f"--sr-resource-id {registry_id} --no-progress {additional_init_args} "
+        f"--no-progress {additional_init_args} "
 
     # TODO: assert return once there is a return for init
     run(command)
@@ -102,7 +102,8 @@ def test_init_scenario(
 
     # create command
     create_command = f"az iot ops create -g {resource_group} --cluster {cluster_name} "\
-        f"-n {instance_name} --no-progress {additional_create_args} "
+        f"--sr-resource-id {registry_id}  -n {instance_name} "\
+        f"--no-progress {additional_create_args} "
     # TODO: assert create when return be returning
     run(create_command)
 

--- a/azext_edge/tests/edge/init/int/test_init_int.py
+++ b/azext_edge/tests/edge/init/int/test_init_int.py
@@ -61,7 +61,6 @@ def init_test_setup(settings, tracked_resources):
         "clusterName": settings.env.azext_edge_cluster,
         "resourceGroup": settings.env.azext_edge_rg,
         "schemaRegistryId": registry["id"],
-        "schemaRegistryNamespace": registry_namespace,
         "instanceName": instance_name,
         "additionalCreateArgs": _strip_quotes(settings.env.azext_edge_create_args),
         "additionalInitArgs": _strip_quotes(settings.env.azext_edge_init_args),
@@ -132,7 +131,7 @@ def test_init_scenario(
                 instance_name=instance_name,
                 cluster_name=cluster_name,
                 resource_group=resource_group,
-                schema_registry_namespace=init_test_setup["schemaRegistryNamespace"],
+                schema_registry_id=registry_id,
                 **create_arg_dict
             )
     except Exception as e:  # pylint: disable=broad-except
@@ -190,7 +189,7 @@ def assert_aio_init(
 def assert_aio_instance(
     instance_name: str,
     resource_group: str,
-    schema_registry_namespace: str,
+    schema_registry_id: str,
     custom_location: Optional[str] = None,
     description: Optional[str] = None,
     location: Optional[str] = None,
@@ -209,7 +208,7 @@ def assert_aio_instance(
 
     instance_props = instance_show["properties"]
     assert instance_props.get("description") == description
-    assert instance_props["schemaRegistryNamespace"] == schema_registry_namespace
+    assert instance_props["schemaRegistryRef"] == {"resource_id": schema_registry_id}
 
     expected_components = {"adr", "akri", "connectors", "dataflows", "schemaRegistry"}
     disabled_components = []

--- a/azext_edge/tests/edge/orchestration/test_deletion_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_deletion_unit.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 from azext_edge.edge.providers.orchestration.deletion import IoTOperationsResource
+from azext_edge.edge.providers.orchestration.work import IOT_OPS_EXTENSION_TYPE
 
 from ...generators import generate_random_string
 
@@ -86,9 +87,16 @@ def _assemble_resource_map_mock(
     resource_map_mock().custom_locations = custom_locations
     resource_map_mock().get_resources.return_value = resources
     resource_map_mock().get_resource_sync_rules.return_value = sync_rules
-    # to fully replicate no extensions, we need to make sure the instance extension isn't added later
-    if not extensions:
-        resource_map_mock().connected_cluster.get_extensions_by_type.return_value = {}
+    resource_map_mock().connected_cluster.get_extensions_by_type.return_value = {
+        IOT_OPS_EXTENSION_TYPE: {"id": "aio-ext-id"}
+    }
+    resource_map_mock().extensions.append(
+        IoTOperationsResource(
+            resource_id="aio-ext-id",
+            display_name="aio-extension",
+            api_version="aio-ext-api"
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -98,7 +106,7 @@ def _assemble_resource_map_mock(
             "resources": None,
             "resource sync rules": None,
             "custom locations": None,
-            "extensions": None,
+            "extensions": [],
             "meta": {
                 "expected_total": 0,
             },
@@ -186,6 +194,7 @@ def test_batch_resources(
             "extensions": [],
             "meta": {
                 "expected_total": 0,
+                "expected_delete_calls": 1,  # aio extension
             },
         },
         {
@@ -263,9 +272,6 @@ def test_delete_lifecycle(
     delete_ops_resources(**kwargs)
 
     expected_delete_calls: int = expected_resources_map["meta"].get("expected_delete_calls", 0)
-    # not sure what this was checking for but it was broken now that delete doesn't delete the instance
-    # if not include_dependencies and expected_delete_calls > 0:
-    #     expected_delete_calls = expected_delete_calls - 1
 
     spy_deletion_manager["_display_resource_tree"].assert_called_once()
     spy_deletion_manager["_process"].assert_called_once()

--- a/azext_edge/tests/edge/orchestration/test_deletion_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_deletion_unit.py
@@ -86,6 +86,9 @@ def _assemble_resource_map_mock(
     resource_map_mock().custom_locations = custom_locations
     resource_map_mock().get_resources.return_value = resources
     resource_map_mock().get_resource_sync_rules.return_value = sync_rules
+    # to fully replicate no extensions, we need to make sure the instance extension isn't added later
+    if not extensions:
+        resource_map_mock().connected_cluster.get_extensions_by_type.return_value = {}
 
 
 @pytest.mark.parametrize(
@@ -260,8 +263,9 @@ def test_delete_lifecycle(
     delete_ops_resources(**kwargs)
 
     expected_delete_calls: int = expected_resources_map["meta"].get("expected_delete_calls", 0)
-    if not include_dependencies and expected_delete_calls > 0:
-        expected_delete_calls = expected_delete_calls - 1
+    # not sure what this was checking for but it was broken now that delete doesn't delete the instance
+    # if not include_dependencies and expected_delete_calls > 0:
+    #     expected_delete_calls = expected_delete_calls - 1
 
     spy_deletion_manager["_display_resource_tree"].assert_called_once()
     spy_deletion_manager["_process"].assert_called_once()

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -13,7 +13,6 @@ from azext_edge.edge.providers.orchestration.targets import (
     InitTargets,
     assemble_nargs_to_dict,
     get_insecure_listener,
-    REGISTRY_API_VERSION,
 )
 
 from ...generators import generate_random_string
@@ -174,7 +173,7 @@ def test_init_targets(target_scenario: dict):
     assert instance_template["resources"]["aioInstance"]["properties"]["description"] == targets.instance_description
 
     assert instance_template["resources"]["aioInstance"]["properties"]["schemaRegistryRef"] == {
-        "resourceId": f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').id]"
+        "resourceId": f"[parameters('schemaRegistryId')]"
     }
 
     if targets.tags:

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -138,7 +138,6 @@ def test_init_targets(target_scenario: dict):
             targets, targets_key
         ), f"{parameter} value mismatch with targets {targets_key} value."
 
-
     extension_ids = [generate_random_string(), generate_random_string()]
     extension_config = {"schemaRegistry.values.resourceId": target_scenario.get("schema_registry_resource_id")}
     target_scenario_has_user_trust = target_scenario.get("trust_settings")

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -173,10 +173,9 @@ def test_init_targets(target_scenario: dict):
 
     assert instance_template["resources"]["aioInstance"]["properties"]["description"] == targets.instance_description
 
-    assert (
-        instance_template["resources"]["aioInstance"]["properties"]["schemaRegistryNamespace"]
-        == f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').namespace]"
-    )
+    assert instance_template["resources"]["aioInstance"]["properties"]["schemaRegistryRef"] == {
+        "resourceId": f"[reference(parameters('schemaRegistryId'), '{REGISTRY_API_VERSION}').id]"
+    }
 
     if targets.tags:
         assert instance_template["resources"]["aioInstance"]["tags"] == targets.tags

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -129,7 +129,8 @@ def test_init_targets(target_scenario: dict):
 
     verify_user_trust_settings(targets, target_scenario)
 
-    enablement_template, enablement_parameters = targets.get_ops_enablement_template()
+    _, enablement_parameters = targets.get_ops_enablement_template()
+    # test enablement_template
     for parameter in enablement_parameters:
         targets_key = parameter
         if parameter in ENABLEMENT_PARAM_CONVERSION_MAP:
@@ -139,17 +140,11 @@ def test_init_targets(target_scenario: dict):
         ), f"{parameter} value mismatch with targets {targets_key} value."
 
     extension_ids = [generate_random_string(), generate_random_string()]
-    extension_config = {"schemaRegistry.values.resourceId": target_scenario.get("schema_registry_resource_id")}
     target_scenario_has_user_trust = target_scenario.get("trust_settings")
     if target_scenario_has_user_trust:
-        extension_config["trustSource"] = "CustomerManaged"
-        extension_config["trustBundleSettings.issuer.name"] = target_scenario["trust_settings"]["issuerName"]
-        extension_config["trustBundleSettings.issuer.kind"] = target_scenario["trust_settings"]["issuerKind"]
-        extension_config["trustBundleSettings.configMap.name"] = target_scenario["trust_settings"]["configMapName"]
-        extension_config["trustBundleSettings.configMap.key"] = target_scenario["trust_settings"]["configMapKey"]
         targets.trust_config = None
 
-    instance_template, instance_parameters = targets.get_ops_instance_template(extension_ids, extension_config)
+    instance_template, instance_parameters = targets.get_ops_instance_template(extension_ids)
 
     if targets.ops_version:
         assert instance_template["variables"]["VERSIONS"]["iotOperations"] == targets.ops_version

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -10,8 +10,8 @@ import pytest
 
 from azext_edge.edge.providers.orchestration.template import (
     IOT_OPERATIONS_VERSION_MONIKER,
-    M2_ENABLEMENT_TEMPLATE,
-    M2_INSTANCE_TEMPLATE,
+    M3_ENABLEMENT_TEMPLATE,
+    M3_INSTANCE_TEMPLATE,
     TemplateBlueprint,
     get_insecure_listener,
 )
@@ -59,37 +59,37 @@ EXPECTED_SHARED_DEFINITION_KEYS = frozenset(
 
 
 def test_enablement_template():
-    assert M2_ENABLEMENT_TEMPLATE.commit_id
-    assert M2_ENABLEMENT_TEMPLATE.content
+    assert M3_ENABLEMENT_TEMPLATE.commit_id
+    assert M3_ENABLEMENT_TEMPLATE.content
 
     for resource in EXPECTED_EXTENSION_RESOURCE_KEYS:
-        assert M2_ENABLEMENT_TEMPLATE.get_resource_by_key(resource)
+        assert M3_ENABLEMENT_TEMPLATE.get_resource_by_key(resource)
 
     for definition in EXPECTED_SHARED_DEFINITION_KEYS:
-        assert M2_ENABLEMENT_TEMPLATE.get_type_definition(definition)
+        assert M3_ENABLEMENT_TEMPLATE.get_type_definition(definition)
 
 
 def test_instance_template():
-    assert M2_INSTANCE_TEMPLATE.commit_id
-    assert M2_INSTANCE_TEMPLATE.content
+    assert M3_INSTANCE_TEMPLATE.commit_id
+    assert M3_INSTANCE_TEMPLATE.content
 
     for resource in EXPECTED_INSTANCE_RESOURCE_KEYS:
-        assert M2_INSTANCE_TEMPLATE.get_resource_by_key(resource)
+        assert M3_INSTANCE_TEMPLATE.get_resource_by_key(resource)
 
     for definition in EXPECTED_SHARED_DEFINITION_KEYS:
-        assert M2_INSTANCE_TEMPLATE.get_type_definition(definition)
+        assert M3_INSTANCE_TEMPLATE.get_type_definition(definition)
 
-    instance = M2_INSTANCE_TEMPLATE.get_resource_by_type("Microsoft.IoTOperations/instances")
+    instance = M3_INSTANCE_TEMPLATE.get_resource_by_type("Microsoft.IoTOperations/instances")
     assert instance and isinstance(instance, dict)
 
     # Copy test in other area
-    m2_template_copy = M2_INSTANCE_TEMPLATE.copy()
+    m3_template_copy = M3_INSTANCE_TEMPLATE.copy()
 
     instance_name = generate_random_string()
     broker_name = generate_random_string()
 
-    m2_template_copy.add_resource("insecure_listener", get_insecure_listener(instance_name, broker_name))
-    listeners = m2_template_copy.get_resource_by_type(
+    m3_template_copy.add_resource("insecure_listener", get_insecure_listener(instance_name, broker_name))
+    listeners = m3_template_copy.get_resource_by_type(
         "Microsoft.IoTOperations/instances/brokers/listeners", first=False
     )
     assert listeners and isinstance(listeners, list)

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -24,9 +24,9 @@ EXPECTED_EXTENSION_RESOURCE_KEYS = frozenset(
     [
         "cluster",
         "aio_platform_extension",
-        "secret_sync_controller_extension",
+        "secret_store_extension",
         "open_service_mesh_extension",
-        "edge_storage_accelerator_extension",
+        "container_storage_extension",
         "aio_extension",
     ]
 )

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -27,7 +27,6 @@ EXPECTED_EXTENSION_RESOURCE_KEYS = frozenset(
         "secret_store_extension",
         "open_service_mesh_extension",
         "container_storage_extension",
-        "aio_extension",
     ]
 )
 
@@ -35,8 +34,9 @@ EXPECTED_EXTENSION_RESOURCE_KEYS = frozenset(
 EXPECTED_INSTANCE_RESOURCE_KEYS = frozenset(
     [
         "cluster",
+        "aio_extension",
         "customLocation",
-        "broker_syncRule",
+        "aio_syncRule",
         "deviceRegistry_syncRule",
         "aioInstance",
         "broker",


### PR DESCRIPTION
A few big key points in this PR:
- updates template components for a new deployment structure that moves the AIO k8s extension to the instance side
- `init` no longer requires a schema registry ID, and no longer deploys the AIO k8s extension.
- `create` now requires the schema registry ID, and deploys the AIO k8s extension and creates the IoT Operations instance.
- `delete` now deletes the AIO k8s extension as well as the IoT Operations instance by default (without `--include-deps`)

Unit tests are passing but integration tests will need updated.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
