### PR TITLE
fix(test): only check initial prefix for missing/extra resource names

### DIFF
--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -51,8 +51,9 @@ def find_extra_or_missing_names(
     ignore_missing: bool = False,
 ):
     error_msg = []
-    # expected_names might contains descriptor, if so, remove it
+    # names may contain descriptors after the initial '.', just comparing first prefix
     expected_names = [name.split(".")[0] for name in expected_names]
+    result_names = [name.split(".")[0] for name in result_names]
     extra_names = [name for name in result_names if name not in expected_names]
     if extra_names:
         msg = f"Extra {resource_type} names: {', '.join(extra_names)}."


### PR DESCRIPTION
Fixes a small error occurring in our e2e tests

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
