### PR TITLE
fix: patch for deletion when no aio_extension exists

### DIFF
--- a/azext_edge/edge/providers/orchestration/deletion.py
+++ b/azext_edge/edge/providers/orchestration/deletion.py
@@ -149,12 +149,13 @@ class DeletionManager:
             aio_ext_obj = self.resource_map.connected_cluster.get_extensions_by_type(IOT_OPS_EXTENSION_TYPE).get(
                 IOT_OPS_EXTENSION_TYPE, {}
             )
-            aio_ext_id: str = aio_ext_obj.get("id", "")
-            aio_ext = next(
-                (ext for ext in self.resource_map.extensions if ext.resource_id.lower() == aio_ext_id.lower()), None
-            )
-            if aio_ext:
-                todo_extensions.append(aio_ext)
+            if aio_ext_obj:
+                aio_ext_id: str = aio_ext_obj.get("id", "")
+                aio_ext = next(
+                    (ext for ext in self.resource_map.extensions if ext.resource_id.lower() == aio_ext_id.lower()), None
+                )
+                if aio_ext:
+                    todo_extensions.append(aio_ext)
         todo_custom_locations = self.resource_map.custom_locations
         todo_resource_sync_rules = []
         todo_resources = []


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
