### PR TITLE
refactor: update broker stats to use new property names

### DIFF
--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -131,13 +131,13 @@ class MqDiagnosticPropertyIndex(Enum):
     MQ Diagnostic Property Index Strings
     """
 
-    publishes_received_per_second = "aio_mq_publishes_received_per_second"
-    publishes_sent_per_second = "aio_mq_publishes_sent_per_second"
-    publish_route_replication_correctness = "aio_mq_publish_route_replication_correctness"
-    publish_latency_mu_ms = "aio_mq_publish_latency_mu_ms"
-    publish_latency_sigma_ms = "aio_mq_publish_latency_sigma_ms"
-    connected_sessions = "aio_mq_connected_sessions"
-    total_subscriptions = "aio_mq_total_subscriptions"
+    publishes_received_per_second = "aio_broker_publishes_received_per_second"
+    publishes_sent_per_second = "aio_broker_publishes_sent_per_second"
+    publish_route_replication_correctness = "aio_broker_publish_route_replication_correctness"
+    publish_latency_mu_ms = "aio_broker_publish_latency_mu_ms"
+    publish_latency_sigma_ms = "aio_broker_publish_latency_sigma_ms"
+    connected_sessions = "aio_broker_connected_sessions"
+    total_subscriptions = "aio_broker_store_total_subscriptions"
 
 
 class OpsServiceType(ListableEnum):

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -81,7 +81,7 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     "ports": [
                         {"name": "bincode-listener-service", "port": 9700, "protocol": "TCP", "targetPort": 9700},
                         {"name": "protobuf-listener-service", "port": 9800, "protocol": "TCP", "targetPort": 9800},
-                        {"name": "aio-mq-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
+                        {"name": "aio-broker-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
                     ],
                 },
             ),
@@ -153,7 +153,7 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     "ports": [
                         {"name": "bincode-listener-service", "port": 9700, "protocol": "TCP", "targetPort": 9700},
                         {"name": "protobuf-listener-service", "port": 9800, "protocol": "TCP", "targetPort": 9800},
-                        {"name": "aio-mq-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
+                        {"name": "aio-broker-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
                     ],
                 },
             ),
@@ -225,7 +225,7 @@ def test_check_mq_by_resource_types(ops_service, mocker, mock_resource_types, re
                     "ports": [
                         {"name": "bincode-listener-service", "port": 9700, "protocol": "TCP", "targetPort": 9700},
                         {"name": "protobuf-listener-service", "port": 9800, "protocol": "TCP", "targetPort": 9800},
-                        {"name": "aio-mq-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
+                        {"name": "aio-broker-metrics-service", "port": 9600, "protocol": "TCP", "targetPort": 9600},
                     ],
                 },
             ),

--- a/azext_edge/tests/edge/mq/raw_stats.txt
+++ b/azext_edge/tests/edge/mq/raw_stats.txt
@@ -1,288 +1,288 @@
-# TYPE aio_mq_store_retained_messages gauge
-aio_mq_store_retained_messages{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_retained_messages{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 1
-aio_mq_store_retained_messages{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 1
-aio_mq_store_retained_messages{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_authentication_deny counter
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_deny{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_deny{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_deny{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-# TYPE aio_mq_ping_correctness gauge
-aio_mq_ping_correctness{route="aio-mq-dmqtt-frontend-1"} 1
-aio_mq_ping_correctness{route="aio-mq-dmqtt-frontend-0"} 1
-# TYPE aio_mq_subscribe_route_replication_correctness gauge
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_subscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-# TYPE aio_mq_publish_route_replication_correctness gauge
-aio_mq_publish_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_publish_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_publish_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_publish_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-# TYPE aio_mq_store_total_subscriptions gauge
-aio_mq_store_total_subscriptions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 258
-aio_mq_store_total_subscriptions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 258
-aio_mq_store_total_subscriptions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 258
-aio_mq_store_total_subscriptions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 258
-# TYPE aio_mq_publish_latency_sigma_ms gauge
-aio_mq_publish_latency_sigma_ms 17.652887
-# TYPE aio_mq_ping_latency_route_ms gauge
-aio_mq_ping_latency_route_ms{route=""} 111.50912
-# TYPE aio_mq_subscribe_latency_route_ms gauge
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 3.217114
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 46.881306
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 2.3446221
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 77.88732
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 44.94545
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 7.618704
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 47.346355
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 48.460068
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 3.41304
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 49.23383
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 49.087955
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 46.974224
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 47.013584
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 51.384243
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 3.541
-aio_mq_subscribe_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 49.028214
-# TYPE aio_mq_ping_latency_mu_ms gauge
-aio_mq_ping_latency_mu_ms 112.64005
-# TYPE aio_mq_store_will_bytes gauge
-aio_mq_store_will_bytes{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_bytes{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_bytes{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_bytes{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_connected_sessions gauge
-aio_mq_connected_sessions{hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
-aio_mq_connected_sessions{hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 5
-# TYPE aio_mq_payload_bytes_received counter
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_received{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_received{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 214
-aio_mq_payload_bytes_received{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1984
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_publish_latency_mu_ms gauge
-aio_mq_publish_latency_mu_ms 60.079346
-# TYPE aio_mq_store_total_sessions gauge
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_total_sessions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
-# TYPE aio_mq_authorization_allow counter
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_allow{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 311
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_allow{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 315
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_allow{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_allow{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 1
-# TYPE aio_mq_store_retained_bytes gauge
-aio_mq_store_retained_bytes{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_retained_bytes{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_retained_bytes{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 24
-aio_mq_store_retained_bytes{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 24
-# TYPE aio_mq_unsubscribe_latency_sigma_ms gauge
-aio_mq_unsubscribe_latency_sigma_ms 21.741936
+# TYPE aio_broker_store_retained_messages gauge
+aio_broker_store_retained_messages{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_retained_messages{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 1
+aio_broker_store_retained_messages{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 1
+aio_broker_store_retained_messages{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_authentication_deny counter
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_deny{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_deny{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_deny{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+# TYPE aio_broker_ping_correctness gauge
+aio_broker_ping_correctness{route="aio-broker-dmqtt-frontend-1"} 1
+aio_broker_ping_correctness{route="aio-broker-dmqtt-frontend-0"} 1
+# TYPE aio_broker_subscribe_route_replication_correctness gauge
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_subscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+# TYPE aio_broker_publish_route_replication_correctness gauge
+aio_broker_publish_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_publish_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_publish_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_publish_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+# TYPE aio_broker_store_total_subscriptions gauge
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 258
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 258
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 258
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 258
+# TYPE aio_broker_publish_latency_sigma_ms gauge
+aio_broker_publish_latency_sigma_ms 17.652887
+# TYPE aio_broker_ping_latency_route_ms gauge
+aio_broker_ping_latency_route_ms{route=""} 111.50912
+# TYPE aio_broker_subscribe_latency_route_ms gauge
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 3.217114
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 46.881306
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 2.3446221
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 77.88732
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 44.94545
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 7.618704
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 47.346355
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 48.460068
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 3.41304
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 49.23383
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 49.087955
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 46.974224
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 47.013584
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 51.384243
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 3.541
+aio_broker_subscribe_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 49.028214
+# TYPE aio_broker_ping_latency_mu_ms gauge
+aio_broker_ping_latency_mu_ms 112.64005
+# TYPE aio_broker_store_will_bytes gauge
+aio_broker_store_will_bytes{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_bytes{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_bytes{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_bytes{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_connected_sessions gauge
+aio_broker_connected_sessions{hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
+aio_broker_connected_sessions{hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 5
+# TYPE aio_broker_payload_bytes_received counter
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_received{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_received{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 214
+aio_broker_payload_bytes_received{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1984
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_publish_latency_mu_ms gauge
+aio_broker_publish_latency_mu_ms 60.079346
+# TYPE aio_broker_store_total_sessions gauge
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_total_sessions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
+# TYPE aio_broker_authorization_allow counter
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_allow{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 311
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_allow{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 315
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_allow{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_allow{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 1
+# TYPE aio_broker_store_retained_bytes gauge
+aio_broker_store_retained_bytes{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_retained_bytes{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_retained_bytes{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 24
+aio_broker_store_retained_bytes{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 24
+# TYPE aio_broker_unsubscribe_latency_sigma_ms gauge
+aio_broker_unsubscribe_latency_sigma_ms 21.741936
 # TYPE qos0_messages_dropped counter
-qos0_messages_dropped{category="broker_selftest",direction="outgoing",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="aio-opc",direction="incoming",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="aio-opc",direction="outgoing",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="broker_selftest",direction="incoming",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="broker_selftest",direction="incoming",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="broker_selftest",direction="outgoing",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-# TYPE aio_mq_store_will_messages gauge
-aio_mq_store_will_messages{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_messages{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_messages{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_will_messages{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_connect_route_replication_correctness gauge
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-0 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 1
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-0 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 1
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 1
-aio_mq_connect_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-0 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 1
-# TYPE aio_mq_publish_latency_route_ms gauge
-aio_mq_publish_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 9.32115
-aio_mq_publish_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 9.317781
-aio_mq_publish_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 8.493393
-aio_mq_publish_latency_route_ms{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 9.31679
-# TYPE aio_mq_authentication_successes counter
-aio_mq_authentication_successes{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 315
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_successes{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 1
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_successes{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_successes{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 311
-# TYPE aio_mq_publish_latency_last_value_ms gauge
-aio_mq_publish_latency_last_value_ms 84.76163
-# TYPE aio_mq_authorization_deny counter
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_deny{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_deny{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_deny{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authorization_deny{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_publishes_received_per_second gauge
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received_per_second{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received_per_second{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0.033333335
-aio_mq_publishes_received_per_second{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0.53333336
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_store_connected_sessions gauge
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
-aio_mq_store_connected_sessions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
-# TYPE aio_mq_state_store_insertions counter
-aio_mq_state_store_insertions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_insertions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_insertions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_insertions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_state_store_deletions counter
-aio_mq_state_store_deletions{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_deletions{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_deletions{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_deletions{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_backpressure_packets_rejected counter
-aio_mq_backpressure_packets_rejected{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_backpressure_packets_rejected{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_backpressure_packets_rejected{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_backpressure_packets_rejected{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_publishes_sent_per_second gauge
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0.9
-aio_mq_publishes_sent_per_second{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1.0666667
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0.8666667
-aio_mq_publishes_sent_per_second{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent_per_second{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent_per_second{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_ping_latency_sigma_ms gauge
-aio_mq_ping_latency_sigma_ms 5.326966
-# TYPE aio_mq_state_store_modifications counter
-aio_mq_state_store_modifications{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_modifications{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_modifications{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_modifications{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_state_store_retrievals counter
-aio_mq_state_store_retrievals{hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_retrievals{hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_retrievals{hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_state_store_retrievals{hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-# TYPE aio_mq_unsubscribe_latency_mu_ms gauge
-aio_mq_unsubscribe_latency_mu_ms 32087.498
-# TYPE aio_mq_total_subscriptions gauge
-aio_mq_total_subscriptions{hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 8
-aio_mq_total_subscriptions{hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
-# TYPE aio_mq_unsubscribe_latency_last_value_ms gauge
-aio_mq_unsubscribe_latency_last_value_ms 32076.668
-# TYPE aio_mq_ping_latency_last_value_ms gauge
-aio_mq_ping_latency_last_value_ms 111.44446
-# TYPE aio_mq_total_sessions gauge
-aio_mq_total_sessions{hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 5
-aio_mq_total_sessions{hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
-# TYPE aio_mq_unsubscribe_route_replication_correctness gauge
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1"} 0
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:1 aio-mq-dmqtt-backend-2-1:1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 0
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1"} 0
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 0
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:1 aio-mq-dmqtt-backend-1-1:1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0"} 0
-aio_mq_unsubscribe_route_replication_correctness{route="aio-mq-diagnostics-probe-0 aio-mq-dmqtt-frontend-1 aio-mq-dmqtt-backend-1-0:0 aio-mq-dmqtt-backend-1-1:0 aio-mq-dmqtt-backend-2-0:0 aio-mq-dmqtt-backend-2-1:0"} 0
-# TYPE aio_mq_authentication_failures counter
-aio_mq_authentication_failures{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_failures{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_authentication_failures{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_authentication_failures{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-# TYPE aio_mq_publishes_sent counter
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 4878
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_sent{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 3967
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 4784
-aio_mq_publishes_sent{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_sent{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-# TYPE aio_mq_publishes_received counter
-aio_mq_publishes_received{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 96
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_publishes_received{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_publishes_received{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1984
-# TYPE aio_mq_payload_bytes_sent counter
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_sent{category="aio-opc",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_sent{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 3967
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_sent{category="broker_selftest",hostname="aio-mq-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
-aio_mq_payload_bytes_sent{category="uncategorized",hostname="aio-mq-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="broker_selftest",direction="outgoing",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="aio-opc",direction="incoming",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="aio-opc",direction="outgoing",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="broker_selftest",direction="incoming",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="broker_selftest",direction="incoming",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="broker_selftest",direction="outgoing",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+qos0_messages_dropped{category="uncategorized",direction="outgoing",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+qos0_messages_dropped{category="uncategorized",direction="incoming",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+# TYPE aio_broker_store_will_messages gauge
+aio_broker_store_will_messages{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_messages{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_messages{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_will_messages{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_connect_route_replication_correctness gauge
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-0 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 1
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-0 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 1
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 1
+aio_broker_connect_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-0 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 1
+# TYPE aio_broker_publish_latency_route_ms gauge
+aio_broker_publish_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 9.32115
+aio_broker_publish_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 9.317781
+aio_broker_publish_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 8.493393
+aio_broker_publish_latency_route_ms{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 9.31679
+# TYPE aio_broker_authentication_successes counter
+aio_broker_authentication_successes{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 315
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_successes{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 1
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_successes{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_successes{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 311
+# TYPE aio_broker_publish_latency_last_value_ms gauge
+aio_broker_publish_latency_last_value_ms 84.76163
+# TYPE aio_broker_authorization_deny counter
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_deny{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_deny{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_deny{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authorization_deny{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_publishes_received_per_second gauge
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received_per_second{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received_per_second{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0.033333335
+aio_broker_publishes_received_per_second{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0.53333336
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_store_connected_sessions gauge
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",is_persistent="true",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 3
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
+aio_broker_store_connected_sessions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",is_persistent="false",namespace="azure-iot-operations",pod_type="BE"} 4
+# TYPE aio_broker_state_store_insertions counter
+aio_broker_state_store_insertions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_insertions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_insertions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_insertions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_state_store_deletions counter
+aio_broker_state_store_deletions{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_deletions{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_deletions{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_deletions{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_backpressure_packets_rejected counter
+aio_broker_backpressure_packets_rejected{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_backpressure_packets_rejected{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_backpressure_packets_rejected{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_backpressure_packets_rejected{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_publishes_sent_per_second gauge
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0.9
+aio_broker_publishes_sent_per_second{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1.0666667
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0.8666667
+aio_broker_publishes_sent_per_second{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent_per_second{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent_per_second{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_ping_latency_sigma_ms gauge
+aio_broker_ping_latency_sigma_ms 5.326966
+# TYPE aio_broker_state_store_modifications counter
+aio_broker_state_store_modifications{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_modifications{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_modifications{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_modifications{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_state_store_retrievals counter
+aio_broker_state_store_retrievals{hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_retrievals{hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_retrievals{hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_state_store_retrievals{hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+# TYPE aio_broker_unsubscribe_latency_mu_ms gauge
+aio_broker_unsubscribe_latency_mu_ms 32087.498
+# TYPE aio_broker_store_total_subscriptions gauge
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 8
+aio_broker_store_total_subscriptions{hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
+# TYPE aio_broker_unsubscribe_latency_last_value_ms gauge
+aio_broker_unsubscribe_latency_last_value_ms 32076.668
+# TYPE aio_broker_ping_latency_last_value_ms gauge
+aio_broker_ping_latency_last_value_ms 111.44446
+# TYPE aio_broker_total_sessions gauge
+aio_broker_total_sessions{hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 5
+aio_broker_total_sessions{hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 2
+# TYPE aio_broker_unsubscribe_route_replication_correctness gauge
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1"} 0
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:1 aio-broker-dmqtt-backend-2-1:1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 0
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1"} 0
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 0
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:1 aio-broker-dmqtt-backend-1-1:1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0"} 0
+aio_broker_unsubscribe_route_replication_correctness{route="aio-broker-diagnostics-probe-0 aio-broker-dmqtt-frontend-1 aio-broker-dmqtt-backend-1-0:0 aio-broker-dmqtt-backend-1-1:0 aio-broker-dmqtt-backend-2-0:0 aio-broker-dmqtt-backend-2-1:0"} 0
+# TYPE aio_broker_authentication_failures counter
+aio_broker_authentication_failures{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_failures{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_authentication_failures{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_authentication_failures{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+# TYPE aio_broker_publishes_sent counter
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 4878
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_sent{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 3967
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 4784
+aio_broker_publishes_sent{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_sent{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+# TYPE aio_broker_publishes_received counter
+aio_broker_publishes_received{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 96
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_publishes_received{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_publishes_received{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 1984
+# TYPE aio_broker_payload_bytes_sent counter
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-0",instance="aefa2f1f-7576-4ba4-9627-49d4ef0045e5",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_sent{category="aio-opc",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_sent{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-1",instance="694fdfcb-34a6-4364-a783-dc0e3af80131",namespace="azure-iot-operations",pod_type="FE"} 3967
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_sent{category="broker_selftest",hostname="aio-broker-dmqtt-frontend-0",instance="73b35e4b-e124-41b6-98da-f23cad761c84",namespace="azure-iot-operations",pod_type="FE"} 0
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-0",instance="37d8f0d9-7088-4db3-9c60-72157a5a47f8",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-1-1",instance="a55e6597-6906-44b5-9678-2d6b2808998c",namespace="azure-iot-operations",pod_type="BE"} 0
+aio_broker_payload_bytes_sent{category="uncategorized",hostname="aio-broker-dmqtt-backend-2-1",instance="028d15b1-625d-4256-ad0b-e534027e96da",namespace="azure-iot-operations",pod_type="BE"} 0
 # EOF

--- a/azext_edge/tests/edge/mq/traces_data.py
+++ b/azext_edge/tests/edge/mq/traces_data.py
@@ -21,7 +21,7 @@ TEST_TRACE_PARTIAL = TestTraceData(
         "resourceSpans": [
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -61,7 +61,7 @@ TEST_TRACE = TestTraceData(
         "resourceSpans": [
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -91,7 +91,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -121,7 +121,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -152,7 +152,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -182,7 +182,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -212,7 +212,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -242,7 +242,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -264,7 +264,7 @@ TEST_TRACE = TestTraceData(
                                             "stringValue": '{"id":1590916709755722418,"version":0,"trace_id":176088501121717014071716630412632417632,"parent_id":4535909789485131942,"flags":1}'
                                         },
                                     },
-                                    {"key": "pod_id", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}},
+                                    {"key": "pod_id", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}},
                                 ],
                                 "status": {},
                             }
@@ -274,7 +274,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -304,7 +304,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -334,7 +334,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-frontend-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-frontend-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -364,7 +364,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -394,7 +394,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -424,7 +424,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -455,7 +455,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -480,10 +480,10 @@ TEST_TRACE = TestTraceData(
                                     {
                                         "key": "cell_map",
                                         "value": {
-                                            "stringValue": "ReplicaCellMap { id: aio-mq-dmqtt-backend-2-0:1, position: Some(Backend((3, 0, Replica))), cell_map: CellMap { backends: [Chain { id: 0, replicas: [ReplicaInfo { state: Ready, role:Replica, address: aio-mq-dmqtt-backend-1-0.aio-mq-dmqtt-backend.azure-iot"
+                                            "stringValue": "ReplicaCellMap { id: aio-broker-dmqtt-backend-2-0:1, position: Some(Backend((3, 0, Replica))), cell_map: CellMap { backends: [Chain { id: 0, replicas: [ReplicaInfo { state: Ready, role:Replica, address: aio-broker-dmqtt-backend-1-0.aio-broker-dmqtt-backend.azure-iot"
                                         },
                                     },
-                                    {"key": "pod_id", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0:1"}},
+                                    {"key": "pod_id", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0:1"}},
                                 ],
                                 "status": {},
                             }
@@ -493,7 +493,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -523,7 +523,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -553,7 +553,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -583,7 +583,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -599,11 +599,11 @@ TEST_TRACE = TestTraceData(
                                 "endTimeUnixNano": "1701380840984477448",
                                 "attributes": [
                                     {"key": "cell_map_version", "value": {"stringValue": "3"}},
-                                    {"key": "pod_id", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1:1"}},
+                                    {"key": "pod_id", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1:1"}},
                                     {
                                         "key": "cell_map",
                                         "value": {
-                                            "stringValue": "ReplicaCellMap { id: aio-mq-dmqtt-backend-2-1:1, position: Some(Backend((3, 1, Tail))), cell_map: CellMap { backends: [Chain { id: 0, replicas: [ReplicaInfo{ state: Ready, role: Replica, address: aio-mq-dmqtt-backend-1-0.aio-mq-dmqtt-backend.azure-iot-op"
+                                            "stringValue": "ReplicaCellMap { id: aio-broker-dmqtt-backend-2-1:1, position: Some(Backend((3, 1, Tail))), cell_map: CellMap { backends: [Chain { id: 0, replicas: [ReplicaInfo{ state: Ready, role: Replica, address: aio-broker-dmqtt-backend-1-0.aio-broker-dmqtt-backend.azure-iot-op"
                                         },
                                     },
                                     {
@@ -621,7 +621,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -651,7 +651,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -681,7 +681,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -711,7 +711,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -741,7 +741,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -771,7 +771,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -801,7 +801,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -831,7 +831,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-dmqtt-backend-2-1"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-dmqtt-backend-2-1"}}]
                 },
                 "scopeSpans": [
                     {
@@ -861,7 +861,7 @@ TEST_TRACE = TestTraceData(
             },
             {
                 "resource": {
-                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-mq-diagnostics-probe-0"}}]
+                    "attributes": [{"key": "service.name", "value": {"stringValue": "aio-broker-diagnostics-probe-0"}}]
                 },
                 "scopeSpans": [
                     {
@@ -907,6 +907,6 @@ TEST_TRACE = TestTraceData(
         ],
         "status": {},
     },
-    resource_name="aio-mq-diagnostics-probe-0",
+    resource_name="aio-broker-diagnostics-probe-0",
     timestamp=datetime(2023, 11, 30, 21, 47, 20, 937646),
 )

--- a/azext_edge/tests/edge/orchestration/resources/test_broker_listeners_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_broker_listeners_unit.py
@@ -46,7 +46,7 @@ def get_mock_broker_listener_record(
                 }
             ],
             "provisioningState": "Succeeded",
-            "serviceName": "aio-mq-dmqtt-frontend",
+            "serviceName": "aio-broker-dmqtt-frontend",
             "serviceType": "ClusterIp",
         },
         resource_group_name=resource_group_name,

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -83,8 +83,8 @@ def convert_file_names(files: List[str]) -> Dict[str, List[Dict[str, str]]]:
             if "trace" not in file_name_objs:
                 file_name_objs["trace"] = []
             # trace file
-            # aio-mq-dmqtt-frontend-1.Publish.b9c3173d9c2b97b75edfb6cf7cb482f2.otlp.pb
-            # aio-mq-dmqtt-frontend-1.Publish.b9c3173d9c2b97b75edfb6cf7cb482f2.tempo.json
+            # aio-broker-dmqtt-frontend-1.Publish.b9c3173d9c2b97b75edfb6cf7cb482f2.otlp.pb
+            # aio-broker-dmqtt-frontend-1.Publish.b9c3173d9c2b97b75edfb6cf7cb482f2.tempo.json
             name_obj["name"] = file_type
             name_obj["action"] = name.pop(0).lower()
             name_obj["identifier"] = name.pop(0)


### PR DESCRIPTION
Also patches a few older `mq` values in tests.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
