### PR TITLE
feat: set of initial clone follow ups, more parameterization

### DIFF
--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -461,7 +461,7 @@ def load_iotops_arguments(self, _):
         context.argument(
             "custom_endpoint",
             options_list=["--custom-ep"],
-            help="Endpoint to use for the custom auth service. Format is 'https://.*'.",
+            help="Endpoint to use for the custom auth service. Format is `https://.*`.",
             arg_group="Custom",
         )
         context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1066,7 +1066,7 @@ def load_iotops_arguments(self, _):
             options_list=["--base-uri"],
             help="Base URI to use for template links. If not provided a relative path strategy will be used. "
             "Relevant when --mode is set to 'linked'. "
-            "Example: 'https://raw.githubusercontent.com/myorg/myproject/main/myclones/'.",
+            "Example: `https://raw.githubusercontent.com/myorg/myproject/main/myclones/`.",
             arg_group="Local Target",
         )
         context.argument(

--- a/azext_edge/tests/edge/orchestration/resources/conftest.py
+++ b/azext_edge/tests/edge/orchestration/resources/conftest.py
@@ -59,9 +59,13 @@ def get_mock_resource(
     identity: dict = {},
     qualified_type: Optional[str] = None,
     tags: Optional[dict] = None,
+    is_proxy_resource: bool = False,
 ) -> dict:
+    kwargs = {}
     if not location:
         location = "northeurope"
+    if not is_proxy_resource:
+        kwargs["location"] = location
     resource = {
         "extendedLocation": {
             "name": f"/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}"
@@ -73,7 +77,6 @@ def get_mock_resource(
             resource_path=resource_path,
             resource_provider=resource_provider or RESOURCE_PROVIDER,
         ).split("?")[0][len(BASE_URL) :],
-        "location": location,
         "name": name,
         "properties": properties,
         "resourceGroup": resource_group_name,
@@ -86,6 +89,7 @@ def get_mock_resource(
             "lastModifiedByType": "Application",
         },
         "type": qualified_type or QUALIFIED_INSTANCE_TYPE,
+        **kwargs,
     }
 
     if identity:

--- a/azext_edge/tests/edge/orchestration/resources/test_broker_authns_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_broker_authns_unit.py
@@ -51,6 +51,7 @@ def get_mock_broker_authn_record(
         properties=properties or default_properties,
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/brokers/authentications",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_broker_authzs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_broker_authzs_unit.py
@@ -52,6 +52,7 @@ def get_mock_broker_authz_record(
         },
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/brokers/authorizations",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_broker_listeners_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_broker_listeners_unit.py
@@ -77,6 +77,7 @@ def get_mock_broker_listener_record(
         properties=properties or default_properties,
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/brokers/listeners",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
@@ -48,7 +48,8 @@ def get_mock_broker_record(broker_name: str, instance_name: str, resource_group_
             "provisioningState": "Succeeded",
         },
         resource_group_name=resource_group_name,
-        qualified_type="microsoft.iotoperations/instances/brokers"
+        qualified_type="microsoft.iotoperations/instances/brokers",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_endpoints_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_endpoints_unit.py
@@ -39,6 +39,7 @@ def get_mock_dataflow_endpoint_record(
         },
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/dataflowendpoints",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_profiles_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_profiles_unit.py
@@ -43,7 +43,8 @@ def get_mock_dataflow_profile_record(profile_name: str, instance_name: str, reso
             "provisioningState": "Succeeded",
         },
         resource_group_name=resource_group_name,
-        qualified_type="microsoft.iotoperations/instances/dataflowprofiles"
+        qualified_type="microsoft.iotoperations/instances/dataflowprofiles",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflows_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflows_unit.py
@@ -43,6 +43,7 @@ def get_mock_dataflow_record(
         },
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/dataflows",
+        is_proxy_resource=True,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/test_clone_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_clone_unit.py
@@ -1521,13 +1521,13 @@ class CloneAssertor:
             resource_group="[parameters('schemaRegistryId').resourceGroup]",
             depends_on=["iotOperations"],
         )
+        assert deployment["condition"] == "[parameters('applyRoleAssignments')]"
         dep_props = deployment["properties"]
         dep_props["parameters"] = {
             "clusterName": {"value": "[parameters('clusterName')]"},
             "instanceName": {"value": "[parameters('instanceName')]"},
             "principalId": {"value": "[reference('iotOperations', '2023-05-01', 'Full').identity.principalId]"},
             "schemaRegistryId": {"value": "[parameters('schemaRegistryId')]"},
-            "applyRoleAssignments": {"value": "[parameters('applyRoleAssignments')]"},
         }
         template = deployment["properties"]["template"]
         assert template["$schema"] == "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"
@@ -1537,7 +1537,6 @@ class CloneAssertor:
             "instanceName": {"type": "string"},
             "principalId": {"type": "string"},
             "schemaRegistryId": {"type": "object"},
-            "applyRoleAssignments": {"type": "bool"},
         }
         assert isinstance(template["resources"], list), "Deployment resources key should be a list"
         assert len(template["resources"]) == 1


### PR DESCRIPTION
- New root deployment param `location`, (default from model instance)
  - All tracked resources use the param.
- New root deployment param `schemaRegistryId`, (default from model instance)
  - It is an object type because parts of the resource Id are re-used for a role assignment sub deployment
- New root deployment param `applyRoleAssignments`, bool with default `true`.
- Instance feature mode not supporting reapplying its own representation (mode = "")
  - When mode="" the property will be omitted.