### PR TITLE
feat: add openservice mesh resources in support bundle

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -11,6 +11,10 @@ from knack.help_files import helps
 
 from azext_edge.edge.providers.edge_api import SECRETSTORE_API_V1, SECRETSYNC_API_V1
 from azext_edge.edge.providers.edge_api.arccontainerstorage import ARCCONTAINERSTORAGE_API_V1, CONTAINERSTORAGE_API_V1
+from azext_edge.edge.providers.edge_api.openservicemesh import (
+    OPENSERVICEMESH_CONFIG_API_V1,
+    OPENSERVICEMESH_POLICY_API_V1,
+)
 
 from .providers.support_bundle import (
     COMPAT_CLUSTER_CONFIG_APIS,
@@ -58,6 +62,8 @@ def load_iotops_help():
             - {COMPAT_DATAFLOW_APIS.as_str()}
             - {ARCCONTAINERSTORAGE_API_V1.as_str()}
             - {CONTAINERSTORAGE_API_V1.as_str()}
+            - {OPENSERVICEMESH_CONFIG_API_V1.as_str()}
+            - {OPENSERVICEMESH_POLICY_API_V1.as_str()}
             - {SECRETSYNC_API_V1.as_str()}
             - {SECRETSTORE_API_V1.as_str()}
 

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -132,6 +132,7 @@ class OpsServiceType(ListableEnum):
     """
 
     mq = "broker"
+    openservicemesh = "osm"
     opcua = "opcua"
     akri = "akri"
     deviceregistry = "deviceregistry"

--- a/azext_edge/edge/common.py
+++ b/azext_edge/edge/common.py
@@ -132,7 +132,7 @@ class OpsServiceType(ListableEnum):
     """
 
     mq = "broker"
-    openservicemesh = "osm"
+    openservicemesh = "openservicemesh"
     opcua = "opcua"
     akri = "akri"
     deviceregistry = "deviceregistry"

--- a/azext_edge/edge/providers/edge_api/__init__.py
+++ b/azext_edge/edge/providers/edge_api/__init__.py
@@ -8,6 +8,7 @@ from .base import EdgeResourceApi, EdgeApiManager
 from .clusterconfig import CLUSTER_CONFIG_API_V1
 from .mq import MQ_ACTIVE_API, MQTT_BROKER_API_V1, MqResourceKinds
 from .opcua import OPCUA_API_V1, OpcuaResourceKinds
+from .openservicemesh import OPENSERVICEMESH_CONFIG_API_V1, OPENSERVICEMESH_POLICY_API_V1
 from .keyvault import KEYVAULT_API_V1, KeyVaultResourceKinds
 from .deviceregistry import DEVICEREGISTRY_API_V1, DeviceRegistryResourceKinds
 from .dataflow import DATAFLOW_API_V1, DataflowResourceKinds
@@ -26,6 +27,8 @@ __all__ = [
     "MqResourceKinds",
     "MQ_ACTIVE_API",
     "MQTT_BROKER_API_V1",
+    "OPENSERVICEMESH_CONFIG_API_V1",
+    "OPENSERVICEMESH_POLICY_API_V1",
     "OPCUA_API_V1",
     "OpcuaResourceKinds",
     "KeyVaultResourceKinds",

--- a/azext_edge/edge/providers/edge_api/openservicemesh.py
+++ b/azext_edge/edge/providers/edge_api/openservicemesh.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from .base import EdgeResourceApi
+
+
+OPENSERVICEMESH_CONFIG_API_V1 = EdgeResourceApi(
+    group="config.openservicemesh.io",
+    version="v1alpha2",
+    moniker="openservicemesh",
+)
+
+OPENSERVICEMESH_POLICY_API_V1 = EdgeResourceApi(
+    group="policy.openservicemesh.io",
+    version="v1alpha1",
+    moniker="openservicemesh",
+)

--- a/azext_edge/edge/providers/support/openservicemesh.py
+++ b/azext_edge/edge/providers/support/openservicemesh.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from functools import partial
+from typing import Iterable, Optional
+
+from knack.log import get_logger
+
+from ..edge_api import OPENSERVICEMESH_CONFIG_API_V1, EdgeResourceApi
+from .base import (
+    DAY_IN_SECONDS,
+    assemble_crd_work,
+    process_config_maps,
+    process_deployments,
+    process_replicasets,
+    process_services,
+    process_v1_pods,
+)
+
+logger = get_logger(__name__)
+
+OSM_DIRECTORY_PATH = OPENSERVICEMESH_CONFIG_API_V1.moniker
+OSM_NAMESPACE = "arc-osm-system"
+
+
+def fetch_deployments():
+    return process_deployments(
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+
+
+def fetch_replicasets():
+    return process_replicasets(
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+
+
+def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
+    return process_v1_pods(
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+        since_seconds=since_seconds,
+    )
+
+
+def fetch_services():
+    return process_services(
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+
+
+def fetch_configmaps():
+    return process_config_maps(
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+
+
+support_runtime_elements = {
+    "configmaps": fetch_configmaps,
+    "deployments": fetch_deployments,
+    "replicasets": fetch_replicasets,
+    "services": fetch_services,
+}
+
+
+def prepare_bundle(
+    log_age_seconds: int = DAY_IN_SECONDS,
+    apis: Optional[Iterable[EdgeResourceApi]] = None,
+) -> dict:
+    acs_to_run = {}
+
+    if apis:
+        acs_to_run.update(assemble_crd_work(apis=apis))
+
+    support_runtime_elements["pods"] = partial(fetch_pods, since_seconds=log_age_seconds)
+    acs_to_run.update(support_runtime_elements)
+
+    return acs_to_run

--- a/azext_edge/edge/providers/support/openservicemesh.py
+++ b/azext_edge/edge/providers/support/openservicemesh.py
@@ -74,12 +74,12 @@ def prepare_bundle(
     log_age_seconds: int = DAY_IN_SECONDS,
     apis: Optional[Iterable[EdgeResourceApi]] = None,
 ) -> dict:
-    acs_to_run = {}
+    osm_to_run = {}
 
     if apis:
-        acs_to_run.update(assemble_crd_work(apis=apis))
+        osm_to_run.update(assemble_crd_work(apis=apis))
 
     support_runtime_elements["pods"] = partial(fetch_pods, since_seconds=log_age_seconds)
-    acs_to_run.update(support_runtime_elements)
+    osm_to_run.update(support_runtime_elements)
 
-    return acs_to_run
+    return osm_to_run

--- a/azext_edge/edge/providers/support_bundle.py
+++ b/azext_edge/edge/providers/support_bundle.py
@@ -16,6 +16,8 @@ from ..providers.edge_api import (
     CLUSTER_CONFIG_API_V1,
     CONTAINERSTORAGE_API_V1,
     MQTT_BROKER_API_V1,
+    OPENSERVICEMESH_CONFIG_API_V1,
+    OPENSERVICEMESH_POLICY_API_V1,
     OPCUA_API_V1,
     DEVICEREGISTRY_API_V1,
     DATAFLOW_API_V1,
@@ -33,6 +35,7 @@ console = Console()
 
 COMPAT_CLUSTER_CONFIG_APIS = EdgeApiManager(resource_apis=[CLUSTER_CONFIG_API_V1])
 COMPAT_MQTT_BROKER_APIS = EdgeApiManager(resource_apis=[MQTT_BROKER_API_V1])
+COMPAT_OSM_APIS = EdgeApiManager(resource_apis=[OPENSERVICEMESH_CONFIG_API_V1, OPENSERVICEMESH_POLICY_API_V1])
 COMPAT_OPCUA_APIS = EdgeApiManager(resource_apis=[OPCUA_API_V1])
 COMPAT_DEVICEREGISTRY_APIS = EdgeApiManager(resource_apis=[DEVICEREGISTRY_API_V1])
 COMPAT_DATAFLOW_APIS = EdgeApiManager(resource_apis=[DATAFLOW_API_V1])
@@ -54,6 +57,7 @@ def build_bundle(
 
     from .support.billing import prepare_bundle as prepare_billing_bundle
     from .support.mq import prepare_bundle as prepare_mq_bundle
+    from .support.openservicemesh import prepare_bundle as prepare_openservicemesh_bundle
     from .support.opcua import prepare_bundle as prepare_opcua_bundle
     from .support.dataflow import prepare_bundle as prepare_dataflow_bundle
     from .support.deviceregistry import prepare_bundle as prepare_deviceregistry_bundle
@@ -87,6 +91,10 @@ def build_bundle(
         OpsServiceType.billing.value: {
             "apis": COMPAT_CLUSTER_CONFIG_APIS,
             "prepare_bundle": prepare_billing_bundle,
+        },
+        OpsServiceType.openservicemesh.value: {
+            "apis": COMPAT_OSM_APIS,
+            "prepare_bundle": prepare_openservicemesh_bundle,
         },
         OpsServiceType.opcua.value: {
             "apis": COMPAT_OPCUA_APIS,

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -140,40 +140,16 @@ def _get_expected_services(
 ) -> List[str]:
     expected_services = [ops_service] if ops_service else OpsServiceType.list()
 
-    # device registry folder will not be created if there are no device registry resources
-    if (
-        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.deviceregistry.value))
-        and OpsServiceType.deviceregistry.value in expected_services
-    ):
-        expected_services.remove(OpsServiceType.deviceregistry.value)
-
-    # arccotainerstorage folder will not be created under aio namespace
-    if (
-        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, "arccontainerstorage"))
-        and OpsServiceType.arccontainerstorage.value in expected_services
-    ):
-        expected_services.remove(OpsServiceType.arccontainerstorage.value)
-
-    # secretstore folder will not be created if there are no secretstore resources
-    if (
-        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.secretstore.value))
-        and OpsServiceType.secretstore.value in expected_services
-    ):
-        expected_services.remove(OpsServiceType.secretstore.value)
-
-    # azuremonitor folder will not be created if there are no azuremonitor resources
-    if (
-        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.azuremonitor.value))
-        and OpsServiceType.azuremonitor.value in expected_services
-    ):
-        expected_services.remove(OpsServiceType.azuremonitor.value)
-
-    # openservicemesh folder will not be created under aio namespace
-    if (
-        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.openservicemesh.value))
-        and OpsServiceType.openservicemesh.value in expected_services
-    ):
-        expected_services.remove(OpsServiceType.openservicemesh.value)
+    # remove services that are not created in aio namespace
+    for monikor, service in [
+        (OpsServiceType.deviceregistry.value, OpsServiceType.deviceregistry.value),
+        ("arccontainerstorage", OpsServiceType.arccontainerstorage.value),
+        (OpsServiceType.secretstore.value, OpsServiceType.secretstore.value),
+        (OpsServiceType.azuremonitor.value, OpsServiceType.azuremonitor.value),
+        (OpsServiceType.openservicemesh.value, OpsServiceType.openservicemesh.value),
+    ]:
+        if not walk_result.get(path.join(BASE_ZIP_PATH, namespace, monikor)) and service in expected_services:
+            expected_services.remove(service)
 
     expected_services.append("meta")
     return expected_services

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -65,6 +65,7 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
     ssc_namespace = namespaces.get("ssc")
     arc_namespace = namespaces.get("arc")
     certmanager_namespace = namespaces.get("certmanager")
+    osm_namespace = namespaces.get("osm")
 
     # Level 1
     level_1 = walk_result.pop(path.join(BASE_ZIP_PATH, aio_namespace))
@@ -90,6 +91,7 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
         (acstor_namespace, "containerstorage"),
         (ssc_namespace, OpsServiceType.secretstore.value),
         (certmanager_namespace, OpsServiceType.certmanager.value),
+        (osm_namespace, OpsServiceType.openservicemesh.value),
     ]:
         if namespace:
             walk_result.pop(path.join(BASE_ZIP_PATH, namespace, service), {})
@@ -165,6 +167,13 @@ def _get_expected_services(
         and OpsServiceType.azuremonitor.value in expected_services
     ):
         expected_services.remove(OpsServiceType.azuremonitor.value)
+
+    # openservicemesh folder will not be created under aio namespace
+    if (
+        not walk_result.get(path.join(BASE_ZIP_PATH, namespace, OpsServiceType.openservicemesh.value))
+        and OpsServiceType.openservicemesh.value in expected_services
+    ):
+        expected_services.remove(OpsServiceType.openservicemesh.value)
 
     expected_services.append("meta")
     return expected_services

--- a/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
@@ -31,7 +31,7 @@ def test_create_bundle_osm(init_setup, tracked_files):
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_CONFIG_API_V1)
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_POLICY_API_V1)
 
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
+    expected_workload_types = ["configmap", "deployment", "pod", "replicaset", "service"]
     expected_types = set(expected_workload_types).union(OPENSERVICEMESH_CONFIG_API_V1.kinds)
     expected_types = expected_types.union(OPENSERVICEMESH_POLICY_API_V1.kinds)
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from knack.log import get_logger
+from azext_edge.edge.common import OpsServiceType
+from azext_edge.edge.providers.edge_api import OPENSERVICEMESH_CONFIG_API_V1, OPENSERVICEMESH_POLICY_API_V1
+from .helpers import (
+    check_custom_resource_files,
+    check_workload_resource_files,
+    get_file_map,
+    run_bundle_command,
+)
+
+logger = get_logger(__name__)
+
+
+def test_create_bundle_osm(init_setup, tracked_files):
+    """Test for ensuring file names and content. ONLY CHECKS openservicemesh."""
+    # dir for unpacked files
+    ops_service = OpsServiceType.openservicemesh.value
+    command = f"az iot ops support create-bundle --ops-service {ops_service}"
+    walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
+    file_map = get_file_map(walk_result, ops_service)
+
+    # arc-osm-system
+    osm_file_map = file_map["osm"]
+
+    check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_CONFIG_API_V1)
+    check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_POLICY_API_V1)
+
+    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
+    expected_types = set(expected_workload_types).union(OPENSERVICEMESH_CONFIG_API_V1.kinds)
+    expected_types = expected_types.union(OPENSERVICEMESH_POLICY_API_V1.kinds)
+
+    assert set(osm_file_map.keys()).issubset(set(expected_types))
+
+    workload_resource_prefixes = [
+        "osm",
+        "kube-root-ca",
+        "preset-mesh-config",
+    ]
+    check_workload_resource_files(
+        file_objs=osm_file_map,
+        expected_workload_types=expected_workload_types,
+        prefixes=workload_resource_prefixes,
+        bundle_path=bundle_path,
+    )

--- a/azext_edge/tests/edge/support/test_openservicemesh_unit.py
+++ b/azext_edge/tests/edge/support/test_openservicemesh_unit.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import random
+
+from azext_edge.edge.commands_edge import support_bundle
+from azext_edge.edge.common import OpsServiceType
+from azext_edge.edge.providers.support.openservicemesh import (
+    OSM_DIRECTORY_PATH,
+    OSM_NAMESPACE,
+)
+from azext_edge.tests.edge.support.test_support_unit import (
+    assert_list_config_maps,
+    assert_list_deployments,
+    assert_list_pods,
+    assert_list_replica_sets,
+    assert_list_services,
+)
+
+from ...generators import generate_random_string
+
+a_bundle_dir = f"support_test_{generate_random_string()}"
+
+
+def test_create_bundle_osm(
+    mocked_client,
+    mocked_config,
+    mocked_os_makedirs,
+    mocked_zipfile,
+    mocked_list_config_maps,
+    mocked_list_deployments,
+    mocked_list_pods,
+    mocked_list_replicasets,
+    mocked_list_services,
+    mocked_list_nodes,
+    mocked_list_cluster_events,
+    mocked_list_storage_classes,
+    mocked_root_logger,
+    mocked_get_config_map,
+):
+    since_seconds = random.randint(86400, 172800)
+    result = support_bundle(
+        None,
+        ops_services=[OpsServiceType.openservicemesh.value],
+        bundle_dir=a_bundle_dir,
+        log_age_seconds=since_seconds,
+    )
+
+    assert "bundlePath" in result
+    assert a_bundle_dir in result["bundlePath"]
+
+    assert_list_deployments(
+        mocked_client,
+        mocked_zipfile,
+        label_selector=None,
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+    assert_list_replica_sets(
+        mocked_client,
+        mocked_zipfile,
+        label_selector=None,
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+    assert_list_services(
+        mocked_client,
+        mocked_zipfile,
+        label_selector=None,
+        directory_path=OSM_DIRECTORY_PATH,
+        namespace=OSM_NAMESPACE,
+    )
+    assert_list_pods(
+        mocked_client,
+        mocked_zipfile,
+        mocked_list_pods,
+        label_selector=None,
+        directory_path=OSM_DIRECTORY_PATH,
+        since_seconds=since_seconds,
+        namespace=OSM_NAMESPACE,
+    )
+    assert_list_config_maps(
+        mocked_client,
+        mocked_zipfile,
+        directory_path=OSM_DIRECTORY_PATH,
+        label_selector=None,
+        namespace=OSM_NAMESPACE,
+    )


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
