### PR TITLE
test: Update support bundle tests

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -269,14 +269,24 @@ jobs:
           azext_edge_init_redeployment: false
         run: |
           tox r -e python-init-int --skip-pkg-install -- --durations=0
-      - name: "Tox Integration Tests"
+      - name: "Tox Edge Integration Tests"
         if: ${{ matrix.feature == 'default' && !inputs.use-container }}
         env:
           azext_edge_rg: ${{ steps.env_out.outputs.RESOURCE_GROUP }}
           azext_edge_cluster: ${{ steps.env_out.outputs.CLUSTER_NAME }}
           azext_edge_instance: ${{ steps.env_out.outputs.INSTANCE_NAME }}
         run: |
-          tox r -e "python-all-int" --skip-pkg-install -- --durations=0 --dist=loadfile -n auto
+          tox r -e "python-edge-int" --skip-pkg-install -- --durations=0 --dist=loadfile -n auto
+          coverage=$(jq .totals.percent_covered coverage.json | cut -c1-4)
+          echo "Code coverage: $coverage%" >> $GITHUB_STEP_SUMMARY
+      - name: "Tox Cloud Integration Tests"
+        if: ${{ matrix.feature == 'default' && !inputs.use-container }}
+        env:
+          azext_edge_rg: ${{ steps.env_out.outputs.RESOURCE_GROUP }}
+          azext_edge_cluster: ${{ steps.env_out.outputs.CLUSTER_NAME }}
+          azext_edge_instance: ${{ steps.env_out.outputs.INSTANCE_NAME }}
+        run: |
+          tox r -e "python-rpsaas-int" --skip-pkg-install -- --durations=0 --dist=loadfile -n auto
           coverage=$(jq .totals.percent_covered coverage.json | cut -c1-4)
           echo "Code coverage: $coverage%" >> $GITHUB_STEP_SUMMARY
       - name: "Tox Workload Identity Integration Tests"

--- a/azext_edge/edge/providers/rpsaas/adr/asset_endpoint_profiles.py
+++ b/azext_edge/edge/providers/rpsaas/adr/asset_endpoint_profiles.py
@@ -227,7 +227,7 @@ def _assert_above_min(param: str, value: int, minimum: int = 0) -> str:
 def _raise_if_connector_error(connector_type: str, error_msg: str):
     if error_msg:
         raise InvalidArgumentValueError(
-            f"The following {connector_type} connector arguments are invalid:\n {error_msg}"
+            f"The following {connector_type} connector arguments are invalid:\n{error_msg}"
         )
 
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
@@ -78,6 +78,6 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
     check_workload_resource_files(
         file_objs=file_map,
         expected_workload_types=expected_workload_types,
-        prefixes=["aio-broker", "aio-dmqtt"],
+        prefixes=["aio-broker", "aio-dmqtt", "otel-collector-service"],
         bundle_path=bundle_path,
     )


### PR DESCRIPTION
Separate supportbundle/edge side testing vs rpsaas

add in prefix for mq testing



---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
