### PR TITLE
fix: fix build_tree issue if aio_ext does not exist

### DIFF
--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -151,7 +151,7 @@ class DeletionManager:
             )
             aio_ext_id: str = aio_ext_obj.get("id", "")
             aio_ext = next(
-                (_ for _ in self.resource_map.extensions if _.resource_id.lower() == aio_ext_id.lower()), None
+                (ext for ext in self.resource_map.extensions if ext.resource_id.lower() == aio_ext_id.lower()), None
             )
             if aio_ext:
                 todo_extensions.append(aio_ext)

--- a/azext_edge/edge/providers/orchestration/resource_map.py
+++ b/azext_edge/edge/providers/orchestration/resource_map.py
@@ -134,7 +134,7 @@ class IoTOperationsResourceMap:
 
         self._cluster_container = refreshed_cluster_container
 
-    def build_tree(self, include_dependencies: bool = False, category_color: str = "cyan") -> Tree:
+    def build_tree(self, include_dependencies: bool = True, category_color: str = "cyan") -> Tree:
         from .work import IOT_OPS_EXTENSION_TYPE
 
         tree = Tree(f"[green]{self.connected_cluster.cluster_name}")
@@ -146,10 +146,11 @@ class IoTOperationsResourceMap:
             aio_ext_obj = self.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
                 IOT_OPS_EXTENSION_TYPE, {}
             )
-            aio_ext_id: str = aio_ext_obj.get("id", "")
-            aio_ext = next((_ for _ in self.extensions if _.resource_id.lower() == aio_ext_id.lower()), None)
-            if aio_ext:
-                extensions_node.add(aio_ext.display_name)
+            if aio_ext_obj:
+                aio_ext_id: str = aio_ext_obj.get("id", "")
+                aio_ext = next((_ for _ in self.extensions if _.resource_id.lower() == aio_ext_id.lower()), None)
+                if aio_ext:
+                    extensions_node.add(aio_ext.display_name)
         else:
             [extensions_node.add(ext.display_name) for ext in self.extensions]
 

--- a/azext_edge/edge/providers/orchestration/resource_map.py
+++ b/azext_edge/edge/providers/orchestration/resource_map.py
@@ -148,7 +148,7 @@ class IoTOperationsResourceMap:
             )
             if aio_ext_obj:
                 aio_ext_id: str = aio_ext_obj.get("id", "")
-                aio_ext = next((_ for _ in self.extensions if _.resource_id.lower() == aio_ext_id.lower()), None)
+                aio_ext = next((ext for ext in self.extensions if ext.resource_id.lower() == aio_ext_id.lower()), None)
                 if aio_ext:
                     extensions_node.add(aio_ext.display_name)
         else:


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
