### PR TITLE
feat!: SR create role assignment failure will throw an error vs warning. 

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -6,11 +6,16 @@
 
 from typing import TYPE_CHECKING, Iterable, Optional
 
-from azure.cli.core.azclierror import ValidationError, FileOperationError, ForbiddenError, InvalidArgumentValueError
+from azure.cli.core.azclierror import (
+    AzureResponseError,
+    FileOperationError,
+    ForbiddenError,
+    InvalidArgumentValueError,
+    ValidationError,
+)
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from knack.log import get_logger
 from rich.console import Console
-
 
 from ....util.az_client import (
     get_registry_mgmt_client,
@@ -21,7 +26,7 @@ from ....util.az_client import (
 from ....util.common import should_continue_prompt
 from ....util.queryable import Queryable
 from ..common import SchemaFormat, SchemaType
-from ..permissions import PermissionManager, ROLE_DEF_FORMAT_STR, PrincipalType
+from ..permissions import ROLE_DEF_FORMAT_STR, PermissionManager, PrincipalType
 
 logger = get_logger(__name__)
 console = Console()
@@ -68,7 +73,7 @@ class SchemaRegistries(Queryable):
         custom_role_id: Optional[str] = None,
         **kwargs,
     ) -> dict:
-        from ..rp_namespace import register_providers, ADR_PROVIDER
+        from ..rp_namespace import ADR_PROVIDER, register_providers
         with console.status("Working...") as c:
             # Register the schema (ADR) provider
             register_providers(self.default_subscription_id, ADR_PROVIDER)
@@ -140,9 +145,9 @@ class SchemaRegistries(Queryable):
                 )
             except Exception as e:
                 c.stop()
-                logger.warning(
+                raise AzureResponseError(
                     get_user_msg_warn_ra(
-                        prefix=f"Role assignment failed with:\n{str(e)}.",
+                        prefix=f"Role assignment failed with:\n{str(e)}",
                         principal_id=result["identity"]["principalId"],
                         scope=blob_container["id"],
                     )

--- a/azext_edge/tests/edge/orchestration/resources/conftest.py
+++ b/azext_edge/tests/edge/orchestration/resources/conftest.py
@@ -4,10 +4,8 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import re
 from typing import Optional
-
-from requests.models import PreparedRequest
-from responses import CallList
 
 from ....generators import generate_random_string, get_zeroed_subscription
 
@@ -92,7 +90,5 @@ def get_resource_id(
     ).split("?")[0][len(BASE_URL) :]
 
 
-def find_request_by_url(calls: CallList, url: str) -> Optional[PreparedRequest]:
-    for call in calls:
-        if call.request.url == url:
-            return call.request
+def get_authz_endpoint_pattern() -> re.Pattern:
+    return re.compile(r"https:\/\/.*\/providers\/Microsoft\.Authorization\/roleAssignments.*")

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
@@ -345,8 +345,9 @@ def test_schema_registry_create(
     )
 
     if create_role_assignment_code not in [200, 201]:
-        with pytest.raises(AzureResponseError):
+        with pytest.raises(AzureResponseError) as error:
             create_registry(**create_registry_kwargs)
+        assert str(error.value).startswith("Role assignment failed")
         return
 
     create_result = create_registry(**create_registry_kwargs)


### PR DESCRIPTION
* Motivation: SR create and the way assign role assignment is implemented in the client are idempotent. The operation is also relatively fast. The change is intended to net a more consistent outcome as SR cannot function properly without the role assignment.
* Improve unit test pattern.