### PR TITLE
feat: enable --user-trust configuration on init and create

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -482,11 +482,10 @@ def load_iotops_help():
         - name: Similar to the prior example but with Arc Container Storage fault-tolerance enabled (requires at least 3 nodes).
           text: >
              az iot ops init --cluster mycluster -g myresourcegroup --enable-fault-tolerance
-        - name: This example highlights trust settings for a user provided cert manager config.
+        - name: This example highlights enabling user trust settings for a custom cert manager config.
+            This will skip deployment of the system CertManager and TrustManager.
           text: >
-             az iot ops init --cluster mycluster -g myresourcegroup --trust-settings
-             configMapName=example-bundle configMapKey=trust-bundle.pem issuerKind=ClusterIssuer
-             issuerName=trust-manager-selfsigned-issuer
+             az iot ops init --cluster mycluster -g myresourcegroup --user-trust
 
     """
 
@@ -522,6 +521,13 @@ def load_iotops_help():
           text: >
              az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
              --enable-rsync
+        - name: This example highlights trust settings for a user provided cert manager config.
+            Note: Cluster must have been initialized with `--user-trust` and a user CertManager deployment must be present.
+          text: >
+              az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
+              --trust-settings configMapName=example-bundle configMapKey=trust-bundle.pem 
+              issuerKind=ClusterIssuer issuerName=trust-manager-selfsigned-issuer
+
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -482,8 +482,8 @@ def load_iotops_help():
         - name: Similar to the prior example but with Arc Container Storage fault-tolerance enabled (requires at least 3 nodes).
           text: >
              az iot ops init --cluster mycluster -g myresourcegroup --enable-fault-tolerance
-        - name: This example highlights enabling user trust settings for a custom cert manager config.
-            This will skip deployment of the system CertManager and TrustManager.
+        - name: This example highlights enabling user trust settings for a custom cert-manager config.
+            This will skip deployment of the system cert-manager and trust-manager.
           text: >
              az iot ops init --cluster mycluster -g myresourcegroup --user-trust
 
@@ -521,8 +521,8 @@ def load_iotops_help():
           text: >
              az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
              --enable-rsync
-        - name: This example highlights trust settings for a user provided cert manager config.
-            Note: Cluster must have been initialized with `--user-trust` and a user CertManager deployment must be present.
+        - name: This example highlights trust settings for a user provided cert-manager config.
+            Note that the cluster must have been initialized with `--user-trust` and a user cert-manager deployment must be present.
           text: >
               az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
               --trust-settings configMapName=example-bundle configMapKey=trust-bundle.pem

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -525,7 +525,7 @@ def load_iotops_help():
             Note: Cluster must have been initialized with `--user-trust` and a user CertManager deployment must be present.
           text: >
               az iot ops create --cluster mycluster -g myresourcegroup --name myinstance --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
-              --trust-settings configMapName=example-bundle configMapKey=trust-bundle.pem 
+              --trust-settings configMapName=example-bundle configMapKey=trust-bundle.pem
               issuerKind=ClusterIssuer issuerName=trust-manager-selfsigned-issuer
 
     """

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -109,10 +109,10 @@ def init(
     cmd,
     cluster_name: str,
     resource_group_name: str,
-    trust_settings: Optional[List[str]] = None,
     enable_fault_tolerance: Optional[bool] = None,
     no_progress: Optional[bool] = None,
     ensure_latest: Optional[bool] = None,
+    user_trust: Optional[bool] = None,
     **kwargs,
 ) -> Union[Dict[str, Any], None]:
     from .common import INIT_NO_PREFLIGHT_ENV_KEY
@@ -130,7 +130,7 @@ def init(
         cluster_name=cluster_name,
         resource_group_name=resource_group_name,
         enable_fault_tolerance=enable_fault_tolerance,
-        trust_settings=trust_settings,
+        user_trust=user_trust,
     )
 
 
@@ -167,6 +167,7 @@ def create_instance(
     enable_rsync_rules: Optional[bool] = None,
     instance_description: Optional[str] = None,
     dataflow_profile_instances: int = 1,
+    trust_settings: Optional[List[str]] = None,
     # Ops extension
     container_runtime_socket: Optional[str] = None,
     kubernetes_distro: str = KubernetesDistroType.k8s.value,
@@ -221,6 +222,7 @@ def create_instance(
         instance_description=instance_description,
         add_insecure_listener=add_insecure_listener,
         dataflow_profile_instances=dataflow_profile_instances,
+        trust_settings=trust_settings,
         # Ops Extension
         container_runtime_socket=container_runtime_socket,
         kubernetes_distro=kubernetes_distro,

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -543,8 +543,8 @@ def load_iotops_arguments(self, _):
                 "user_trust",
                 options_list=["--user-trust", "--ut"],
                 arg_type=get_three_state_flag(),
-                help="Skip the deployment of the system CertManager and TrustManager "
-                "in favor of a user-provided configuration",
+                help="Skip the deployment of the system cert-manager and trust-manager "
+                "in favor of a user-provided configuration.",
                 arg_group="Trust",
             )
 

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -539,6 +539,13 @@ def load_iotops_arguments(self, _):
                 "used, a system provided self-signed trust bundle is configured.",
                 arg_group="Trust",
             )
+            context.argument(
+                "user_trust",
+                options_list=["--user-trust", "--ut"],
+                arg_type=get_three_state_flag(),
+                help="Skip the deployment of the system CertManager and TrustManager in favor of a user-provided configuration",
+                arg_group="Trust",
+            )
 
     with self.argument_context("iot ops upgrade") as context:
         # Schema Registry

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -543,7 +543,8 @@ def load_iotops_arguments(self, _):
                 "user_trust",
                 options_list=["--user-trust", "--ut"],
                 arg_type=get_three_state_flag(),
-                help="Skip the deployment of the system CertManager and TrustManager in favor of a user-provided configuration",
+                help="Skip the deployment of the system CertManager and TrustManager "
+                "in favor of a user-provided configuration",
                 arg_group="Trust",
             )
 

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -63,6 +63,8 @@ class InitTargets:
         # Akri
         kubernetes_distro: str = KubernetesDistroType.k8s.value,
         container_runtime_socket: Optional[str] = None,
+        # User Trust Config
+        user_trust: Optional[bool] = None,
         **_,
     ):
         self.cluster_name = cluster_name
@@ -84,6 +86,7 @@ class InitTargets:
         self.trust_settings = assemble_nargs_to_dict(trust_settings)
         self.trust_config = self.get_trust_settings_target_map()
         self.advanced_config = self.get_advanced_config_target_map()
+        self.user_trust = user_trust
 
         # Dataflow
         self.dataflow_profile_instances = self._sanitize_int(dataflow_profile_instances)
@@ -150,7 +153,11 @@ class InitTargets:
             },
             template_blueprint=M3_ENABLEMENT_TEMPLATE,
         )
-
+        if self.user_trust:
+            # disable cert and trust manager
+            parameters["trustConfig"]["value"]["source"] = "CustomerManaged"
+            # patch enablement template expecting full trust settings for source: CustomerManaged
+            del template.content["definitions"]["_1.CustomerManaged"]["properties"]["settings"]
         # TODO - @digimaun - expand trustSource for self managed & trustBundleSettings
         return template.content, parameters
 

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -158,7 +158,6 @@ class InitTargets:
             parameters["trustConfig"]["value"]["source"] = "CustomerManaged"
             # patch enablement template expecting full trust settings for source: CustomerManaged
             del template.content["definitions"]["_1.CustomerManaged"]["properties"]["settings"]
-        # TODO - @digimaun - expand trustSource for self managed & trustBundleSettings
         return template.content, parameters
 
     def get_ops_instance_template(

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -157,7 +157,7 @@ class InitTargets:
             # disable cert and trust manager
             parameters["trustConfig"]["value"]["source"] = "CustomerManaged"
             # patch enablement template expecting full trust settings for source: CustomerManaged
-            del template.content["definitions"]["_1.CustomerManaged"]["properties"]["settings"]
+            template.get_type_definition("_1.CustomerManaged")["properties"]["settings"]["nullable"] = True
         return template.content, parameters
 
     def get_ops_instance_template(

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -139,18 +139,14 @@ class WorkManager:
     def _build_display(self):
         pre_check_cat_desc = "Pre-Flight"
         self._display.add_category(WorkCategoryKey.PRE_FLIGHT, pre_check_cat_desc, skipped=not self._pre_flight)
-        self._display.add_step(
-            WorkCategoryKey.PRE_FLIGHT, WorkStepKey.REG_RP, "Ensure registered resource providers"
-        )
+        self._display.add_step(WorkCategoryKey.PRE_FLIGHT, WorkStepKey.REG_RP, "Ensure registered resource providers")
         self._display.add_step(
             WorkCategoryKey.PRE_FLIGHT, WorkStepKey.ENUMERATE_PRE_FLIGHT, "Enumerate pre-flight checks"
         )
 
         if self._apply_foundation:
             self._display.add_category(WorkCategoryKey.ENABLE_IOT_OPS, "Enablement")
-            self._display.add_step(
-                WorkCategoryKey.ENABLE_IOT_OPS, WorkStepKey.WHAT_IF_ENABLEMENT, "What-If evaluation"
-            )
+            self._display.add_step(WorkCategoryKey.ENABLE_IOT_OPS, WorkStepKey.WHAT_IF_ENABLEMENT, "What-If evaluation")
             self._display.add_step(
                 WorkCategoryKey.ENABLE_IOT_OPS,
                 WorkStepKey.DEPLOY_ENABLEMENT,
@@ -292,9 +288,7 @@ class WorkManager:
             # Enable IoT Ops workflow
             if self._apply_foundation:
                 enablement_work_name = self._work_format_str.format(op="enablement")
-                self.render_display(
-                    category=WorkCategoryKey.ENABLE_IOT_OPS, active_step=WorkStepKey.WHAT_IF_ENABLEMENT
-                )
+                self.render_display(category=WorkCategoryKey.ENABLE_IOT_OPS, active_step=WorkStepKey.WHAT_IF_ENABLEMENT)
                 enablement_content, enablement_parameters = self._targets.get_ops_enablement_template()
                 self._deploy_template(
                     content=enablement_content,
@@ -359,14 +353,22 @@ class WorkManager:
                             "Foundational service installation not detected. "
                             "Instance deployment will not continue. Please run `az iot ops init`."
                         )
-                
+
                 # validate trust config in platform extension matches trust settings in create
-                platform_extension_config=self._extension_map[IOT_OPS_PLAT_EXTENSION_TYPE]["properties"]["configurationSettings"]
+                platform_extension_config = self._extension_map[IOT_OPS_PLAT_EXTENSION_TYPE]["properties"][
+                    "configurationSettings"
+                ]
                 is_user_trust = platform_extension_config.get("installCertManager", "").lower() != "true"
                 if is_user_trust and not self._targets.trust_settings:
-                    raise ValidationError("Cluster was enabled with user-managed trust configuration, --trust-settings arguments are required to create an instance on this cluster.")
+                    raise ValidationError(
+                        "Cluster was enabled with user-managed trust configuration, "
+                        "--trust-settings arguments are required to create an instance on this cluster."
+                    )
                 elif not is_user_trust and self._targets.trust_settings:
-                    raise ValidationError("Cluster was enabled with system CertManager, trust settings (--trust-settings) are not applicable to this cluster.")
+                    raise ValidationError(
+                        "Cluster was enabled with system CertManager, "
+                        "trust settings (--trust-settings) are not applicable to this cluster."
+                    )
 
                 instance_work_name = self._work_format_str.format(op="instance")
                 self.render_display(category=WorkCategoryKey.DEPLOY_IOT_OPS, active_step=WorkStepKey.WHAT_IF_INSTANCE)
@@ -403,7 +405,7 @@ class WorkManager:
                 instance_output = wait_for_terminal_state(instance_poller)
 
                 # safely get nested property
-                keys = ['properties', 'outputs', 'aioExtension', 'value', 'identityPrincipalId']
+                keys = ["properties", "outputs", "aioExtension", "value", "identityPrincipalId"]
                 extension_principal_id = reduce(lambda val, key: val.get(key) if val else None, keys, instance_output)
                 # TODO - @c-ryan-k consider setting role_assignment_error if extension_principal_id is None
                 role_assignment_error = None

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -359,6 +359,14 @@ class WorkManager:
                             "Foundational service installation not detected. "
                             "Instance deployment will not continue. Please run `az iot ops init`."
                         )
+                
+                # validate trust config in platform extension matches trust settings in create
+                platform_extension_config=self._extension_map[IOT_OPS_PLAT_EXTENSION_TYPE]["properties"]["configurationSettings"]
+                is_user_trust = platform_extension_config.get("installCertManager", "").lower() != "true"
+                if is_user_trust and not self._targets.trust_settings:
+                    raise ValidationError("Cluster was enabled with user-managed trust configuration, --trust-settings arguments are required to create an instance on this cluster.")
+                elif not is_user_trust and self._targets.trust_settings:
+                    raise ValidationError("Cluster was enabled with system CertManager, trust settings (--trust-settings) are not applicable to this cluster.")
 
                 instance_work_name = self._work_format_str.format(op="instance")
                 self.render_display(category=WorkCategoryKey.DEPLOY_IOT_OPS, active_step=WorkStepKey.WHAT_IF_INSTANCE)

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -366,7 +366,7 @@ class WorkManager:
                     )
                 elif not is_user_trust and self._targets.trust_settings:
                     raise ValidationError(
-                        "Cluster was enabled with system CertManager, "
+                        "Cluster was enabled with system cert-manager, "
                         "trust settings (--trust-settings) are not applicable to this cluster."
                     )
 

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -113,7 +113,7 @@ INSTANCE_PARAM_CONVERSION_MAP = {
                 resource_provider="Microsoft.DeviceRegistry",
             ),
             user_trust=True,
-        )
+        ),
     ],
 )
 def test_init_targets(target_scenario: dict):
@@ -141,12 +141,7 @@ def test_init_targets(target_scenario: dict):
 
     enablement_template, enablement_parameters = targets.get_ops_enablement_template()
 
-    if target_scenario.get("user_trust"):
-        assert targets.trust_config["source"] == "CustomerManaged"
-        # TODO @c-ryan-k - Enablement template should not require "settings" for customer managed trust config
-        assert enablement_template["definitions"]["_1.CustomerManaged"]["properties"]["settings"]["nullable"]
-    elif not target_scenario.get("trust_settings"):
-        assert targets.trust_config["source"] == "SelfSigned"
+    verify_user_trust_enablement(targets, enablement_template, target_scenario)
 
     for parameter in enablement_parameters:
         targets_key = parameter
@@ -162,7 +157,6 @@ def test_init_targets(target_scenario: dict):
         targets.trust_config = None
 
     instance_template, instance_parameters = targets.get_ops_instance_template(extension_ids)
-
 
     if targets.ops_version:
         assert instance_template["variables"]["VERSIONS"]["iotOperations"] == targets.ops_version
@@ -227,3 +221,12 @@ def verify_user_trust_settings(targets: InitTargets, target_scenario: dict):
             "configMapName": target_scenario["trust_settings"]["configMapName"],
         },
     }
+
+
+def verify_user_trust_enablement(targets: InitTargets, enablement_template: dict, target_scenario: dict):
+    if target_scenario.get("user_trust"):
+        assert targets.trust_config["source"] == "CustomerManaged"
+        # TODO @c-ryan-k - Enablement template should not require "settings" for customer managed trust config
+        assert enablement_template["definitions"]["_1.CustomerManaged"]["properties"]["settings"]["nullable"]
+    elif not target_scenario.get("trust_settings"):
+        assert targets.trust_config["source"] == "SelfSigned"


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
