### PR TITLE
fix: remove prompts in `az iot ops connector opcua`

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1425,6 +1425,13 @@ def load_iotops_help():
             az iot ops connector opcua client add --instance instance --resource-group instanceresourcegroup
             --public-key-file "newopc.der" --private-key-file "newopc.pem" --subject-name "aio-opc-opcuabroker"
             --application-uri "urn:microsoft.com:aio:opc:opcuabroker"
+        - name: Add an client certificate with custom public and private key secret name.
+          text: >
+            az iot ops connector opcua client add
+            --instance instance --resource-group instanceresourcegroup
+            --certificate-file "certificate.der" --public-key-secret public-secret-name
+            --private-key-secret private-secret-name --subject-name "aio-opc-opcuabroker"
+            --application-uri "urn:microsoft.com:aio:opc:opcuabroker"
       """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1428,9 +1428,13 @@ def load_iotops_help():
         - name: Add an client certificate with custom public and private key secret name.
           text: >
             az iot ops connector opcua client add
-            --instance instance --resource-group instanceresourcegroup
-            --certificate-file "certificate.der" --public-key-secret public-secret-name
-            --private-key-secret private-secret-name --subject-name "aio-opc-opcuabroker"
+            --instance instance
+            --resource-group instanceresourcegroup
+            --public-key-file "newopc.der"
+            --private-key-file "newopc.pem"
+            --public-key-secret public-secret-name
+            --private-key-secret private-secret-name
+            --subject-name "aio-opc-opcuabroker"
             --application-uri "urn:microsoft.com:aio:opc:opcuabroker"
       """
 

--- a/azext_edge/edge/commands_connector.py
+++ b/azext_edge/edge/commands_connector.py
@@ -46,6 +46,8 @@ def add_connector_opcua_client(
     private_key_file: str,
     subject_name: str,
     application_uri: str,
+    public_key_secret_name: Optional[str] = None,
+    private_key_secret_name: Optional[str] = None,
 ) -> dict:
     return OpcUACerts(cmd).client_add(
         instance_name=instance_name,
@@ -54,4 +56,6 @@ def add_connector_opcua_client(
         private_key_file=private_key_file,
         subject_name=subject_name,
         application_uri=application_uri,
+        public_key_secret_name=public_key_secret_name,
+        private_key_secret_name=private_key_secret_name,
     )

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1332,6 +1332,18 @@ def load_iotops_arguments(self, _):
             options_list=["--application-uri", "--au"],
             help="The application instance URI embedded in the application instance.",
         )
+        context.argument(
+            "public_key_secret_name",
+            options_list=["--public-key-secret", "--pks"],
+            help="Public key secret name in the Key Vault. If not provided, the "
+            "certificate file name will be used to generate the secret name.",
+        )
+        context.argument(
+            "private_key_secret_name",
+            options_list=["--private-key-secret", "--prks"],
+            help="Private key secret name in the Key Vault. If not provided, the "
+            "certificate file name will be used to generate the secret name.",
+        )
 
     with self.argument_context("iot ops schema version") as context:
         context.argument(

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -246,13 +246,18 @@ class OpcUACerts(Queryable):
             cert_extension = file_name_info[1].replace(".", "")
             secret_name = f"{file_name_info[0]}-{cert_extension}"
 
-            # iterate over secrets to check if secret with same name exists
-            if file == public_key_file:
-                flag = "public-key-secret"
-                secret_name = public_key_secret_name if public_key_secret_name else secret_name
-            else:
-                flag = "private-key-secret"
-                secret_name = private_key_secret_name if private_key_secret_name else secret_name
+            file_type_map = {
+                public_key_file: (
+                    "public-key-secret", public_key_secret_name if public_key_secret_name else secret_name
+                ),
+                private_key_file: (
+                    "private-key-secret", private_key_secret_name if private_key_secret_name else secret_name
+                )
+            }
+
+            # Iterate over secrets to check if a secret with the same name exists
+            if file in file_type_map:
+                flag, secret_name = file_type_map[file]
             secret_name = secret_name.replace(".", "-")
             secret_name = self._check_secret_name(secrets, secret_name, spc_keyvault_name, flag)
             self._upload_to_key_vault(secret_name, file, cert_extension)

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/conftest.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/conftest.py
@@ -131,41 +131,42 @@ def setup_mock_common_responses(
         content_type="application/json",
     )
 
-    # set secret
-    mocked_responses.add(
-        method=responses.PUT,
-        url=get_secret_endpoint(keyvault_name="mock-keyvault", secret_name=secret_name),
-        json={},
-        status=200,
-        content_type="application/json",
-    )
+    if secret_name != "mock-secret":
+        # set secret
+        mocked_responses.add(
+            method=responses.PUT,
+            url=get_secret_endpoint(keyvault_name="mock-keyvault", secret_name=secret_name),
+            json={},
+            status=200,
+            content_type="application/json",
+        )
 
-    # get opcua spc
-    mocked_responses.add(
-        method=responses.GET,
-        url=get_spc_endpoint(spc_name=OPCUA_SPC_NAME, resource_group_name=rg_name),
-        json=spc,
-        status=200,
-        content_type="application/json",
-    )
+        # get opcua spc
+        mocked_responses.add(
+            method=responses.GET,
+            url=get_spc_endpoint(spc_name=OPCUA_SPC_NAME, resource_group_name=rg_name),
+            json=spc,
+            status=200,
+            content_type="application/json",
+        )
 
-    # set opcua spc
-    mocked_responses.add(
-        method=responses.PUT,
-        url=get_spc_endpoint(spc_name=OPCUA_SPC_NAME, resource_group_name=rg_name),
-        json={},
-        status=200,
-        content_type="application/json",
-    )
+        # set opcua spc
+        mocked_responses.add(
+            method=responses.PUT,
+            url=get_spc_endpoint(spc_name=OPCUA_SPC_NAME, resource_group_name=rg_name),
+            json={},
+            status=200,
+            content_type="application/json",
+        )
 
-    # get opcua secretsync
-    mocked_responses.add(
-        method=responses.GET,
-        url=get_secretsync_endpoint(secretsync_name=opcua_secretsync_name, resource_group_name=rg_name),
-        json=secretsync,
-        status=200,
-        content_type="application/json",
-    )
+        # get opcua secretsync
+        mocked_responses.add(
+            method=responses.GET,
+            url=get_secretsync_endpoint(secretsync_name=opcua_secretsync_name, resource_group_name=rg_name),
+            json=secretsync,
+            status=200,
+            content_type="application/json",
+        )
 
 
 def assemble_resource_map_mock(

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
@@ -161,6 +161,28 @@ def test_trust_add(
             None,
             "Please enable secret sync before adding certificate.",
         ),
+        # secret existed
+        (
+            {
+                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resource sync rules": [generate_ops_resource()],
+                "custom locations": [generate_ops_resource()],
+                "extensions": [generate_ops_resource()],
+                "meta": {
+                    "expected_total": 4,
+                    "resource_batches": 1,
+                },
+            },
+            get_mock_spc_record(spc_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"),
+            get_mock_secretsync_record(
+                secretsync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME,
+                resource_group_name="mock-rg",
+            ),
+            "/fake/path/certificate.der",
+            "mock-secret",
+            "Secret with name mock-secret already exists in keyvault mock-keyvault. "
+            "Please provide a different name via --secret.",
+        ),
         # duplicate target key
         (
             {


### PR DESCRIPTION
instead fail with error
<img width="618" alt="image" src="https://github.com/user-attachments/assets/c5214a5d-c09c-4ab6-a0b9-3412fb60bfc5">


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
