### PR TITLE
fix: changes for `az iot ops upgrade` display text

### DIFF
--- a/azext_edge/edge/providers/orchestration/upgrade.py
+++ b/azext_edge/edge/providers/orchestration/upgrade.py
@@ -112,7 +112,7 @@ class UpgradeManager:
         print()
         print("[yellow]Upgrading may fail and require you to delete and re-create your cluster.[/yellow]")
 
-        should_bail = not should_continue_prompt(confirm_yes=confirm_yes)
+        should_bail = not should_continue_prompt(confirm_yes=confirm_yes, context="Upgrade")
         if should_bail:
             return
 
@@ -155,8 +155,9 @@ class UpgradeManager:
                 "properties" : {
                     "autoUpgradeMinorVersion": "false",
                     "releaseTrain": train_map[extension_key],
-                    "version": version_map[extension_key]
-                }
+                    "version": version_map[extension_key],
+                },
+                "currentVersion": current_version
             }
 
             if extension_type == "microsoft.openservicemesh":
@@ -186,8 +187,9 @@ class UpgradeManager:
         # text to print (ordered)
         display_desc = "[dim]"
         for extension, update in self.extensions_to_update.items():
-            version = update["properties"]["version"]
-            display_desc += f"• {extension}: {version}\n"
+            new_version = update["properties"]["version"]
+            old_version = update.pop("currentVersion")
+            display_desc += f"• {extension}: {old_version} -> {new_version}\n"
         return display_desc[:-1] + ""
 
     def _get_resource_map(self) -> IoTOperationsResourceMap:


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ae033de0-d14e-47a8-bef6-af771f8151a8)

'nuff said

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
