### PR TITLE
fix: cert management look up existing resource use cl + rg instead of just rg

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -329,6 +329,7 @@ class OpcUACerts(Queryable):
 
         return secretsync_spc
 
+    # TODO: consider moving under instance as common method
     def _find_resource_from_cl_resources(
         self,
         cl_resources: List[dict],

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -76,14 +76,6 @@ class OpcUACerts(Queryable):
         secret_name = self._check_secret_name(secrets, secret_name, spc_keyvault_name, "secret")
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
-        # check if there is a spc called "opc-ua-connector", if not create one
-        # try:
-        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-        #         resource_group_name=resource_group,
-        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_spc = {}
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,
@@ -99,14 +91,6 @@ class OpcUACerts(Queryable):
             spc_client_id=spc_client_id,
         )
 
-        # check if there is a secret sync called "aio-opc-ua-broker-trust-list ", if not create one
-        # try:
-        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-        #         resource_group_name=resource_group,
-        #         secret_sync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_secret_sync = {}
         opcua_secret_sync = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SECRET_SYNC_RESOURCE_TYPE,
@@ -147,13 +131,6 @@ class OpcUACerts(Queryable):
         # get cert name by removing extension
         cert_name = os.path.splitext(file_name)[0]
 
-        # try:
-        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-        #         resource_group_name=resource_group,
-        #         secret_sync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_secret_sync = {}
         opcua_secret_sync = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SECRET_SYNC_RESOURCE_TYPE,
@@ -180,14 +157,6 @@ class OpcUACerts(Queryable):
         secret_name = self._check_secret_name(secrets, secret_name, spc_keyvault_name, "secret")
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
-        # check if there is a spc called "opc-ua-connector", if not create one
-        # try:
-        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-        #         resource_group_name=resource_group,
-        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_spc = {}
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,
@@ -243,14 +212,6 @@ class OpcUACerts(Queryable):
 
         secrets: PageIterator = self.keyvault_client.list_properties_of_secrets()
 
-        # check if there is a spc called "opc-ua-connector", if not create one
-        # try:
-        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-        #         resource_group_name=resource_group,
-        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_spc = {}
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,
@@ -258,13 +219,6 @@ class OpcUACerts(Queryable):
         )
 
         # check if there is a secret sync called "aio-opc-ua-broker-client-certificate", if not create one
-        # try:
-        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-        #         resource_group_name=resource_group,
-        #         secret_sync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
-        #     )
-        # except ResourceNotFoundError:
-        #     opcua_secret_sync = {}
         opcua_secret_sync = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SECRET_SYNC_RESOURCE_TYPE,

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -75,13 +75,18 @@ class OpcUACerts(Queryable):
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
         # check if there is a spc called "opc-ua-connector", if not create one
-        try:
-            opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-                resource_group_name=resource_group,
-                azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_spc = {}
+        # try:
+        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
+        #         resource_group_name=resource_group,
+        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_spc = {}
+        opcua_spc = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            resource_name=OPCUA_SPC_NAME,
+        )
 
         self._add_secrets_to_spc(
             secrets=[secret_name],
@@ -93,13 +98,18 @@ class OpcUACerts(Queryable):
         )
 
         # check if there is a secret sync called "aio-opc-ua-broker-trust-list ", if not create one
-        try:
-            opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-                resource_group_name=resource_group,
-                secret_sync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_secret_sync = {}
+        # try:
+        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
+        #         resource_group_name=resource_group,
+        #         secret_sync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_secret_sync = {}
+        opcua_secret_sync = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/secretsyncs",
+            resource_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME,
+        )
 
         return self._add_secrets_to_secret_sync(
             secrets=[(secret_name, file_name)],
@@ -135,13 +145,18 @@ class OpcUACerts(Queryable):
         # get cert name by removing extension
         cert_name = os.path.splitext(file_name)[0]
 
-        try:
-            opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-                resource_group_name=resource_group,
-                secret_sync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_secret_sync = {}
+        # try:
+        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
+        #         resource_group_name=resource_group,
+        #         secret_sync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_secret_sync = {}
+        opcua_secret_sync = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/secretsyncs",
+            resource_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME,
+        )
 
         if cert_extension == ".crl":
             matched_names = []
@@ -164,13 +179,18 @@ class OpcUACerts(Queryable):
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
         # check if there is a spc called "opc-ua-connector", if not create one
-        try:
-            opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-                resource_group_name=resource_group,
-                azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_spc = {}
+        # try:
+        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
+        #         resource_group_name=resource_group,
+        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_spc = {}
+        opcua_spc = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            resource_name=OPCUA_SPC_NAME,
+        )
 
         self._add_secrets_to_spc(
             secrets=[secret_name],
@@ -222,22 +242,32 @@ class OpcUACerts(Queryable):
         secrets: PageIterator = self.keyvault_client.list_properties_of_secrets()
 
         # check if there is a spc called "opc-ua-connector", if not create one
-        try:
-            opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-                resource_group_name=resource_group,
-                azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_spc = {}
+        # try:
+        #     opcua_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
+        #         resource_group_name=resource_group,
+        #         azure_key_vault_secret_provider_class_name=OPCUA_SPC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_spc = {}
+        opcua_spc = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            resource_name=OPCUA_SPC_NAME,
+        )
 
         # check if there is a secret sync called "aio-opc-ua-broker-client-certificate", if not create one
-        try:
-            opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
-                resource_group_name=resource_group,
-                secret_sync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
-            )
-        except ResourceNotFoundError:
-            opcua_secret_sync = {}
+        # try:
+        #     opcua_secret_sync = self.ssc_mgmt_client.secret_syncs.get(
+        #         resource_group_name=resource_group,
+        #         secret_sync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
+        #     )
+        # except ResourceNotFoundError:
+        #     opcua_secret_sync = {}
+        opcua_secret_sync = self._find_resource_from_cl_resources(
+            cl_resources=cl_resources,
+            resource_type="microsoft.secretsynccontroller/secretsyncs",
+            resource_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
+        )
 
         secrets_to_add = []
         for file in [public_key_file, private_key_file]:
@@ -325,15 +355,20 @@ class OpcUACerts(Queryable):
         # check if secret sync enabled by getting the default secretproviderclass
         secretsync_spc = None
 
+        # if cl_resources:
+        #     for resource in cl_resources:
+        #         if resource["type"].lower() == "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses":
+        #             resource_id_container = parse_resource_id(resource["id"])
+        #             secretsync_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
+        #                 resource_group_name=resource_id_container.resource_group_name,
+        #                 azure_key_vault_secret_provider_class_name=resource_id_container.resource_name,
+        #             )
+        #             break
         if cl_resources:
-            for resource in cl_resources:
-                if resource["type"].lower() == "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses":
-                    resource_id_container = parse_resource_id(resource["id"])
-                    secretsync_spc = self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
-                        resource_group_name=resource_id_container.resource_group_name,
-                        azure_key_vault_secret_provider_class_name=resource_id_container.resource_name,
-                    )
-                    break
+            secretsync_spc = self._find_resource_from_cl_resources(
+                cl_resources=cl_resources,
+                resource_type="microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            )
 
         if not secretsync_spc:
             raise ResourceNotFoundError(
@@ -342,6 +377,34 @@ class OpcUACerts(Queryable):
             )
 
         return secretsync_spc
+    
+
+    def _find_resource_from_cl_resources(
+        self,
+        cl_resources: List[dict],
+        resource_type: str,
+        resource_name: Optional[str] = None,
+    ) -> dict:
+        for resource in cl_resources:
+            resource_id_container = parse_resource_id(resource["id"])
+            cl_resource_name = resource_id_container.resource_name
+            name_matched = True
+            if resource_name:
+                name_matched = cl_resource_name == resource_name
+            if resource["type"].lower() == resource_type and name_matched:
+                if resource_type == "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses":
+                    return self.ssc_mgmt_client.azure_key_vault_secret_provider_classes.get(
+                        resource_group_name=resource_id_container.resource_group_name,
+                        azure_key_vault_secret_provider_class_name=cl_resource_name,
+                    )
+                elif resource_type == "microsoft.secretsynccontroller/secretsyncs":
+                    return self.ssc_mgmt_client.secret_syncs.get(
+                        resource_group_name=resource_id_container.resource_group_name,
+                        secret_sync_name=cl_resource_name,
+                    )
+        return {}
+
+        
 
     def _check_secret_name(self, secrets: PageIterator, secret_name: str, spc_keyvault_name: str, flag: str) -> str:
 

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -76,6 +76,7 @@ class OpcUACerts(Queryable):
         secret_name = self._check_secret_name(secrets, secret_name, spc_keyvault_name, "secret")
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
+        # check if there is a spc called "opc-ua-connector", if not create one
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,
@@ -91,6 +92,7 @@ class OpcUACerts(Queryable):
             spc_client_id=spc_client_id,
         )
 
+        # check if there is a secret sync called "aio-opc-ua-broker-trust-list ", if not create one
         opcua_secret_sync = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SECRET_SYNC_RESOURCE_TYPE,
@@ -157,6 +159,7 @@ class OpcUACerts(Queryable):
         secret_name = self._check_secret_name(secrets, secret_name, spc_keyvault_name, "secret")
         self._upload_to_key_vault(secret_name, file, cert_extension)
 
+        # check if there is a spc called "opc-ua-connector", if not create one
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,
@@ -212,6 +215,7 @@ class OpcUACerts(Queryable):
 
         secrets: PageIterator = self.keyvault_client.list_properties_of_secrets()
 
+        # check if there is a spc called "opc-ua-connector", if not create one
         opcua_spc = self._find_resource_from_cl_resources(
             cl_resources=cl_resources,
             resource_type=SPC_RESOURCE_TYPE,

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
@@ -35,7 +35,13 @@ from azext_edge.tests.helpers import generate_ops_resource
     [
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extension": {IOT_OPS_EXTENSION_TYPE: {"id": "aio-ext-id", "name": "aio-ext-name", "properties": {}}},
@@ -140,6 +146,11 @@ def test_client_add(
         subject_name="subjectname",
     )
 
+    assert (
+        mocked_logger.warning.call_args[0][0] == "Please ensure the certificate must be added "
+        "to the issuers list if it was issued by a CA. "
+    )
+
     if result:
         if not client_app_spc:
             assert (
@@ -191,7 +202,13 @@ def test_client_add(
         # no aio extension
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extension": {},

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
@@ -30,7 +30,13 @@ from azext_edge.tests.helpers import generate_ops_resource
     [
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -54,7 +60,13 @@ from azext_edge.tests.helpers import generate_ops_resource
         # adding .crl with corresponding .der or crt
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -244,7 +256,13 @@ def test_issuer_add(
         # adding .crl without corresponding .der or crt
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -264,7 +282,13 @@ def test_issuer_add(
         # duplicate targetKey in objectSecretMapping
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -290,7 +314,13 @@ def test_issuer_add(
         # secret existed
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_ISSUER_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
@@ -30,7 +30,13 @@ from azext_edge.tests.helpers import generate_ops_resource
     [
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -164,7 +170,13 @@ def test_trust_add(
         # secret existed
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],
@@ -186,7 +198,13 @@ def test_trust_add(
         # duplicate target key
         (
             {
-                "resources": [get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg")],
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_TRUST_LIST_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
                 "resource sync rules": [generate_ops_resource()],
                 "custom locations": [generate_ops_resource()],
                 "extensions": [generate_ops_resource()],


### PR DESCRIPTION
this way will fix the issue when there is already a resource with same name existed in rg with other aio instance

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
