### PR TITLE
fix: instance name for template output 

### DIFF
--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -218,6 +218,8 @@ class InitTargets:
             dataflow_profile["name"] = f"{self.instance_name}/{DEFAULT_DATAFLOW_PROFILE}"
             dataflow_endpoint["name"] = f"{self.instance_name}/{DEFAULT_DATAFLOW_ENDPOINT}"
 
+            template.content["outputs"]["aio"]["name"] = self.instance_name
+
         if self.custom_broker_config:
             if "properties" in self.custom_broker_config:
                 self.custom_broker_config = self.custom_broker_config["properties"]

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -210,6 +210,7 @@ def test_init_targets(target_scenario: dict):
         assert instance_template["resources"]["broker_listener"]["name"] == f"{targets.instance_name}/default/default"
         assert instance_template["resources"]["dataflow_profile"]["name"] == f"{targets.instance_name}/default"
         assert instance_template["resources"]["dataflow_endpoint"]["name"] == f"{targets.instance_name}/default"
+        assert instance_template["outputs"]["aio"]["name"] == targets.instance_name
 
     if targets.custom_broker_config:
         assert instance_template["resources"]["broker"]["properties"] == targets.custom_broker_config


### PR DESCRIPTION
* Instance name is a required input for `az iot ops create`. This input gets applied to the template definition; however outputs (specifically outputs.aio.name) was not changed from the auto generated instance name approach the default template takes. 