### PR TITLE
fix: asset endpoint opcua create bug

### DIFF
--- a/azext_edge/edge/providers/rpsaas/adr/asset_endpoint_profiles.py
+++ b/azext_edge/edge/providers/rpsaas/adr/asset_endpoint_profiles.py
@@ -300,10 +300,10 @@ def _build_opcua_config(
         config["subscription"] = {}
     if sub_life_time:
         error_msg += _assert_above_min("--subscription-life-time", sub_life_time)
-        config["subscription"]["maxItems"] = sub_life_time
+        config["subscription"]["lifeTimeMilliseconds"] = sub_life_time
     if sub_max_items:
         error_msg += _assert_above_min("--subscription-max-items", sub_max_items, 1)
-        config["subscription"]["lifeTimeMilliseconds"] = sub_max_items
+        config["subscription"]["maxItems"] = sub_max_items
 
     # security
     if any([

--- a/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profile_helpers_unit.py
+++ b/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profile_helpers_unit.py
@@ -182,16 +182,16 @@ def test_build_opcua_config_error(req):
         )
     assert e.value.error_msg
     min_dict = {
-        "default_publishing_interval": (-1, "--default-publishing-int/--dpi"),
-        "default_sampling_interval": (-1, "--default-sampling-int/--dsi"),
-        "default_queue_size": (0, "--default-queue-size/--dqs"),
-        "keep_alive": (0, "--keep-alive/--ka"),
-        "session_timeout": (0, "--session-timeout/--st"),
-        "session_keep_alive": (0, "--session-keep-alive/--ska"),
-        "session_reconnect_period": (0, "--session-reconnect-period/--srp"),
-        "session_reconnect_exponential_back_off": (-1, "--session-reconnect-backoff/--srb"),
-        "sub_max_items": (1, "--subscription-max-items/--smi"),
-        "sub_life_time": (0, "--subscription-life-time/--slt"),
+        "default_publishing_interval": (-1, "--default-publishing-int"),
+        "default_sampling_interval": (-1, "--default-sampling-int"),
+        "default_queue_size": (0, "--default-queue-size"),
+        "keep_alive": (0, "--keep-alive"),
+        "session_timeout": (0, "--session-timeout"),
+        "session_keep_alive": (0, "--session-keep-alive"),
+        "session_reconnect_period": (0, "--session-reconnect-period"),
+        "session_reconnect_exponential_back_off": (-1, "--session-reconnect-backoff"),
+        "sub_max_items": (1, "--subscription-max-items"),
+        "sub_life_time": (0, "--subscription-life-time"),
     }
     expected_error_params = [
         param for param in req if (min_dict.get(param) is not None) and (req[param] < min_dict[param][0])

--- a/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profile_helpers_unit.py
+++ b/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profile_helpers_unit.py
@@ -16,6 +16,7 @@ from azure.cli.core.azclierror import (
     RequiredArgumentMissingError,
 )
 
+from azext_edge.edge.common import SecurityPolicies, SecurityModes
 from azext_edge.edge.providers.rpsaas.adr.asset_endpoint_profiles import (
     _assert_above_min,
     _build_opcua_config,
@@ -62,8 +63,8 @@ def test_assert_above_min(value, minimum):
         },
         "security": {
             "autoAcceptUntrustedServerCertificates": False,
-            "securityMode": generate_random_string(),
-            "securityPolicy": generate_random_string()
+            "securityMode": SecurityModes.none.value,
+            "securityPolicy": "http://opcfoundation.org/UA/SecurityPolicy#" + SecurityPolicies.basic256sha256.value
         }
     }
 ])
@@ -81,8 +82,8 @@ def test_assert_above_min(value, minimum):
         "session_keep_alive": 666,
         "session_reconnect_period": 777,
         "session_reconnect_exponential_back_off": 888,
-        "security_policy": generate_random_string(),
-        "security_mode": generate_random_string(),
+        "security_policy": SecurityPolicies.aes128.value,
+        "security_mode": SecurityModes.sign_and_encrypt.value,
         "sub_max_items": 999,
         "sub_life_time": 1000,
     },
@@ -129,8 +130,8 @@ def test_build_opcua_config(original_config, req):
 
     og_sub = original_config.get("subscription", {})
     res_sub = result.get("subscription", {})
-    assert res_sub.get("maxItems") == req.get("sub_life_time", og_sub.get("maxItems"))
-    assert res_sub.get("lifeTimeMilliseconds") == req.get("sub_max_items", og_sub.get("lifeTimeMilliseconds"))
+    assert res_sub.get("maxItems") == req.get("sub_max_items", og_sub.get("maxItems"))
+    assert res_sub.get("lifeTimeMilliseconds") == req.get("sub_life_time", og_sub.get("lifeTimeMilliseconds"))
 
     og_security = original_config.get("security", {})
     res_security = result.get("security", {})
@@ -181,16 +182,16 @@ def test_build_opcua_config_error(req):
         )
     assert e.value.error_msg
     min_dict = {
-        "default_publishing_interval": (-1, "--default-publishing-int"),
-        "default_sampling_interval": (-1, "--default-sampling-int"),
-        "default_queue_size": (0, "--default-queue-size"),
-        "keep_alive": (0, "--keep-alive"),
-        "session_timeout": (0, "--session-timeout"),
-        "session_keep_alive": (0, "--session-keep-alive"),
-        "session_reconnect_period": (0, "--session-reconnect-period"),
-        "session_reconnect_exponential_back_off": (-1, "--session-reconnect-backoff"),
-        "sub_max_items": (1, "--subscription-max-items"),
-        "sub_life_time": (0, "--subscription-life-time"),
+        "default_publishing_interval": (-1, "--default-publishing-int/--dpi"),
+        "default_sampling_interval": (-1, "--default-sampling-int/--dsi"),
+        "default_queue_size": (0, "--default-queue-size/--dqs"),
+        "keep_alive": (0, "--keep-alive/--ka"),
+        "session_timeout": (0, "--session-timeout/--st"),
+        "session_keep_alive": (0, "--session-keep-alive/--ska"),
+        "session_reconnect_period": (0, "--session-reconnect-period/--srp"),
+        "session_reconnect_exponential_back_off": (-1, "--session-reconnect-backoff/--srb"),
+        "sub_max_items": (1, "--subscription-max-items/--smi"),
+        "sub_life_time": (0, "--subscription-life-time/--slt"),
     }
     expected_error_params = [
         param for param in req if (min_dict.get(param) is not None) and (req[param] < min_dict[param][0])

--- a/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profiles_int.py
+++ b/azext_edge/tests/edge/rpsaas/adr/test_asset_endpoint_profiles_int.py
@@ -209,9 +209,9 @@ def assert_opcua_props(result, **expected):
 
     # subscription
     if expected.get("sub_life_time"):
-        result_config["subscription"]["maxItems"] = expected["sub_life_time"]
+        result_config["subscription"]["lifeTimeMilliseconds"] = expected["sub_life_time"]
     if expected.get("sub_max_items"):
-        result_config["subscription"]["lifeTimeMilliseconds"] = expected["sub_max_items"]
+        result_config["subscription"]["maxItems"] = expected["sub_max_items"]
 
     # security
     if expected.get("accept_untrusted_certs") is not None:


### PR DESCRIPTION
Two params were mixed up by accident



---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
