### PR TITLE
feat!: remove verify-host, hide upgrade, re-classify preview cmds

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -277,7 +277,6 @@ jobs:
           az iot ops check --as-object
           az iot ops check --svc broker --resources broker brokerlistener
           az iot ops asset query -g ${{ env.RESOURCE_GROUP }} --location westus -o table
-          az iot ops verify-host
       - name: "Delete Cluster for redeployment"
         if: ${{ matrix.feature == 'redeploy' }}
         run: |

--- a/azext_edge/azext_metadata.json
+++ b/azext_edge/azext_metadata.json
@@ -1,4 +1,3 @@
 {
-    "azext.minCliCoreVersion": "2.53.0",
-    "azext.isPreview": true
+    "azext.minCliCoreVersion": "2.53.0"
 }

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "1.0.0a1"
+VERSION = "1.0.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -570,6 +570,30 @@ def load_iotops_help():
     """
 
     helps[
+        "iot ops upgrade"
+    ] = """
+        type: command
+        short-summary: Upgrade an IoT Operations instance to the latest version.
+        long-summary: |
+                      WARNING: This command may fail and require you to delete and re-create your cluster and instance.
+
+                      Upgrade an IoT Operations instance, including updating the extensions to the latest versions.
+                      Use this command if `az iot ops show` or similiar commands are failing.
+
+                      Schema registry resource Id is an optional parameter and may be required in specific scenarios.
+        examples:
+        - name: Upgrade the instance with minimal inputs.
+          text: >
+            az iot ops upgrade --name myinstance -g myresourcegroup
+        - name: Skip the conformation prompt during instance upgrade.
+          text: >
+            az iot ops upgrade --name myinstance -g myresourcegroup -y
+        - name: Upgrade the instance and specify the schema registry resource Id.
+          text: >
+            az iot ops upgrade --name myinstance -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
+    """
+
+    helps[
         "iot ops identity"
     ] = """
         type: group

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -522,8 +522,6 @@ def load_iotops_help():
         long-summary: Optionally the command can output a tree structure of associated resources representing
           the IoT Operations deployment against the backing cluster.
 
-          If this command fails, please use `az iot ops upgrade` to upgrade your instance to the latest version before continuing.
-
         examples:
         - name: Basic usage to show an instance.
           text: >
@@ -571,29 +569,30 @@ def load_iotops_help():
             az iot ops update --name myinstance -g myresourcegroup --desc "Fabrikam Widget Factory B42"
     """
 
-    helps[
-        "iot ops upgrade"
-    ] = """
-        type: command
-        short-summary: Upgrade an IoT Operations instance to the latest version.
-        long-summary: |
-                      WARNING: This command may fail and require you to delete and re-create your cluster and instance.
+    # TODO: Next iteration of upgrade
+    # helps[
+    #     "iot ops upgrade"
+    # ] = """
+    #     type: command
+    #     short-summary: Upgrade an IoT Operations instance to the latest version.
+    #     long-summary: |
+    #                   WARNING: This command may fail and require you to delete and re-create your cluster and instance.
 
-                      Upgrade an IoT Operations instance, including updating the extensions to the latest versions.
-                      Use this command if `az iot ops show` or similiar commands are failing.
+    #                   Upgrade an IoT Operations instance, including updating the extensions to the latest versions.
+    #                   Use this command if `az iot ops show` or similiar commands are failing.
 
-                      Schema registry resource Id is an optional parameter and may be required in specific scenarios.
-        examples:
-        - name: Upgrade the instance with minimal inputs.
-          text: >
-            az iot ops upgrade --name myinstance -g myresourcegroup
-        - name: Skip the conformation prompt during instance upgrade.
-          text: >
-            az iot ops upgrade --name myinstance -g myresourcegroup -y
-        - name: Upgrade the instance and specify the schema registry resource Id.
-          text: >
-            az iot ops upgrade --name myinstance -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
-    """
+    #                   Schema registry resource Id is an optional parameter and may be required in specific scenarios.
+    #     examples:
+    #     - name: Upgrade the instance with minimal inputs.
+    #       text: >
+    #         az iot ops upgrade --name myinstance -g myresourcegroup
+    #     - name: Skip the conformation prompt during instance upgrade.
+    #       text: >
+    #         az iot ops upgrade --name myinstance -g myresourcegroup -y
+    #     - name: Upgrade the instance and specify the schema registry resource Id.
+    #       text: >
+    #         az iot ops upgrade --name myinstance -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
+    # """
 
     helps[
         "iot ops identity"
@@ -653,19 +652,17 @@ def load_iotops_help():
         type: command
         short-summary: Enable secret sync for an instance.
         long-summary: |
-            The operation handles federation, creation of a secret provider class
-            and role assignments of the managed identity to the target Key Vault.
-
-            Only one Secret Provider Class must be associated to the instance at a time.
+            The operation handles identity federation, creation of a default secret provider class
+            and role assignments of the managed identity against the target Key Vault.
 
         examples:
         - name: Enable the target instance for Key Vault secret sync.
           text: >
-            az iot ops secretsync enable --name myinstance -g myresourcegroup
+            az iot ops secretsync enable --instance myinstance -g myresourcegroup
             --mi-user-assigned $UA_MI_RESOURCE_ID --kv-resource-id $KEYVAULT_RESOURCE_ID
         - name: Same as prior example except flag to skip Key Vault role assignments.
           text: >
-            az iot ops secretsync enable --name myinstance -g myresourcegroup
+            az iot ops secretsync enable --instance myinstance -g myresourcegroup
             --mi-user-assigned $UA_MI_RESOURCE_ID --kv-resource-id $KEYVAULT_RESOURCE_ID --skip-ra
     """
 
@@ -678,7 +675,7 @@ def load_iotops_help():
         examples:
         - name: List the secret sync configs associated with an instance.
           text: >
-            az iot ops secretsync list --name myinstance -g myresourcegroup
+            az iot ops secretsync list --instance myinstance -g myresourcegroup
     """
 
     helps[
@@ -693,7 +690,7 @@ def load_iotops_help():
         examples:
         - name: Disable secret sync for an instance.
           text: >
-            az iot ops secretsync disable --name myinstance -g myresourcegroup
+            az iot ops secretsync disable --instance myinstance -g myresourcegroup
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -416,18 +416,6 @@ def load_iotops_help():
     """
 
     helps[
-        "iot ops verify-host"
-    ] = """
-        type: command
-        short-summary: Runs a set of cluster host verifications for IoT Operations deployment compatibility.
-        long-summary: Intended to be run directly on a target cluster host.
-          The command may prompt to apply a set of privileged actions such as installing a dependency.
-          In this case the CLI must be run with elevated permissions. For example
-
-            `sudo AZURE_EXTENSION_DIR=~/.azure/cliextensions az iot ops verify-host`.
-    """
-
-    helps[
         "iot ops init"
     ] = """
         type: command

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -555,7 +555,7 @@ def load_iotops_help():
     ] = """
         type: command
         short-summary: Update an IoT Operations instance.
-        long-summary: Currently instance tags and description can be updated. If you want to upgrade your instance to a newer version, please use `az iot ops upgrade` instead.
+        long-summary: Currently instance tags and description can be updated.
 
         examples:
         - name: Update instance tags. This is equivalent to a replace.

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -569,31 +569,6 @@ def load_iotops_help():
             az iot ops update --name myinstance -g myresourcegroup --desc "Fabrikam Widget Factory B42"
     """
 
-    # TODO: Next iteration of upgrade
-    # helps[
-    #     "iot ops upgrade"
-    # ] = """
-    #     type: command
-    #     short-summary: Upgrade an IoT Operations instance to the latest version.
-    #     long-summary: |
-    #                   WARNING: This command may fail and require you to delete and re-create your cluster and instance.
-
-    #                   Upgrade an IoT Operations instance, including updating the extensions to the latest versions.
-    #                   Use this command if `az iot ops show` or similiar commands are failing.
-
-    #                   Schema registry resource Id is an optional parameter and may be required in specific scenarios.
-    #     examples:
-    #     - name: Upgrade the instance with minimal inputs.
-    #       text: >
-    #         az iot ops upgrade --name myinstance -g myresourcegroup
-    #     - name: Skip the conformation prompt during instance upgrade.
-    #       text: >
-    #         az iot ops upgrade --name myinstance -g myresourcegroup -y
-    #     - name: Upgrade the instance and specify the schema registry resource Id.
-    #       text: >
-    #         az iot ops upgrade --name myinstance -g myresourcegroup --sr-resource-id $SCHEMA_REGISTRY_RESOURCE_ID
-    # """
-
     helps[
         "iot ops identity"
     ] = """

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -26,17 +26,14 @@ def load_iotops_commands(self, _):
     with self.command_group(
         "iot ops",
         command_type=edge_resource_ops,
-        is_preview=True,
     ) as cmd_group:
-        cmd_group.command("check", "check")
+        cmd_group.command("check", "check", is_preview=True)
         cmd_group.command("init", "init")
-        cmd_group.command("upgrade", "upgrade")
         cmd_group.command("create", "create_instance")
         cmd_group.command("update", "update_instance")
         cmd_group.show_command("show", "show_instance")
         cmd_group.command("list", "list_instances")
         cmd_group.command("delete", "delete")
-        cmd_group.command("verify-host", "verify_host")
 
     with self.command_group(
         "iot ops identity",
@@ -49,6 +46,7 @@ def load_iotops_commands(self, _):
     with self.command_group(
         "iot ops secretsync",
         command_type=secretsync_resource_ops,
+        is_preview=True,
     ) as cmd_group:
         cmd_group.command("enable", "secretsync_enable")
         cmd_group.command("disable", "secretsync_disable")
@@ -57,6 +55,7 @@ def load_iotops_commands(self, _):
     with self.command_group(
         "iot ops support",
         command_type=edge_resource_ops,
+        is_preview=True,
     ) as cmd_group:
         cmd_group.command("create-bundle", "support_bundle")
 
@@ -168,6 +167,7 @@ def load_iotops_commands(self, _):
     with self.command_group(
         "iot ops schema",
         command_type=schema_resource_ops,
+        is_preview=True,
     ) as cmd_group:
         cmd_group.command("create", "create_schema")
         cmd_group.show_command("show", "show_schema")
@@ -183,6 +183,22 @@ def load_iotops_commands(self, _):
         cmd_group.show_command("show", "show_registry")
         cmd_group.command("list", "list_registries")
         cmd_group.command("delete", "delete_registry")
+
+    with self.command_group(
+        "iot ops schema version",
+        command_type=schema_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_version")
+        cmd_group.show_command("show", "show_version")
+        cmd_group.command("list", "list_versions")
+        cmd_group.command("remove", "remove_version")
+
+    with self.command_group(
+        "iot ops connector",
+        command_type=connector_resource_ops,
+        is_preview=True,
+    ) as cmd_group:
+        pass
 
     with self.command_group(
         "iot ops connector opcua trust",
@@ -201,12 +217,3 @@ def load_iotops_commands(self, _):
         command_type=connector_resource_ops,
     ) as cmd_group:
         cmd_group.command("add", "add_connector_opcua_client")
-
-    with self.command_group(
-        "iot ops schema version",
-        command_type=schema_resource_ops,
-    ) as cmd_group:
-        cmd_group.command("add", "add_version")
-        cmd_group.show_command("show", "show_version")
-        cmd_group.command("list", "list_versions")
-        cmd_group.command("remove", "remove_version")

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -29,6 +29,7 @@ def load_iotops_commands(self, _):
     ) as cmd_group:
         cmd_group.command("check", "check", is_preview=True)
         cmd_group.command("init", "init")
+        cmd_group.command("upgrade", "upgrade", deprecate_info=cmd_group.deprecate(hide=True))
         cmd_group.command("create", "create_instance")
         cmd_group.command("update", "update_instance")
         cmd_group.show_command("show", "show_instance")

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -173,7 +173,7 @@ def load_iotops_commands(self, _):
         cmd_group.command("create", "create_schema")
         cmd_group.show_command("show", "show_schema")
         cmd_group.command("list", "list_schemas")
-        cmd_group.command("show-dataflow-refs", "list_schema_versions_dataflow_format")
+        cmd_group.command("show-dataflow-refs", "list_schema_versions_dataflow_format", is_experimental=True)
         cmd_group.command("delete", "delete_schema")
 
     with self.command_group(

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -95,16 +95,6 @@ def check(
     )
 
 
-def verify_host(
-    cmd,
-    no_progress: Optional[bool] = None,
-):
-    from .providers.orchestration import run_host_verify
-
-    run_host_verify(render_progress=not no_progress)
-    return
-
-
 def init(
     cmd,
     cluster_name: str,

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -311,12 +311,6 @@ def load_iotops_arguments(self, _):
     for cmd_space in ["iot ops init", "iot ops create"]:
         with self.argument_context(cmd_space) as context:
             context.argument(
-                "instance_name",
-                options_list=["--name", "-n"],
-                help="IoT Operations instance name. An instance name must be provided to "
-                "deploy an instance during init orchestration.",
-            )
-            context.argument(
                 "cluster_name",
                 options_list=["--cluster"],
                 help="Target cluster name for IoT Operations deployment.",
@@ -533,14 +527,19 @@ def load_iotops_arguments(self, _):
         context.argument(
             "spc_name",
             options_list=["--spc"],
-            help="The secret provider class name for secret sync enablement. "
-            "The default pattern is '{instance_name}-spc'.",
+            help="The default secret provider class name for secret sync enablement. "
+            "The default pattern is 'spc-ops-{hash}'.",
         )
         context.argument(
             "skip_role_assignments",
             options_list=["--skip-ra"],
             arg_type=get_three_state_flag(),
             help="When used the role assignment step of the operation will be skipped.",
+        )
+        context.argument(
+            "instance_name",
+            options_list=["--instance", "-i", "-n"],
+            help="IoT Operations instance name.",
         )
 
     with self.argument_context("iot ops asset") as context:
@@ -1233,7 +1232,7 @@ def load_iotops_arguments(self, _):
     with self.argument_context("iot ops connector opcua") as context:
         context.argument(
             "instance_name",
-            options_list=["--instance", "-i"],
+            options_list=["--instance", "-i", "-n"],
             help="IoT Operations instance name.",
         )
         context.argument(

--- a/azext_edge/edge/providers/orchestration/__init__.py
+++ b/azext_edge/edge/providers/orchestration/__init__.py
@@ -5,11 +5,9 @@
 # ----------------------------------------------------------------------------------------------
 
 from .deletion import delete_ops_resources
-from .host import run_host_verify
 from .work import WorkManager
 
 __all__ = [
     "WorkManager",
     "delete_ops_resources",
-    "run_host_verify",
 ]

--- a/azext_edge/edge/providers/orchestration/host.py
+++ b/azext_edge/edge/providers/orchestration/host.py
@@ -5,14 +5,14 @@
 # ----------------------------------------------------------------------------------------------
 
 
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, List, NamedTuple
 
 import requests
 from azure.cli.core.azclierror import ValidationError
 from knack.log import get_logger
 from rich.console import Console
 
-from .common import ARM_ENDPOINT, MCR_ENDPOINT
+from .common import ARM_ENDPOINT
 
 logger = get_logger(__name__)
 console = Console(width=88)
@@ -33,22 +33,6 @@ class EndpointConnections(NamedTuple):
         failed_conns = self.failed_connections
         if failed_conns:
             raise ValidationError(get_connectivity_error(failed_conns, include_cluster=include_cluster))
-
-
-def run_host_verify(render_progress: Optional[bool] = True):
-    if not render_progress:
-        console.quiet = True
-    connect_endpoints = [ARM_ENDPOINT, MCR_ENDPOINT]
-    console.print()
-
-    with console.status(status="Analyzing host..."):
-        console.print("[bold]Connectivity[/bold] to:")
-        endpoint_connections = preflight_http_connections(connect_endpoints)
-        for endpoint in endpoint_connections.connect_map:
-            console.print(f"- {endpoint} ", "...", endpoint_connections.connect_map[endpoint])
-        endpoint_connections.throw_if_failure()
-
-    console.print()
 
 
 def check_connectivity(url: str, timeout: int = 20):

--- a/azext_edge/tests/edge/conftest.py
+++ b/azext_edge/tests/edge/conftest.py
@@ -194,9 +194,7 @@ def init_setup(request, cluster_connection, settings):
     settings.add_to_config(EnvironmentVariables.rg.value)
     settings.add_to_config(EnvironmentVariables.instance.value)
 
-    run("az iot ops verify-host")
     yield {
         "instanceName": settings.env.azext_edge_instance,
         "resourceGroup": settings.env.azext_edge_rg,
     }
-    return


### PR DESCRIPTION
* To match the connector commands, the secretsync commands will align on --instance over --name, when referring to instance, however -n is an option added to both as a happy medium.