### PR TITLE
fix(test): do not fail pod status check if pod phase is succeeded

### DIFF
--- a/azext_edge/tests/edge/checks/int/helpers.py
+++ b/azext_edge/tests/edge/checks/int/helpers.py
@@ -6,6 +6,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 from azure.cli.core.azclierror import CLIInternalError
+from azext_edge.edge.common import PodState
 from azext_edge.edge.providers.edge_api.base import EdgeResourceApi
 from ....helpers import (
     PLURAL_KEY,
@@ -267,6 +268,7 @@ def _assert_pod_conditions(
         ("PodReadyToStartContainers", "status.conditions.podreadytostartcontainers"),
     ]
     pod_conditions = kubectl_pod["status"].get("conditions", {})
+    pod_phase = kubectl_pod['status'].get("phase", "").lower()
 
     known_conditions = [condition[0] for condition in conditions_to_evaluate]
     unknown_conditions = [
@@ -277,7 +279,8 @@ def _assert_pod_conditions(
     if _all_known_conditions_true(pod_conditions, known_conditions):
         is_known_success = True
 
-    if not is_known_success:
+    # Pod states should not be marked as error if overall pod phase is 'succeeded'
+    if not is_known_success and pod_phase != PodState.succeeded.value:
         expected_status = "error"
 
     if is_known_success and unknown_conditions:


### PR DESCRIPTION
Int tests are currently failing for Akri checks because they have pod states that are `False` but the code is designed to[ mark those pods as successful if the overall pod phase is `succeeded`.](https://github.com/Azure/azure-iot-ops-cli-extension/blob/97189119afd9565d425071ee8fd106f51df65e56/azext_edge/edge/providers/check/base/pod.py#L129)

This change fixes the test to reflect the correct code result, but I'm curious if we want to take a look at this method in the future to make checks a bit more precise.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
