### PR TITLE
refactor: force enabled public network access storage accounts for schema tests

### DIFF
--- a/azext_edge/tests/edge/orchestration/resources/test_schema_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_int.py
@@ -22,11 +22,9 @@ def test_schema_lifecycle(settings_with_rg, tracked_resources, tracked_files):
     registry_namespace = f"test-namespace-{generate_random_string(force_lower=True, size=6)}"
     # create the storage account and get the id
     # NOTE: storage account needs to have public network access enabled to work.
-    # if we want to check the blobs (aka see that the schema content goes in the right place)
-    # we would need to enable shared key access too...
     storage_account = run(
         f"az storage account create -n {storage_account_name} -g {registry_rg} "
-        "--enable-hierarchical-namespace "
+        "--enable-hierarchical-namespace --public-network-access Enabled "
         "--allow-shared-key-access false --allow-blob-public-access false"
     )
     tracked_resources.append(storage_account['id'])


### PR DESCRIPTION
Doing 
![image](https://github.com/user-attachments/assets/60376e27-504e-479f-a9e4-28bac771ae01)

gives us 
![image](https://github.com/user-attachments/assets/83cd93b3-33c1-409a-9fe1-b8aadf106063)

(which should give us public network access but... https://github.com/Azure/azure-iot-ops-cli-extension/actions/runs/13639929748/job/38127267373#step:18:265)

So we do this 
![image](https://github.com/user-attachments/assets/7a4d77ff-6382-49e7-ad6f-37473d003ad5)

to give us 
![image](https://github.com/user-attachments/assets/f798009a-83b1-4be0-8182-8e56bb1809ca)

and now we can have schemas without worries.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
