### PR TITLE
test: fix support bundle acstor/acs namespace issues

### DIFF
--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -570,7 +570,6 @@ def _clean_up_folders(
     for namespace_folder, monikers in [
         (clusterconfig_namespace, ["clusterconfig"]),
         (arc_namespace, services + ["arcagents"]),
-        (acs_namespace, ["arccontainerstorage"]),
         (ssc_namespace, [OpsServiceType.secretstore.value]),
         (certmanager_namespace, services),
         (osm_namespace, ["openservicemesh"]),
@@ -585,8 +584,10 @@ def _clean_up_folders(
                 f"monikers: [{monikers}]"
             assert not level_1["files"]
 
-    if acstor_namespace:
-        level_1 = walk_result.pop(path.join(BASE_ZIP_PATH, acstor_namespace))
+    if acstor_namespace or acs_namespace:
+        level_1 = walk_result.pop(path.join(BASE_ZIP_PATH, acstor_namespace or acs_namespace))
+        if acs_namespace:
+            services.append("arccontainerstorage")
         if containerstorage_service:
             services.append(containerstorage_service)
         assert set(level_1["folders"]) == set(services), f"Mismatch; folders: [{level_1['folders']}], "\

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -339,8 +339,11 @@ def get_file_map(
         return file_map
     elif ops_service == OpsServiceType.openservicemesh.value:
         # resources only in osm_namespace
-        assert len(walk_result) == 1 + expected_default_walk_result, f"walk result keys: {walk_result.keys()}"
         osm_path = path.join(BASE_ZIP_PATH, osm_namespace, "openservicemesh")
+        if osm_path not in walk_result:
+            assert len(walk_result) == expected_default_walk_result, f"walk result keys: {walk_result.keys()}"
+            pytest.skip(f"No bundles created for {ops_service}.")
+        assert len(walk_result) == 1 + expected_default_walk_result, f"walk result keys: {walk_result.keys()}"
         file_map["osm"] = convert_file_names(walk_result[osm_path]["files"])
         file_map["__namespaces__"]["osm"] = osm_namespace
 

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -339,10 +339,11 @@ def get_file_map(
         return file_map
     elif ops_service == OpsServiceType.openservicemesh.value:
         # resources only in osm_namespace
-        osm_path = path.join(BASE_ZIP_PATH, osm_namespace, "openservicemesh")
-        if osm_path not in walk_result:
+        if not osm_namespace:
             assert len(walk_result) == expected_default_walk_result, f"walk result keys: {walk_result.keys()}"
             pytest.skip(f"No bundles created for {ops_service}.")
+
+        osm_path = path.join(BASE_ZIP_PATH, osm_namespace, "openservicemesh")
         assert len(walk_result) == 1 + expected_default_walk_result, f"walk result keys: {walk_result.keys()}"
         file_map["osm"] = convert_file_names(walk_result[osm_path]["files"])
         file_map["__namespaces__"]["osm"] = osm_namespace
@@ -587,11 +588,12 @@ def _clean_up_folders(
                 f"monikers: [{monikers}]"
             assert not level_1["files"]
 
+    # note that the acstor and acs namespace should be the same value
     if acstor_namespace or acs_namespace:
         level_1 = walk_result.pop(path.join(BASE_ZIP_PATH, acstor_namespace or acs_namespace))
         if acs_namespace:
             services.append("arccontainerstorage")
-        if containerstorage_service:
+        if acstor_namespace and containerstorage_service:
             services.append(containerstorage_service)
         assert set(level_1["folders"]) == set(services), f"Mismatch; folders: [{level_1['folders']}], "\
             f"services [{services}]"

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -25,7 +25,9 @@ pytestmark = pytest.mark.e2e
 
 def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
     # case = ops_service, mq_traces, bundle_dir
-    cases = [(service, False, "support_bundles") for service in OpsServiceType.list()]
+    service_list = OpsServiceType.list()
+    service_list.remove("openservicemesh")
+    cases = [(service, False, "support_bundles") for service in service_list]
     cases.append((OpsServiceType.mq.value, True, None))
 
     # test "all services" bundle
@@ -34,7 +36,7 @@ def generate_bundle_test_cases() -> List[Tuple[str, bool, Optional[str]]]:
 
 
 @pytest.mark.parametrize("ops_service, mq_traces, bundle_dir", generate_bundle_test_cases())
-def test_create_bundle(cluster_connection, bundle_dir, mq_traces, ops_service, tracked_files):
+def test_create_bundle(cluster_connection, ops_service, bundle_dir, mq_traces, tracked_files):
     """Test to focus on ops_service param."""
 
     # skip arccontainerstorage and azuremonitor for aio namespace check


### PR DESCRIPTION
doing testing

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
