### PR TITLE
fix: update check for broker listener service name

### DIFF
--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -343,6 +343,7 @@ def evaluate_broker_listeners(
             if listener_spec_service_name not in processed_services:
                 _evaluate_listener_service(
                     check_manager=check_manager,
+                    listener_name=listener_name,
                     listener_spec=listener_spec,
                     processed_services=processed_services,
                     target_listeners=target_listeners,
@@ -969,6 +970,7 @@ def _evaluate_broker_reference(
 
 def _evaluate_listener_service(
     check_manager: CheckManager,
+    listener_name: str,
     listener_spec: dict,
     processed_services: dict,
     target_listeners: str,
@@ -992,8 +994,8 @@ def _evaluate_listener_service(
             target_name=target_listeners,
             namespace=namespace,
             status=listener_service_eval_status,
-            value={"listener_service": "Unable to fetch service name."},
-            resource_name=f"service/{listener_spec_service_name}",
+            value={"spec.serviceName": listener_spec_service_name},
+            resource_name=listener_name,
         )
         return
 

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -543,8 +543,8 @@ def test_broker_checks(
                 ],
                 [
                     ("status", "error"),
-                    ("name", "service/None"),
-                    ("value/listener_service", "Unable to fetch service name."),
+                    ("name", "mock-name"),
+                    ("value/spec.serviceName", None),
                 ],
             ],
             # service conditions str

--- a/azext_edge/tests/edge/checks/test_mq_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_mq_checks_unit.py
@@ -506,6 +506,61 @@ def test_broker_checks(
                 ],
             ],
         ),
+        # check error when service name is None
+        (
+            # listener
+            generate_resource_stub(
+                spec={
+                    "serviceName": None,
+                    "serviceType": "loadbalancer",
+                    "port": 8080,
+                    "authenticationEnabled": "True",
+                },
+                status={"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
+            ),
+            # service obj
+            generate_resource_stub(
+                status={"loadBalancer": {"ingress": [{"ip": "127.0.0.1"}]}},
+                spec={"clusterIP": "127.0.0.1"},
+            ),
+            # listener conditions str
+            [
+                "len(brokerlisteners)>=1",
+                "status",
+                "spec",
+                "spec.serviceName",
+                "status",
+            ],
+            # listener evaluations
+            [
+                [
+                    ("status", "success"),
+                    ("name", "mock-name"),
+                    (
+                        "value/status",
+                        {"runtimeStatus": {"status": ResourceState.running.value, "description": ""}},
+                    ),
+                ],
+                [
+                    ("status", "error"),
+                    ("name", "service/None"),
+                    ("value/listener_service", "Unable to fetch service name."),
+                ],
+            ],
+            # service conditions str
+            [
+                "listener_service",
+                "status",
+                "len(status.loadBalancer.ingress[*].ip)>=1",
+            ],
+            # service evaluations
+            [
+                [
+                    ("status", "error"),
+                    ("value/listener_service", "service/name"),
+                ],
+            ],
+        ),
     ],
 )
 def test_broker_listener_checks(
@@ -551,12 +606,14 @@ def test_broker_listener_checks(
 
     # check service target
     service_name = listener["spec"]["serviceName"]
-    assert namespace in result["targets"][f"service/{service_name}"]
-    target = result["targets"][f"service/{service_name}"][namespace]
 
-    # conditions
-    assert_conditions(target, service_conditions)
-    assert_evaluations(target, service_evaluations)
+    if service_name:
+        assert namespace in result["targets"][f"service/{service_name}"]
+        target = result["targets"][f"service/{service_name}"][namespace]
+
+        # conditions
+        assert_conditions(target, service_conditions)
+        assert_evaluations(target, service_evaluations)
 
 
 @pytest.mark.parametrize("detail_level", ResourceOutputDetailLevel.list())


### PR DESCRIPTION
Fix for  https://github.com/Azure/azure-cli/issues/31562

Update check for broker listener service name, when it's not existed, make it a check error instead of runtime exception

- **before:**

                  
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/azureuser/.azure/cliextensions/azure-iot-ops/azext_edge/edge/providers/check/mq.py", line 158, in evaluate_broker_listeners
    listener_spec_service_name: str = listener_spec["serviceName"]
                                      ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'serviceName'

cli.azure.cli.core.azclierror: The command failed with an unexpected error. Here is the traceback:
az_command_data_logger: The command failed with an unexpected error. Here is the traceback:
cli.azure.cli.core.azclierror: 'serviceName'
Traceback (most recent call last):
  File "/opt/az/lib/python3.12/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 666, in execute
    raise ex
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 734, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

- **after:**

<img width="374" alt="image" src="https://github.com/user-attachments/assets/1070f94d-5d54-4e23-9f32-9f67683a6b67" />

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
