### PR TITLE
test: refactor support bundle tests

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -105,7 +105,10 @@ def convert_file_names(files: List[str]) -> Dict[str, List[Dict[str, str]]]:
             name_obj["version"] = name.pop(0)
             assert name_obj["version"].startswith("v")
         name_obj["name"] = name.pop(0)
+        # custom re-adding
         if name_obj["name"] == "aio-opc-opc":
+            name_obj["name"] += f".{name.pop(0)}"
+        if name_obj["name"] == "kube-root-ca":
             name_obj["name"] += f".{name.pop(0)}"
 
         # something like "msi-adapter", "init-runner"

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -207,8 +207,8 @@ def check_workload_resource_files(
                 for file in file_objs.get(key, []):
                     assert file["extension"] == "yaml"
                 present_names = [file["name"] for file in file_objs.get(key, [])]
-                if key == "configmap":
-                    import pdb; pdb.set_trace()
+                # kube-root-ca.crt gets split configmap.kube-root-ca.crt.yaml
+                # maybe add in a way to compare full names? or limit splitting for certain types?
                 find_extra_or_missing_names(
                     resource_type=key,
                     result_names=present_names,

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -5,7 +5,7 @@
 # ----------------------------------------------------------------------------------------------
 
 from knack.log import get_logger
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 from os import path
 from zipfile import ZipFile
 import pytest
@@ -149,14 +149,12 @@ def check_custom_resource_files(
 
 def check_workload_resource_files(
     file_objs: Dict[str, List[Dict[str, str]]],
-    expected_workload_types: List[str],
+    pre_bundle_items: List[str],
     prefixes: Union[str, List[str]],
     bundle_path: str,
     expected_label: Optional[str] = None,
-    optional_workload_types: Optional[List[str]] = None,
+   pre_bundle_optional_items: Optional[Dict[str, List[str]]] = None,
 ):
-    if "pod" in expected_workload_types:
-        expected_workload_types.remove("pod")
     # pod
     file_pods = {}
     for file in file_objs.get("pod", []):
@@ -184,14 +182,13 @@ def check_workload_resource_files(
             if file["descriptor"] not in converted_file:
                 converted_file[file["descriptor"]] = False
 
-    expected_pods = get_kubectl_workload_items(prefixes, service_type="pod", label_match=expected_label)
+    post_pods = get_kubectl_workload_items(prefixes, service_type="pod", label_match=expected_label)
     check_log_for_evicted_pods(bundle_path, file_objs.get("pod", []))
     find_extra_or_missing_names(
         resource_type="pod",
         result_names=file_pods.keys(),
-        expected_names=expected_pods.keys(),
-        ignore_extras=True,
-        ignore_missing=True,
+        pre_expected_names=pre_bundle_items.pop("pod", []),
+        post_expected_names=post_pods.keys(),
     )
 
     for name, files in file_pods.items():
@@ -199,21 +196,30 @@ def check_workload_resource_files(
             assert value, f"Pod {name} is missing {extension}."
 
     # other
-    def _check_non_pod_files(workload_types: List[str], required: bool = False, expected_label: Optional[str] = None):
-        for key in workload_types:
+    def _check_non_pod_files(
+        pre_bundle_items: Dict[str, List[str]],
+        required: bool = False,
+        expected_label: Optional[str] = None
+    ):
+        for key, names in pre_bundle_items.items():
             try:
-                expected_items = get_kubectl_workload_items(prefixes, service_type=key, label_match=expected_label)
+                post_bundle_items = get_kubectl_workload_items(prefixes, service_type=key, label_match=expected_label)
                 for file in file_objs.get(key, []):
                     assert file["extension"] == "yaml"
                 present_names = [file["name"] for file in file_objs.get(key, [])]
-                find_extra_or_missing_names(key, present_names, expected_items.keys())
+                find_extra_or_missing_names(
+                    resource_type=key,
+                    result_names=present_names,
+                    pre_expected_names=names,
+                    post_expected_names=post_bundle_items.keys()
+                )
             except CLIInternalError as e:
                 if required:
                     raise e
 
-    _check_non_pod_files(expected_workload_types, expected_label=expected_label)
-    if optional_workload_types:
-        _check_non_pod_files(optional_workload_types, required=False, expected_label=expected_label)
+    _check_non_pod_files(pre_bundle_items, expected_label=expected_label)
+    if pre_bundle_optional_items:
+        _check_non_pod_files(pre_bundle_optional_items, required=False, expected_label=expected_label)
 
 
 def check_log_for_evicted_pods(bundle_dir: str, file_pods: List[Dict[str, str]]):
@@ -353,6 +359,25 @@ def get_file_map(
     file_map["aio"] = convert_file_names(walk_result[ops_path]["files"])
     file_map["__namespaces__"]["aio"] = aio_namespace
     return file_map
+
+
+# TODO rename
+def get_workload_resources(
+    expected_workload_types: Union[str, List[str]],
+    prefixes: Union[str, List[str]],
+    expected_label: Optional[str] = None
+) -> Dict[str, Iterable[str]]:
+    """
+    Fetch a list of the workload resources via kubectl.
+    Returns a mapping of workload type to iterable (dict keys) of names.
+    """
+    result = {}
+    if not isinstance(expected_workload_types, list):
+        expected_workload_types = [expected_workload_types]
+    for key in expected_workload_types:
+        items = get_kubectl_workload_items(prefixes, service_type=key, label_match=expected_label)
+        result[key] = items.keys()
+    return result
 
 
 def process_top_levels(

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -207,6 +207,8 @@ def check_workload_resource_files(
                 for file in file_objs.get(key, []):
                     assert file["extension"] == "yaml"
                 present_names = [file["name"] for file in file_objs.get(key, [])]
+                if key == "configmap":
+                    import pdb; pdb.set_trace()
                 find_extra_or_missing_names(
                     resource_type=key,
                     result_names=present_names,

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -40,7 +40,11 @@ WORKLOAD_TYPES = [
 
 
 def assert_file_names(files: List[str]):
-    """Asserts file names."""
+    """
+    Simple asserts for file names.
+
+    Ensures trace file conventions, extension conventions, etc
+    """
     for full_name in files:
         name = split_name(full_name)
         file_type = name.pop(0)
@@ -69,7 +73,11 @@ def assert_file_names(files: List[str]):
 
 
 def convert_file_names(files: List[str]) -> Dict[str, List[Dict[str, str]]]:
-    """Maps deployment/pod/etc to list of dissembled file names"""
+    """
+    Maps deployment/pod/etc to list of disassembled file names
+
+    Please see comments for examples/conventions.
+    """
     file_name_objs = {}
     for full_name in files:
         name = split_name(full_name)
@@ -77,6 +85,7 @@ def convert_file_names(files: List[str]) -> Dict[str, List[Dict[str, str]]]:
         name_obj = {"extension": name.pop(-1), "full_name": full_name}
 
         if file_type == "pod" and name[-1] == "metric":
+            # note: not a real type
             file_type = "podmetric"
 
         if name_obj["extension"] in ["pb", "json"]:
@@ -105,6 +114,7 @@ def convert_file_names(files: List[str]) -> Dict[str, List[Dict[str, str]]]:
             name_obj["version"] = name.pop(0)
             assert name_obj["version"].startswith("v")
         name_obj["name"] = name.pop(0)
+
         # custom re-adding
         if name_obj["name"] == "aio-opc-opc":
             name_obj["name"] += f".{name.pop(0)}"
@@ -366,11 +376,11 @@ def get_file_map(
     return file_map
 
 
-# TODO rename
+# TODO rename + maybe move
 def get_workload_resources(
     expected_workload_types: Union[str, List[str]],
     prefixes: Union[str, List[str]],
-    expected_label: Optional[str] = None
+    expected_label: Optional[Tuple[str, str]] = None
 ) -> Dict[str, Iterable[str]]:
     """
     Fetch a list of the workload resources via kubectl.

--- a/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
@@ -12,28 +12,28 @@ from .helpers import check_workload_resource_files, get_file_map, get_workload_r
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+AKRI_PREFIXES = ["aio-akri"]
+AKRI_WORKLOAD_TYPES = ["deployment", "pod", "replicaset"]
 
 
 def test_create_bundle_akri(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS AKRI."""
     ops_service = OpsServiceType.akri.value
-    expected_workload_types = ["deployment", "pod", "replicaset"]
-    prefixes = "aio-akri"
 
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=prefixes,
+        expected_workload_types=AKRI_WORKLOAD_TYPES,
+        prefixes=AKRI_WORKLOAD_TYPES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)["aio"]
 
-    expected_types = set(expected_workload_types)
+    expected_types = set(AKRI_WORKLOAD_TYPES)
     assert set(file_map.keys()).issubset(expected_types)
 
     check_workload_resource_files(
         file_objs=file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=prefixes,
+        prefixes=AKRI_WORKLOAD_TYPES,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
@@ -7,27 +7,33 @@
 import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
-from .helpers import check_workload_resource_files, get_file_map, run_bundle_command
+from .helpers import check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_akri(init_setup, tracked_files):
+def test_create_bundle_akri(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS AKRI."""
     ops_service = OpsServiceType.akri.value
+    expected_workload_types = ["deployment", "pod", "replicaset"]
+    prefixes = "aio-akri"
+
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=prefixes,
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)["aio"]
 
-    expected_workload_types = ["deployment", "pod", "replicaset"]
     expected_types = set(expected_workload_types)
     assert set(file_map.keys()).issubset(expected_types)
 
     check_workload_resource_files(
         file_objs=file_map,
-        expected_workload_types=expected_workload_types,
-        prefixes="aio-akri",
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=prefixes,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
@@ -88,6 +88,7 @@ def test_create_bundle_arccontainerstorage(cluster_connection, tracked_files):
 
     expected_types = set(expected_acs_workload_types).union(ARCCONTAINERSTORAGE_API_V1.kinds)
     assert set(acs_file_map.keys()).issubset(set(expected_types))
+    import pdb; pdb.set_trace()
     check_workload_resource_files(
         file_objs=acs_file_map,
         pre_bundle_items=pre_bundle_acstor_workload_items,

--- a/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
@@ -91,8 +91,8 @@ def test_create_bundle_arccontainerstorage(cluster_connection, tracked_files):
     import pdb; pdb.set_trace()
     check_workload_resource_files(
         file_objs=acs_file_map,
-        pre_bundle_items=pre_bundle_acstor_workload_items,
-        prefixes=pre_bundle_acs_workload_items,
+        pre_bundle_items=pre_bundle_acs_workload_items,
+        prefixes=acs_workload_resource_prefixes,
         bundle_path=bundle_path,
     )
     check_custom_resource_files(file_objs=acs_file_map, resource_api=ARCCONTAINERSTORAGE_API_V1)

--- a/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_arccontainerstorage_int.py
@@ -88,7 +88,6 @@ def test_create_bundle_arccontainerstorage(cluster_connection, tracked_files):
 
     expected_types = set(expected_acs_workload_types).union(ARCCONTAINERSTORAGE_API_V1.kinds)
     assert set(acs_file_map.keys()).issubset(set(expected_types))
-    import pdb; pdb.set_trace()
     check_workload_resource_files(
         file_objs=acs_file_map,
         pre_bundle_items=pre_bundle_acs_workload_items,

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -34,7 +34,7 @@ def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
 
 
 @pytest.mark.parametrize("ops_service, mq_traces, bundle_dir", generate_bundle_test_cases())
-def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_files):
+def test_create_bundle(cluster_connection, bundle_dir, mq_traces, ops_service, tracked_files):
     """Test to focus on ops_service param."""
 
     # skip arccontainerstorage and azuremonitor for aio namespace check
@@ -133,9 +133,8 @@ def test_create_bundle(init_setup, bundle_dir, mq_traces, ops_service, tracked_f
             find_extra_or_missing_names(
                 resource_type=f"auto bundle files not found in {ops_service} bundle",
                 result_names=auto_files,
-                expected_names=ser_files,
-                ignore_extras=True,
-                ignore_missing=True,
+                pre_expected_names=ser_files,
+                post_expected_names=[]
             )
 
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_azuremonitor_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_azuremonitor_int.py
@@ -20,14 +20,15 @@ logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 AZUREMONITOR_PREFIXES = ["diagnostics-operator", "diagnostics-v1"]
+AZUREMONITOR_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service", "statefulset", "configmap"]
+
 
 def test_create_bundle_azuremonitor(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.azuremonitor.value
-    expected_workload_types = ["deployment", "pod", "replicaset", "service", "statefulset", "configmap"]
 
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
+        expected_workload_types=AZUREMONITOR_WORKLOAD_TYPES,
         prefixes=AZUREMONITOR_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
@@ -39,7 +40,7 @@ def test_create_bundle_azuremonitor(cluster_connection, tracked_files):
     )
 
     # arc namespace
-    expected_types = set(expected_workload_types).union(AZUREMONITOR_API_V1.kinds)
+    expected_types = set(AZUREMONITOR_WORKLOAD_TYPES).union(AZUREMONITOR_API_V1.kinds)
     assert set(file_map[OpsServiceType.azuremonitor.value].keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map[OpsServiceType.azuremonitor.value],

--- a/azext_edge/tests/edge/support/create_bundle_int/test_billing_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_billing_int.py
@@ -19,23 +19,23 @@ from .helpers import (
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+AIO_PREFIXES = ["aio-usage"]
+AIO_WORKLOAD_TYPES = ["cronjob", "job", "pod"]
+USAGE_PREFIXES = ["billing-operator"]
+USAGE_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service"]
 
 
 def test_create_bundle_billing(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS billing."""
     ops_service = OpsServiceType.billing.value
-    expected_aio_workload_types = ["cronjob", "job", "pod"]
-    aio_prefixes = ["aio-usage"]
     aio_workload_items = get_workload_resources(
-        expected_workload_types=expected_aio_workload_types,
-        prefixes=aio_prefixes,
+        expected_workload_types=AIO_WORKLOAD_TYPES,
+        prefixes=AIO_PREFIXES,
     )
 
-    expected_usage_workload_types = ["deployment", "pod", "replicaset", "service"]
-    usage_prefix = ["billing-operator"]
     usage_workload_items = get_workload_resources(
-        expected_workload_types=expected_usage_workload_types,
-        prefixes=usage_prefix,
+        expected_workload_types=USAGE_WORKLOAD_TYPES,
+        prefixes=USAGE_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -47,12 +47,12 @@ def test_create_bundle_billing(cluster_connection, tracked_files):
         resource_api=CLUSTER_CONFIG_API_V1,
         namespace=file_map["__namespaces__"]["aio"]
     )
-    expected_types = set(expected_aio_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
+    expected_types = set(AIO_WORKLOAD_TYPES).union(CLUSTER_CONFIG_API_V1.kinds)
     assert set(file_map["aio"].keys()).issubset(set(expected_types))
     check_workload_resource_files(
         file_objs=file_map["aio"],
         pre_bundle_items=aio_workload_items,
-        prefixes=aio_prefixes,
+        prefixes=AIO_PREFIXES,
         bundle_path=bundle_path
     )
 
@@ -62,11 +62,11 @@ def test_create_bundle_billing(cluster_connection, tracked_files):
         resource_api=CLUSTER_CONFIG_API_V1,
         namespace=file_map["__namespaces__"]["usage"]
     )
-    expected_types = set(expected_usage_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
+    expected_types = set(USAGE_WORKLOAD_TYPES).union(CLUSTER_CONFIG_API_V1.kinds)
     assert set(file_map["usage"].keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map["usage"],
         pre_bundle_items=usage_workload_items,
-        prefixes=usage_prefix,
+        prefixes=USAGE_PREFIXES,
         bundle_path=bundle_path
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_billing_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_billing_int.py
@@ -12,6 +12,7 @@ from .helpers import (
     check_custom_resource_files,
     check_workload_resource_files,
     get_file_map,
+    get_workload_resources,
     run_bundle_command
 )
 
@@ -20,10 +21,22 @@ logger = get_logger(__name__)
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_billing(init_setup, tracked_files):
+def test_create_bundle_billing(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS billing."""
     ops_service = OpsServiceType.billing.value
-    ops_service = "billing"
+    expected_aio_workload_types = ["cronjob", "job", "pod"]
+    aio_prefixes = ["aio-usage"]
+    aio_workload_items = get_workload_resources(
+        expected_workload_types=expected_aio_workload_types,
+        prefixes=aio_prefixes,
+    )
+
+    expected_usage_workload_types = ["deployment", "pod", "replicaset", "service"]
+    usage_prefix = ["billing-operator"]
+    usage_workload_items = get_workload_resources(
+        expected_workload_types=expected_usage_workload_types,
+        prefixes=usage_prefix,
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)
@@ -34,13 +47,12 @@ def test_create_bundle_billing(init_setup, tracked_files):
         resource_api=CLUSTER_CONFIG_API_V1,
         namespace=file_map["__namespaces__"]["aio"]
     )
-    expected_workload_types = ["cronjob", "job", "pod"]
-    expected_types = set(expected_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
+    expected_types = set(expected_aio_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
     assert set(file_map["aio"].keys()).issubset(set(expected_types))
     check_workload_resource_files(
         file_objs=file_map["aio"],
-        expected_workload_types=expected_workload_types,
-        prefixes=["aio-usage"],
+        pre_bundle_items=aio_workload_items,
+        prefixes=aio_prefixes,
         bundle_path=bundle_path
     )
 
@@ -50,12 +62,11 @@ def test_create_bundle_billing(init_setup, tracked_files):
         resource_api=CLUSTER_CONFIG_API_V1,
         namespace=file_map["__namespaces__"]["usage"]
     )
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
-    expected_types = set(expected_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
+    expected_types = set(expected_usage_workload_types).union(CLUSTER_CONFIG_API_V1.kinds)
     assert set(file_map["usage"].keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map["usage"],
-        expected_workload_types=expected_workload_types,
-        prefixes=["billing-operator"],
+        pre_bundle_items=usage_workload_items,
+        prefixes=usage_prefix,
         bundle_path=bundle_path
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_certmanager_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_certmanager_int.py
@@ -10,16 +10,16 @@ from azext_edge.edge.providers.edge_api import CERTMANAGER_API_V1, TRUSTMANAGER_
 from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
+CERTMGMT_PREFIXES = ["aio-cert-manager", "aio-trust-manager", "kube-root-ca"]
+CERTMGMT_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service", "configmap"]
 
 
 def test_create_bundle_certmanager(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.certmanager.value
-    expected_workload_types = ["deployment", "pod", "replicaset", "service", "configmap"]
-    prefixes = ["aio-cert-manager", "aio-trust-manager", "kube-root-ca"]
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=prefixes,
+        expected_workload_types=CERTMGMT_WORKLOAD_TYPES,
+        prefixes=CERTMGMT_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -37,12 +37,12 @@ def test_create_bundle_certmanager(cluster_connection, tracked_files):
         resource_api=TRUSTMANAGER_API_V1,
         namespace=file_map["__namespaces__"]["certmanager"],
     )
-    expected_types = set(expected_workload_types).union(CERTMANAGER_API_V1.kinds).union(TRUSTMANAGER_API_V1.kinds)
+    expected_types = set(CERTMGMT_WORKLOAD_TYPES).union(CERTMANAGER_API_V1.kinds).union(TRUSTMANAGER_API_V1.kinds)
     assert set(certmanager_file_map.keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=certmanager_file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=prefixes,
+        prefixes=CERTMGMT_PREFIXES,
         bundle_path=bundle_path,
     )
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_connectors_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_connectors_int.py
@@ -20,15 +20,16 @@ def test_create_bundle_connectors(cluster_connection, tracked_files):
     ops_service = OpsServiceType.connectors.value
     expected_workload_types = ["daemonset", "deployment", "pod", "replicaset", "service", "configmap"]
     optional_workload_types = ["podmetric"]
-    prefixes = ["aio-opc", "opcplc"] # TODO may change
+    prefixes = ["aio-opc", "opcplc"]
     pre_bundle_workload_items = get_workload_resources(
         expected_workload_types=expected_workload_types,
         prefixes=prefixes,
     )
-    pre_bundle_optional_workload_items = get_workload_resources(
-        expected_workload_types=optional_workload_types,
-        prefixes=prefixes,
-    )
+    # TODO: not an actual type
+    # pre_bundle_optional_workload_items = get_workload_resources(
+    #     expected_workload_types=optional_workload_types,
+    #     prefixes=prefixes,
+    # )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)["aio"]
@@ -43,5 +44,5 @@ def test_create_bundle_connectors(cluster_connection, tracked_files):
         pre_bundle_items=pre_bundle_workload_items,
         prefixes=prefixes,
         bundle_path=bundle_path,
-        pre_bundle_optional_items=pre_bundle_optional_workload_items
+        # pre_bundle_optional_items=pre_bundle_optional_workload_items
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_connectors_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_connectors_int.py
@@ -8,31 +8,40 @@ import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.edge_api import OPCUA_API_V1
-from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, run_bundle_command
+from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_connectors(init_setup, tracked_files):
+def test_create_bundle_connectors(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS connectors."""
     ops_service = OpsServiceType.connectors.value
+    expected_workload_types = ["daemonset", "deployment", "pod", "replicaset", "service", "configmap"]
+    optional_workload_types = ["podmetric"]
+    prefixes = ["aio-opc", "opcplc"] # TODO may change
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=prefixes,
+    )
+    pre_bundle_optional_workload_items = get_workload_resources(
+        expected_workload_types=optional_workload_types,
+        prefixes=prefixes,
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)["aio"]
 
     check_custom_resource_files(file_objs=file_map, resource_api=OPCUA_API_V1)
 
-    expected_workload_types = ["daemonset", "deployment", "pod", "replicaset", "service", "configmap"]
-    optional_workload_types = ["podmetric"]
     expected_types = set(expected_workload_types + optional_workload_types).union(OPCUA_API_V1.kinds)
     assert set(file_map.keys()).issubset(expected_types)
 
     check_workload_resource_files(
         file_objs=file_map,
-        expected_workload_types=expected_workload_types,
-        prefixes=["aio-opc", "opcplc"],
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=prefixes,
         bundle_path=bundle_path,
-        optional_workload_types=optional_workload_types,
+        pre_bundle_optional_items=pre_bundle_optional_workload_items
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_dataflow_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_dataflow_int.py
@@ -19,16 +19,16 @@ from .helpers import (
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+DATAFLOW_PREFIXES = ["aio-dataflow"]
+DATAFLOW_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service"]
 
 
 def test_create_bundle_dataflow(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS dataflow."""
     ops_service = OpsServiceType.dataflow.value
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
-    prefixes = "aio-dataflow"
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=prefixes,
+        expected_workload_types=DATAFLOW_WORKLOAD_TYPES,
+        prefixes=DATAFLOW_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -39,11 +39,11 @@ def test_create_bundle_dataflow(cluster_connection, tracked_files):
         resource_api=DATAFLOW_API_V1
     )
 
-    expected_types = set(expected_workload_types).union(DATAFLOW_API_V1.kinds)
+    expected_types = set(DATAFLOW_WORKLOAD_TYPES).union(DATAFLOW_API_V1.kinds)
     assert set(file_map.keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=prefixes,
+        prefixes=DATAFLOW_PREFIXES,
         bundle_path=bundle_path
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_deviceregistry_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_deviceregistry_int.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 # pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_deviceregistry(init_setup, tracked_files):
+def test_create_bundle_deviceregistry(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS deviceregistry."""
     ops_service = OpsServiceType.deviceregistry.value
     command = f"az iot ops support create-bundle --ops-service {ops_service}"

--- a/azext_edge/tests/edge/support/create_bundle_int/test_meta_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_meta_int.py
@@ -12,21 +12,20 @@ from .helpers import check_custom_resource_files, check_workload_resource_files,
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+META_PREFIXES = ["aio-operator", "aio-pre-install-job", "aio-post-install-job"]
+META_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service"]
+META_OPTIONAL_WORKLOAD_TYPES = ["job"]
 
 
 def test_create_bundle_meta(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS meta."""
-    prefixes = ["aio-operator", "aio-pre-install-job", "aio-post-install-job"]
-
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
-    optional_workload_types = ["job"]
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=prefixes,
+        expected_workload_types=META_WORKLOAD_TYPES,
+        prefixes=META_PREFIXES,
     )
     pre_bundle_optional_workload_items = get_workload_resources(
-        expected_workload_types=optional_workload_types,
-        prefixes=prefixes,
+        expected_workload_types=META_OPTIONAL_WORKLOAD_TYPES,
+        prefixes=META_PREFIXES,
     )
     command = "az iot ops support create-bundle"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -34,13 +33,12 @@ def test_create_bundle_meta(cluster_connection, tracked_files):
 
     check_custom_resource_files(file_objs=file_map, resource_api=META_API_V1)
 
-    optional_workload_types = ["job"]
-    expected_types = set(expected_workload_types + optional_workload_types).union(META_API_V1.kinds)
+    expected_types = set(META_WORKLOAD_TYPES + META_OPTIONAL_WORKLOAD_TYPES).union(META_API_V1.kinds)
     assert set(file_map.keys()).issubset(set(expected_types))
     check_workload_resource_files(
         file_objs=file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=prefixes,
+        prefixes=META_PREFIXES,
         bundle_path=bundle_path,
         pre_bundle_optional_items=pre_bundle_optional_workload_items
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_meta_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_meta_int.py
@@ -7,29 +7,40 @@
 import pytest
 from knack.log import get_logger
 from azext_edge.edge.providers.edge_api import META_API_V1
-from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, run_bundle_command
+from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_meta(init_setup, tracked_files):
+def test_create_bundle_meta(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS meta."""
-    # dir for unpacked files
+    prefixes = ["aio-operator", "aio-pre-install-job", "aio-post-install-job"]
+
+    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
+    optional_workload_types = ["job"]
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=prefixes,
+    )
+    pre_bundle_optional_workload_items = get_workload_resources(
+        expected_workload_types=optional_workload_types,
+        prefixes=prefixes,
+    )
     command = "az iot ops support create-bundle"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, "meta")["aio"]
 
     check_custom_resource_files(file_objs=file_map, resource_api=META_API_V1)
 
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
     optional_workload_types = ["job"]
     expected_types = set(expected_workload_types + optional_workload_types).union(META_API_V1.kinds)
     assert set(file_map.keys()).issubset(set(expected_types))
     check_workload_resource_files(
         file_objs=file_map,
-        expected_workload_types=expected_workload_types,
-        prefixes=["aio-operator", "aio-pre-install-job", "aio-post-install-job"],
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=prefixes,
         bundle_path=bundle_path,
+        pre_bundle_optional_items=pre_bundle_optional_workload_items
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_mq_int.py
@@ -13,6 +13,7 @@ from .helpers import (
     check_workload_resource_files,
     get_file_map,
     get_kubectl_workload_items,
+    get_workload_resources,
     run_bundle_command,
 )
 
@@ -22,11 +23,24 @@ pytestmark = pytest.mark.e2e
 
 
 @pytest.mark.parametrize("mq_traces", [False, True])
-def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
+def test_create_bundle_mq(cluster_connection, tracked_files, mq_traces):
     """Test for ensuring file names and content. ONLY CHECKS mq."""
     mq_traces = True
 
     ops_service = OpsServiceType.mq.value
+    expected_workload_types = [
+        "pod", "daemonset", "replicaset", "service", "statefulset", "job", "configmap"
+    ]
+    prefixes = ["aio-broker", "aio-dmqtt", "otel-collector-service"]
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=prefixes,
+        expected_label=("app.kubernetes.io/name", "microsoft-iotoperations-mqttbroker")
+    )
+    mq_trace_pods_names = []
+    if mq_traces:
+        mq_trace_pods_names = _get_trace_pods()
+
     command = f"az iot ops support create-bundle --broker-traces {mq_traces} --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service, mq_traces=mq_traces)["aio"]
@@ -39,9 +53,6 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
 
     check_custom_resource_files(file_objs=file_map, resource_api=MQ_ACTIVE_API)
 
-    expected_workload_types = [
-        "pod", "daemonset", "replicaset", "service", "statefulset", "job", "configmap"
-    ]
     expected_types = set(expected_workload_types).union(MQ_ACTIVE_API.kinds)
     assert set(file_map.keys()).issubset(expected_types)
 
@@ -51,8 +62,7 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
 
     if traces:
         # one trace should have two files - grab by id
-        expected_pods = get_kubectl_workload_items("aio-mq", service_type="pod")
-        expected_pod_names = [item["metadata"]["name"] for item in expected_pods]
+        post_expected_pods = _get_trace_pods()
         id_check = {}
         for file in traces["trace"]:
             assert file["action"] in [
@@ -64,7 +74,7 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
                 "subscribe",
                 "unsubscribe",
             ]
-            assert file["name"] in expected_pod_names
+            assert (file["name"] in mq_trace_pods_names) or (file["name"] in post_expected_pods)
 
             # should be a json for each pb
             if file["identifier"] not in id_check:
@@ -79,8 +89,12 @@ def test_create_bundle_mq(init_setup, tracked_files, mq_traces):
 
     check_workload_resource_files(
         file_objs=file_map,
-        expected_workload_types=expected_workload_types,
-        prefixes=["aio-broker", "aio-dmqtt", "otel-collector-service"],
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=prefixes,
         bundle_path=bundle_path,
         expected_label=("app.kubernetes.io/name", "microsoft-iotoperations-mqttbroker")
     )
+
+
+def _get_trace_pods():
+    return get_workload_resources(expected_workload_types=["pod"], prefixes="aio-mq")["pod"]

--- a/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
@@ -11,16 +11,28 @@ from .helpers import (
     check_custom_resource_files,
     check_workload_resource_files,
     get_file_map,
+    get_workload_resources,
     run_bundle_command,
 )
 
 logger = get_logger(__name__)
 
 
-def test_create_bundle_osm(init_setup, tracked_files):
+def test_create_bundle_osm(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS openservicemesh."""
     # dir for unpacked files
     ops_service = OpsServiceType.openservicemesh.value
+
+    expected_workload_types = ["configmap", "deployment", "pod", "replicaset", "service"]
+    workload_resource_prefixes = [
+        "osm",
+        "kube-root-ca",
+        "preset-mesh-config",
+    ]
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=workload_resource_prefixes,
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)
@@ -31,7 +43,6 @@ def test_create_bundle_osm(init_setup, tracked_files):
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_CONFIG_API_V1)
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_POLICY_API_V1)
 
-    expected_workload_types = ["configmap", "deployment", "pod", "replicaset", "service"]
     expected_types = set(expected_workload_types).union(OPENSERVICEMESH_CONFIG_API_V1.kinds)
     expected_types = expected_types.union(OPENSERVICEMESH_POLICY_API_V1.kinds)
 
@@ -44,7 +55,7 @@ def test_create_bundle_osm(init_setup, tracked_files):
     ]
     check_workload_resource_files(
         file_objs=osm_file_map,
-        expected_workload_types=expected_workload_types,
+        pre_bundle_items=pre_bundle_workload_items,
         prefixes=workload_resource_prefixes,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_openservicemesh_int.py
@@ -16,6 +16,8 @@ from .helpers import (
 )
 
 logger = get_logger(__name__)
+EXPECTED_PREFIXES = ["configmap", "deployment", "pod", "replicaset", "service"]
+EXPECTED_WORKLOAD_TYPES = ["osm", "kube-root-ca", "preset-mesh-config"]
 
 
 def test_create_bundle_osm(cluster_connection, tracked_files):
@@ -23,15 +25,9 @@ def test_create_bundle_osm(cluster_connection, tracked_files):
     # dir for unpacked files
     ops_service = OpsServiceType.openservicemesh.value
 
-    expected_workload_types = ["configmap", "deployment", "pod", "replicaset", "service"]
-    workload_resource_prefixes = [
-        "osm",
-        "kube-root-ca",
-        "preset-mesh-config",
-    ]
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=workload_resource_prefixes,
+        expected_workload_types=EXPECTED_WORKLOAD_TYPES,
+        prefixes=EXPECTED_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -43,19 +39,14 @@ def test_create_bundle_osm(cluster_connection, tracked_files):
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_CONFIG_API_V1)
     check_custom_resource_files(file_objs=osm_file_map, resource_api=OPENSERVICEMESH_POLICY_API_V1)
 
-    expected_types = set(expected_workload_types).union(OPENSERVICEMESH_CONFIG_API_V1.kinds)
+    expected_types = set(EXPECTED_WORKLOAD_TYPES).union(OPENSERVICEMESH_CONFIG_API_V1.kinds)
     expected_types = expected_types.union(OPENSERVICEMESH_POLICY_API_V1.kinds)
 
     assert set(osm_file_map.keys()).issubset(set(expected_types))
 
-    workload_resource_prefixes = [
-        "osm",
-        "kube-root-ca",
-        "preset-mesh-config",
-    ]
     check_workload_resource_files(
         file_objs=osm_file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=workload_resource_prefixes,
+        prefixes=EXPECTED_PREFIXES,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
@@ -12,29 +12,29 @@ from .helpers import check_workload_resource_files, get_file_map, get_workload_r
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+SCHEMA_PREFIXES = ["adr-schema-registry"]
+SCHEMA_WORKLOAD_TYPES = ["configmap", "pod", "service", "statefulset", "pvc"]
+SCHEMA_LABEL = ("app.kubernetes.io/name", "microsoft-iotoperations-schemas")
 
 
 def test_create_bundle_schemas(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.schemaregistry.value
-    expected_workload_types = ["configmap", "pod", "service", "statefulset", "pvc"]
-    expected_label = ("app.kubernetes.io/name", "microsoft-iotoperations-schemas")
-    prefixes = "adr-schema-registry"
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=prefixes,
-        expected_label=expected_label
+        expected_workload_types=SCHEMA_WORKLOAD_TYPES,
+        prefixes=SCHEMA_PREFIXES,
+        expected_label=SCHEMA_LABEL
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, "schemaregistry")["aio"]
 
-    assert set(file_map.keys()).issubset(set(expected_workload_types))
+    assert set(file_map.keys()).issubset(set(SCHEMA_WORKLOAD_TYPES))
 
     check_workload_resource_files(
         file_objs=file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=prefixes,
+        prefixes=SCHEMA_PREFIXES,
         bundle_path=bundle_path,
-        expected_label=expected_label,
+        expected_label=SCHEMA_LABEL,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_schemaregistry_int.py
@@ -7,29 +7,34 @@
 import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
-from .helpers import check_workload_resource_files, get_file_map, run_bundle_command
+from .helpers import check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_schemas(init_setup, tracked_files):
+def test_create_bundle_schemas(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.schemaregistry.value
-
+    expected_workload_types = ["configmap", "pod", "service", "statefulset", "pvc"]
+    expected_label = ("app.kubernetes.io/name", "microsoft-iotoperations-schemas")
+    prefixes = "adr-schema-registry"
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=prefixes,
+        expected_label=expected_label
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, "schemaregistry")["aio"]
-
-    expected_workload_types = ["configmap", "pod", "service", "statefulset", "pvc"]
 
     assert set(file_map.keys()).issubset(set(expected_workload_types))
 
     check_workload_resource_files(
         file_objs=file_map,
-        expected_workload_types=expected_workload_types,
-        prefixes=["adr-schema-registry"],
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=prefixes,
         bundle_path=bundle_path,
-        expected_label=("app.kubernetes.io/name", "microsoft-iotoperations-schemas"),
+        expected_label=expected_label,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_secretstore_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_secretstore_int.py
@@ -13,17 +13,17 @@ from .helpers import check_custom_resource_files, check_workload_resource_files,
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
+SSC_PREFIXES = ["secrets-store-sync-controller-manager", "manager-metrics-service"]
+SSC_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "service"]
 
 
 def test_create_bundle_ssc(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.secretstore.value
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
-    secret_store_prefixes = ["secrets-store-sync-controller-manager", "manager-metrics-service"]
 
     pre_bundle_workload_items = get_workload_resources(
-        expected_workload_types=expected_workload_types,
-        prefixes=secret_store_prefixes,
+        expected_workload_types=SSC_WORKLOAD_TYPES,
+        prefixes=SSC_PREFIXES,
     )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
@@ -40,11 +40,11 @@ def test_create_bundle_ssc(cluster_connection, tracked_files):
     )
 
     # SECRETSTORE
-    expected_types = set(expected_workload_types)
+    expected_types = set(SSC_WORKLOAD_TYPES)
     assert set(file_map[OpsServiceType.secretstore.value].keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map[OpsServiceType.secretstore.value],
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=secret_store_prefixes,
+        prefixes=SSC_PREFIXES,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/edge/support/create_bundle_int/test_secretstore_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_secretstore_int.py
@@ -8,17 +8,23 @@ import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.edge_api import SECRETSTORE_API_V1, SECRETSYNC_API_V1
-from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, run_bundle_command
+from .helpers import check_custom_resource_files, check_workload_resource_files, get_file_map, get_workload_resources, run_bundle_command
 
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
 
 
-def test_create_bundle_ssc(init_setup, tracked_files):
+def test_create_bundle_ssc(cluster_connection, tracked_files):
     """Test for ensuring file names and content. ONLY CHECKS arcagents."""
     ops_service = OpsServiceType.secretstore.value
+    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
+    secret_store_prefixes = ["secrets-store-sync-controller-manager", "manager-metrics-service"]
 
+    pre_bundle_workload_items = get_workload_resources(
+        expected_workload_types=expected_workload_types,
+        prefixes=secret_store_prefixes,
+    )
     command = f"az iot ops support create-bundle --ops-service {ops_service}"
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     file_map = get_file_map(walk_result, ops_service)
@@ -34,12 +40,11 @@ def test_create_bundle_ssc(init_setup, tracked_files):
     )
 
     # SECRETSTORE
-    expected_workload_types = ["deployment", "pod", "replicaset", "service"]
     expected_types = set(expected_workload_types)
     assert set(file_map[OpsServiceType.secretstore.value].keys()).issubset(expected_types)
     check_workload_resource_files(
         file_objs=file_map[OpsServiceType.secretstore.value],
-        expected_workload_types=expected_workload_types,
-        prefixes=["secrets-store-sync-controller-manager", "manager-metrics-service"],
+        pre_bundle_items=pre_bundle_workload_items,
+        prefixes=secret_store_prefixes,
         bundle_path=bundle_path,
     )

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -59,8 +59,8 @@ def find_extra_or_missing_names(
     error_msg = []
     # names may contain descriptors after the initial '.', just comparing first prefix
     # vilit double check if ^ is still needed
-    # pre_expected_names = [name.split(".")[0] for name in pre_expected_names]
-    # post_expected_names = [name.split(".")[0] for name in post_expected_names]
+    pre_expected_names = [name.split(".")[0] for name in pre_expected_names]
+    post_expected_names = [name.split(".")[0] for name in post_expected_names]
 
     extra_names = [name for name in result_names if name not in pre_expected_names]
     extra_names = [name for name in extra_names if name not in post_expected_names]

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -59,8 +59,6 @@ def find_extra_or_missing_names(
     error_msg = []
     # names may contain descriptors after the initial '.', just comparing first prefix
     # vilit double check if ^ is still needed
-    pre_expected_names = [name.split(".")[0] for name in pre_expected_names]
-    post_expected_names = [name.split(".")[0] for name in post_expected_names]
 
     extra_names = [name for name in result_names if name not in pre_expected_names]
     extra_names = [name for name in extra_names if name not in post_expected_names]

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -45,23 +45,34 @@ def filter_resources(
 def find_extra_or_missing_names(
     resource_type: str,
     result_names: List[str],
-    expected_names: List[str],
+    pre_expected_names: List[str],
+    post_expected_names: List[str],
     ignore_extras: bool = False,
     # TODO: remove once dynamic pods check logic is implemented
     ignore_missing: bool = False,
 ):
+    """
+    Checks the result to find missing or extra names.
+    First checks the result name against the names in the kubectl results from before the result was fetched.
+    If anything is missing/extra, checks against the kubectl results from after the result was fetched.
+    """
     error_msg = []
     # names may contain descriptors after the initial '.', just comparing first prefix
-    expected_names = [name.split(".")[0] for name in expected_names]
-    result_names = [name.split(".")[0] for name in result_names]
-    extra_names = [name for name in result_names if name not in expected_names]
+    # vilit double check if ^ is still needed
+    # pre_expected_names = [name.split(".")[0] for name in pre_expected_names]
+    # post_expected_names = [name.split(".")[0] for name in post_expected_names]
+
+    extra_names = [name for name in result_names if name not in pre_expected_names]
+    extra_names = [name for name in extra_names if name not in post_expected_names]
     if extra_names:
         msg = f"Extra {resource_type} names: {', '.join(extra_names)}."
         if ignore_extras:
             logger.warning(msg)
         else:
             error_msg.append(msg)
-    missing_names = [name for name in expected_names if name not in result_names]
+
+    missing_names = [name for name in pre_expected_names if name not in result_names]
+    missing_names = [name for name in missing_names if name in post_expected_names]
     if missing_names:
         error_msg.append(f"Missing {resource_type} names: {', '.join(missing_names)}.")
 


### PR DESCRIPTION
The goal here is to make the tests more tolerant of state changes. Now there is:
1. fetch resources before
2. get the support bundle
3. fetch resources after

For the comparison, first the before (1) and the support bundle (2) are compared. If there are extra or missing resources, the after (3) is also compared. 

NOTE: this is ONLY for workload resources since the custom resources seem to be more "stable".

This will not get rid of the possibility of a resource showing up after 1, being caught in the support bundle, and being deleted before 3 (and the reverse missing resource scenario). 

Some other improvements:
1. use the correct fixture (only need cluster connection)
2. remove the "." splitting in the name checks
3. Note some gaps


Note: this is a temp pr to get into the pipeline int testing so more tests can be run.

 
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
