### PR TITLE
fix: fix patch in client cert AIO extension update

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -700,7 +700,7 @@ class OpcUACerts(Queryable):
         properties = aio_extension["properties"]
 
         config_settings: dict = properties.get("configurationSettings", {})
-        
+
         desired_config_settings = config_settings.copy()
         desired_config_settings["connectors.values.securityPki.applicationCert"] = application_cert
         desired_config_settings["connectors.values.securityPki.subjectName"] = subject_name
@@ -896,7 +896,7 @@ class OpcUACerts(Queryable):
             )
 
         return cert_subject_name, cert_application_uri
-    
+
 
 def _get_config_delta(current_config: dict, desired_config: dict) -> dict:
     # get the delta of desired config and current config

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -709,8 +709,8 @@ class OpcUACerts(Queryable):
         desired_config_settings["connectors.values.securityPki.applicationUri"] = application_uri
 
         delta = calculate_config_delta(
-            config_settings=config_settings,
-            desired_config_settings=desired_config_settings,
+            current=config_settings,
+            target=desired_config_settings,
         )
 
         if delta:

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -15,9 +15,6 @@ from knack.log import get_logger
 from rich.console import Console
 import yaml
 
-
-from ......util.x509 import decode_der_certificate
-
 from ....common import CUSTOM_LOCATIONS_API_VERSION, EXTENSION_TYPE_OPS
 from ...instances import SECRET_SYNC_RESOURCE_TYPE, SPC_RESOURCE_TYPE, Instances
 from .....orchestration.upgrade2 import calculate_config_delta
@@ -29,6 +26,7 @@ from ......util.az_client import (
     wait_for_terminal_state,
 )
 from ......util.common import should_continue_prompt
+from ......util.x509 import decode_der_certificate
 
 logger = get_logger(__name__)
 

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
@@ -103,6 +103,44 @@ from azext_edge.tests.generators import generate_random_string
                 },
             }
         ),
+        (
+            {
+                "resources": [
+                    get_mock_spc_record(spc_name="default-spc", resource_group_name="mock-rg"),
+                    get_mock_spc_record(spc_name=OPCUA_SPC_NAME, resource_group_name="mock-rg"),
+                    get_mock_secretsync_record(
+                        secretsync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+                    ),
+                ],
+                "extension": {
+                    EXTENSION_TYPE_OPS: {"id": "aio-ext-id", "name": "aio-ext-name", "properties": {
+                        "configurationSettings": {
+                            "existingProperties": "foo",
+                            "connectors.values.securityPki.applicationCert": OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
+                            "connectors.values.securityPki.subjectName": "subjectnameold",
+                            "connectors.values.securityPki.applicationUri": "uriold",
+                        },
+                    }}
+                },
+            },
+            get_mock_spc_record(spc_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME, resource_group_name="mock-rg"),
+            get_mock_secretsync_record(
+                secretsync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME, resource_group_name="mock-rg"
+            ),
+            "/fake/path/certificate.der",
+            "/fake/path/certificate.pem",
+            get_mock_secretsync_record(
+                secretsync_name=OPCUA_CLIENT_CERT_SECRET_SYNC_NAME,
+                resource_group_name="mock-rg",
+                objects="new-secret",
+            ),
+            {
+                "configurationSettings": {
+                    "connectors.values.securityPki.subjectName": "subjectname",
+                    "connectors.values.securityPki.applicationUri": "uri",
+                },
+            }
+        ),
     ],
 )
 def test_client_add(


### PR DESCRIPTION
Should only patch the modified properties instead of all properties

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
