### PR TITLE
feat: update broker disk persistence + resource Id validation

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.0.0a1"
+VERSION = "2.0.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -212,7 +212,8 @@ def load_iotops_help():
         type: command
         short-summary: Update an mqtt broker's disk persistence settings.
         long-summary: |
-          Configuring disk persistence depends on enablement at broker create time.
+          Updating disk persistence depends on enablement at broker create time.
+          Setting the persistence mode of a broker component will reset its configuration.
 
         examples:
         - name: Update the persistence mode of subscriber message queues, retain topics and state store.
@@ -220,7 +221,24 @@ def load_iotops_help():
             az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode subscriberQueue=All retain=All stateStore=All
         - name: Update a custom persistence policy for retain messages.
           text: >
-            az iot ops broker persist update --in myinstance -g myresourcegroup --retain-topics mytopic1 mytopic2
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode retain=Custom --retain-topics sensor1 factor/# groundfloor/+/temperature
+        - name: Set up state store persistence with multiple key groups including string, pattern, and binary keys.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode stateStore=Custom
+            --state-store-str-keys "device-001" "device-002" --state-store-glob-keys "sensors/*" --state-store-bin-keys "image:thumbnail" "cert:device"
+        - name: Configure subscriber queue persistence for specific client IDs with custom user properties for dynamic control.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode subscriberQueue=Custom
+            --subscriber-client-ids "factory-client-*" "sensor-gateway-01" --user-key disk-persistence --user-value disk
+        - name: Advanced configuration with multiple persistence modes, state store key groupings, and dynamic settings for a custom broker.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --broker default --persist-mode retain=Custom stateStore=Custom subscriberQueue=All
+            --retain-topics "alerts/#" "diagnostics/#" --state-store-str-keys "user:admin" "session:active" --state-store-str-keys "config:database" "config:security"
+            --state-store-glob-keys "logs/*.txt" "backups/*" --disable-dynamic stateStore
+        - name: Disable all persistence modes and remove custom user properties.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode retain=None stateStore=None subscriberQueue=None
+            --user-key="" --user-value=""
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -191,12 +191,36 @@ def load_iotops_help():
         short-summary: Delete an mqtt broker.
 
         examples:
-        - name: Delete an mqtt broker from the instance.
+        - name: Delete the default mqtt broker from the instance.
           text: >
-            az iot ops broker delete -n default --in myinstance -g myresourcegroup
+            az iot ops broker delete --in myinstance -g myresourcegroup
         - name: Same as prior example but skipping the confirmation prompt.
           text: >
-            az iot ops broker delete -n default --in myinstance -g myresourcegroup -y
+            az iot ops broker delete --in myinstance -g myresourcegroup -y
+    """
+
+    helps[
+        "iot ops broker persist"
+    ] = """
+        type: group
+        short-summary: Mqtt broker disk persistence management.
+    """
+
+    helps[
+        "iot ops broker persist update"
+    ] = """
+        type: command
+        short-summary: Update an mqtt broker's disk persistence settings.
+        long-summary: |
+          Configuring disk persistence depends on enablement at broker create time.
+
+        examples:
+        - name: Update the persistence mode of subscriber message queues, retain topics and state store.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode subscriberQueue=All retain=All stateStore=All
+        - name: Update a custom persistence policy for retain messages.
+          text: >
+            az iot ops broker persist update --in myinstance -g myresourcegroup --retain-topics mytopic1 mytopic2
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -232,7 +232,7 @@ def load_iotops_help():
             --subscriber-client-ids "factory-client-*" "sensor-gateway-01" --user-key disk-persistence --user-value disk
         - name: Advanced configuration with multiple persistence modes, state store key groupings, and dynamic settings for a custom broker.
           text: >
-            az iot ops broker persist update --in myinstance -g myresourcegroup --broker default --persist-mode retain=Custom stateStore=Custom subscriberQueue=All
+            az iot ops broker persist update --in myinstance -g myresourcegroup --name default --persist-mode retain=Custom stateStore=Custom subscriberQueue=All
             --retain-topics "alerts/#" "diagnostics/#" --state-store-str-keys "user:admin" "session:active" --state-store-str-keys "config:database" "config:security"
             --state-store-glob-keys "logs/*.txt" "backups/*" --disable-dynamic stateStore
         - name: Disable all persistence modes and remove custom user properties.

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -221,12 +221,12 @@ def load_iotops_help():
             az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode subscriberQueue=All retain=All stateStore=All
         - name: Update a custom persistence policy for retain messages.
           text: >
-            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode retain=Custom --retain-topics sensor1 factor/# groundfloor/+/temperature
-        - name: Set up state store persistence with multiple key groups including string, pattern, and binary keys.
+            az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode retain=Custom --retain-topics "sensor1" "factory/#" "groundfloor/+/temperature"
+        - name: Set up state store persistence with multiple key groups including string, pattern, and binary (base64 encoded) keys.
           text: >
             az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode stateStore=Custom
-            --state-store-str-keys "device-001" "device-002" --state-store-glob-keys "sensors/*" --state-store-bin-keys "image:thumbnail" "cert:device"
-        - name: Configure subscriber queue persistence for specific client IDs with custom user properties for dynamic control.
+            --state-store-str-keys "device-001" "device-002" --state-store-glob-keys "sensors/*" --state-store-bin-keys "bXlrZXkx" "bXlrZXky"
+        - name: Configure subscriber queue persistence for specific client IDs and apply user property key and value for dynamic persistence.
           text: >
             az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode subscriberQueue=Custom
             --subscriber-client-ids "factory-client-*" "sensor-gateway-01" --user-key disk-persistence --user-value disk
@@ -234,8 +234,8 @@ def load_iotops_help():
           text: >
             az iot ops broker persist update --in myinstance -g myresourcegroup --name default --persist-mode retain=Custom stateStore=Custom subscriberQueue=All
             --retain-topics "alerts/#" "diagnostics/#" --state-store-str-keys "user:admin" "session:active" --state-store-str-keys "config:database" "config:security"
-            --state-store-glob-keys "logs/*.txt" "backups/*" --disable-dynamic stateStore
-        - name: Disable all persistence modes and remove custom user properties.
+            --state-store-glob-keys "logs/*" "backups/*" --disable-dynamic stateStore
+        - name: Disable all persistence modes and remove user properties for dynamic persistence.
           text: >
             az iot ops broker persist update --in myinstance -g myresourcegroup --persist-mode retain=None stateStore=None subscriberQueue=None
             --user-key="" --user-value=""

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -82,6 +82,12 @@ def load_iotops_commands(self, _):
         cmd_group.command("delete", "delete_broker", deprecate_info=cmd_group.deprecate(hide=True))
 
     with self.command_group(
+        "iot ops broker persist",
+        command_type=mq_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("update", "update_broker_persist", is_preview=True)
+
+    with self.command_group(
         "iot ops broker listener",
         command_type=mq_resource_ops,
     ) as cmd_group:

--- a/azext_edge/edge/commands_mq.py
+++ b/azext_edge/edge/commands_mq.py
@@ -15,7 +15,7 @@ from .providers.orchestration.common import MqServiceType
 logger = get_logger(__name__)
 
 
-def show_broker(cmd, broker_name: str, instance_name: str, resource_group_name: str) -> dict:
+def show_broker(cmd, instance_name: str, resource_group_name: str, broker_name: str = DEFAULT_BROKER) -> dict:
     return Brokers(cmd).show(name=broker_name, instance_name=instance_name, resource_group_name=resource_group_name)
 
 
@@ -24,13 +24,51 @@ def list_brokers(cmd, instance_name: str, resource_group_name: str) -> Iterable[
 
 
 def delete_broker(
-    cmd, broker_name: str, instance_name: str, resource_group_name: str, confirm_yes: Optional[bool] = None, **kwargs
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    broker_name: str = DEFAULT_BROKER,
+    confirm_yes: Optional[bool] = None,
+    **kwargs,
 ):
     return Brokers(cmd).delete(
         name=broker_name,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         confirm_yes=confirm_yes,
+        **kwargs,
+    )
+
+
+def update_broker_persist(
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    broker_name: str = DEFAULT_BROKER,
+    persist_mode: Optional[List[str]] = None,
+    retain_topics: Optional[List[str]] = None,
+    subscriber_queue_client_ids: Optional[List[str]] = None,
+    state_store_str_keys: Optional[List[List[str]]] = None,
+    state_store_glob_keys: Optional[List[List[str]]] = None,
+    state_store_bin_keys: Optional[List[List[str]]] = None,
+    user_property_key: Optional[str] = None,
+    user_property_value: Optional[str] = None,
+    disable_dynamic: Optional[List[str]] = None,
+    **kwargs,
+) -> dict:
+    return Brokers(cmd).update_persist_config(
+        name=broker_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        persist_mode=persist_mode,
+        retain_topics=retain_topics,
+        subscriber_queue_client_ids=subscriber_queue_client_ids,
+        state_store_str_keys=state_store_str_keys,
+        state_store_glob_keys=state_store_glob_keys,
+        state_store_bin_keys=state_store_bin_keys,
+        user_property_key=user_property_key,
+        user_property_value=user_property_value,
+        disable_dynamic=disable_dynamic,
         **kwargs,
     )
 

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -939,6 +939,84 @@ def load_iotops_arguments(self, _):
             help="Broker name.",
         )
 
+    with self.argument_context("iot ops broker persist") as context:
+        context.argument(
+            "user_property_key",
+            options_list=["--user-key"],
+            help="The user property key to enable persistence dynamically. In addition to 'aio-persistence'. "
+            "Assign empty string to remove.",
+            arg_group="Dynamic Persistence",
+        )
+        context.argument(
+            "user_property_value",
+            options_list=["--user-value"],
+            help="The user property value to enable persistence dynamically. In addition to 'true'. "
+            "Assign empty string to remove.",
+            arg_group="Dynamic Persistence",
+        )
+        context.argument(
+            "disable_dynamic",
+            nargs="+",
+            options_list=["--disable-dynamic"],
+            help="Disable dynamic persistence. Supported values include: 'stateStore', 'retain', 'subscriberQueue'.",
+            arg_group="Dynamic Persistence",
+        )
+        context.argument(
+            "persist_mode",
+            options_list=["--persist-mode"],
+            nargs="+",
+            action="extend",
+            help="Configure disk persistence mode for state store, retain messages and subscriber queues. "
+            "Format is space-separated key=value pairs. Supported keys include: 'stateStore', "
+            "'retain', 'subscriberQueue'. Supported values for each key include: 'None', 'All', 'Custom'. "
+            "By default each mode is set to min Custom with dynamic persistence enabled. "
+            "This option can be used one or more times.",
+        )
+        context.argument(
+            "retain_topics",
+            options_list=["--retain-topics"],
+            nargs="+",
+            help="Space-separated list of topics under which retained messages would be persisted to disk. "
+            "Wildcards # and + supported.",
+            arg_group="Retained Messages",
+        )
+        context.argument(
+            "state_store_bin_keys",
+            options_list=["--state-store-bin-keys"],
+            nargs="+",
+            action="append",
+            help="Space-separated list of binary keys that would be persisted to disk. "
+            "Can be used multiple times, where each occurrence appends to the state store policy collection.",
+            arg_group="State Store",
+        )
+        context.argument(
+            "state_store_glob_keys",
+            options_list=["--state-store-glob-keys"],
+            nargs="+",
+            action="append",
+            help="Space-separated list of glob-style pattern matching keys that would be persisted to disk. "
+            "Can be used multiple times, where each occurrence appends to the state store policy collection.",
+            arg_group="State Store",
+        )
+        context.argument(
+            "state_store_str_keys",
+            options_list=["--state-store-str-keys"],
+            nargs="+",
+            action="append",
+            help="Space-separated list of string keys that would be persisted to disk. "
+            "String keys are used to do an exact match, for example, when a key contains characters that might be "
+            "otherwise matched as a pattern (*, ?, [0-9]). "
+            "Can be used multiple times, where each occurrence appends to the state store policy collection.",
+            arg_group="State Store",
+        )
+        context.argument(
+            "subscriber_queue_client_ids",
+            options_list=["--subscriber-client-ids"],
+            nargs="+",
+            help="Space-separated list of subscriber client IDs, wildcard * supported.",
+            arg_group="Subscriber Queue",
+        )
+
     with self.argument_context("iot ops broker listener") as context:
         context.argument(
             "listener_name",
@@ -1296,7 +1374,7 @@ def load_iotops_arguments(self, _):
                 options_list=["--persist-max-size"],
                 help="The max size of the message buffer on disk. Setting a value will enable disk persistence. "
                 "Kubernetes resource units must be used e.g. the following value suffixes are supported: "
-                "E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.",
+                "E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.",
                 arg_group="Disk Persistence",
             )
             context.argument(

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -985,7 +985,7 @@ def load_iotops_arguments(self, _):
             options_list=["--state-store-bin-keys"],
             nargs="+",
             action="append",
-            help="Space-separated list of binary keys that would be persisted to disk. "
+            help="Space-separated list of binary keys in base-64 encoded format that would be persisted to disk. "
             "Can be used multiple times, where each occurrence appends to the state store policy collection.",
             arg_group="State Store",
         )

--- a/azext_edge/edge/providers/orchestration/resources/brokers.py
+++ b/azext_edge/edge/providers/orchestration/resources/brokers.py
@@ -88,7 +88,7 @@ class Brokers(Queryable):
                 "Use 'az iot ops create' with '--persist-max-size' to enable."
             )
         new_persist_config = self.build_broker_config(
-            persist_mode=persist_mode,
+            persist_mode=parse_kvp_nargs(persist_mode),
             retain_topics=retain_topics,
             subscriber_queue_client_ids=subscriber_queue_client_ids,
             state_store_str_keys=state_store_str_keys,
@@ -113,11 +113,11 @@ class Brokers(Queryable):
             return wait_for_terminal_state(poller, **kwargs)
 
     @classmethod
-    def build_broker_config(
+    def build_broker_config(  # noqa: C901
         cls,
         persist_max_size: Optional[str] = None,
         persist_pvc_sc: Optional[str] = None,
-        persist_mode: Optional[List[str]] = None,
+        persist_mode: Optional[dict[str, str]] = None,
         retain_topics: Optional[List[str]] = None,
         subscriber_queue_client_ids: Optional[List[str]] = None,
         state_store_str_keys: Optional[List[List[str]]] = None,
@@ -160,8 +160,6 @@ class Brokers(Queryable):
 
         config = {}
         persistence = existing_persist_config or {}
-        if isinstance(persist_mode, list):
-            persist_mode = parse_kvp_nargs(persist_mode)
 
         # Initialize new persistence when max size is provided
         if not existing_persist_config:

--- a/azext_edge/edge/providers/orchestration/resources/brokers.py
+++ b/azext_edge/edge/providers/orchestration/resources/brokers.py
@@ -154,12 +154,16 @@ class Brokers(Queryable):
             InvalidArgumentValueError: If persistence is enabled but max size is not provided,
                 or if invalid modes are specified.
         """
+        # Constants
+        VALID_MODE_KEYS = ["stateStore", "retain", "subscriberQueue"]
+        VALID_MODE_VALUES = ["None", "All", "Custom"]
 
         config = {}
         persistence = existing_persist_config or {}
         if isinstance(persist_mode, list):
             persist_mode = parse_kvp_nargs(persist_mode)
 
+        # Initialize new persistence when max size is provided
         if not existing_persist_config:
             if any([persist_pvc_sc, persist_mode]) and not persist_max_size:
                 raise InvalidArgumentValueError(
@@ -167,83 +171,95 @@ class Brokers(Queryable):
                 )
             if persist_max_size:
                 persistence["maxSize"] = persist_max_size
-                persistence["retain"] = {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Enabled"}}}
-                persistence["stateStore"] = {"mode": "Custom", "stateStoreSettings": {"dynamic": {"mode": "Enabled"}}}
-                persistence["subscriberQueue"] = {
-                    "mode": "Custom",
-                    "subscriberQueueSettings": {"dynamic": {"mode": "Enabled"}},
-                }
+                # Create default Custom persistence modes with dynamic enabled
+                for key in VALID_MODE_KEYS:
+                    persistence[key] = {"mode": "Custom", f"{key}Settings": {"dynamic": {"mode": "Enabled"}}}
             if persist_pvc_sc:
                 persistence["persistentVolumeClaimSpec"] = {
                     "storageClassName": persist_pvc_sc,
                     "accessModes": ["ReadWriteOncePod"],
                 }
 
-        valid_mode_keys = ["stateStore", "retain", "subscriberQueue"]
+        # Handle persistence mode updates
         if persist_mode:
-            valid_mode_values = ["None", "All", "Custom"]
             for key, value in persist_mode.items():
-                if key not in valid_mode_keys:
+                if key not in VALID_MODE_KEYS:
                     raise InvalidArgumentValueError(
-                        f"Invalid persistence mode key: {key}. Valid keys are {valid_mode_keys}."
+                        f"Invalid persistence mode key: {key}. Valid keys are {VALID_MODE_KEYS}."
                     )
-                if value not in valid_mode_values:
+                if value not in VALID_MODE_VALUES:
                     raise InvalidArgumentValueError(
-                        f"Invalid persistence mode value: {value}. Valid values are {valid_mode_values}."
+                        f"Invalid persistence mode value: {value}. Valid values are {VALID_MODE_VALUES}."
                     )
                 persistence[key] = {"mode": value}
                 if value == "Custom":
                     persistence[key][f"{key}Settings"] = {"dynamic": {"mode": "Enabled"}}
 
+        # Custom mode validations with specific error messages
+        custom_validations = [
+            (
+                retain_topics,
+                "retain",
+                "To set retain topics for persistence, retain mode must be set to 'Custom'.",
+            ),
+            (
+                subscriber_queue_client_ids,
+                "subscriberQueue",
+                "To set subscriber queue client Ids for persistence, subscriberQueue mode must be set to 'Custom'.",
+            ),
+            (
+                any([state_store_str_keys, state_store_glob_keys, state_store_bin_keys]),
+                "stateStore",
+                "To set state store keys for persistence, stateStore mode must be set to 'Custom'.",
+            ),
+        ]
+
+        for condition, mode_key, error_msg in custom_validations:
+            if condition and persistence[mode_key]["mode"] != "Custom":
+                raise InvalidArgumentValueError(error_msg)
+
+        # Configure retain topics
         if retain_topics:
-            if persistence["retain"]["mode"] != "Custom":
-                raise InvalidArgumentValueError(
-                    "To set retain topics for persistence, the retain mode must be set to 'Custom'."
-                )
             persistence["retain"]["retainSettings"] = {"topics": retain_topics}
 
+        # Configure subscriber queue client IDs
         if subscriber_queue_client_ids:
-            if persistence["subscriberQueue"]["mode"] != "Custom":
-                raise InvalidArgumentValueError(
-                    "To set subscriber queue client Ids for persistence, the subscriber queue mode must be set to 'Custom'."
-                )
             persistence["subscriberQueue"]["subscriberQueueSettings"] = {
                 "subscriberClientIds": subscriber_queue_client_ids
             }
 
+        # Configure state store keys
         if any([state_store_str_keys, state_store_glob_keys, state_store_bin_keys]):
-            if persistence["stateStore"]["mode"] != "Custom":
-                raise InvalidArgumentValueError(
-                    "To set state store keys for persistence, the state store mode must be set to 'Custom'."
-                )
-            state_store_resources: list[dict] = []
+            state_store_resources = []
+            # Process each key type collection
             for collection, key_type in [
                 (state_store_str_keys, "String"),
                 (state_store_glob_keys, "Pattern"),
                 (state_store_bin_keys, "Binary"),
             ]:
-                for items in collection or []:
-                    state_store_resources.append({"keys": items, "keyType": key_type})
+                if collection:
+                    state_store_resources.extend([{"keys": items, "keyType": key_type} for items in collection])
             persistence["stateStore"]["stateStoreSettings"] = {"stateStoreResources": state_store_resources}
 
-        if any([user_property_key is not None, user_property_value is not None]):
-            if (user_property_key is None) != (user_property_value is None):
+        # Handle user properties (both must be provided or both must be None)
+        if user_property_key is not None or user_property_value is not None:
+            if user_property_key is None or user_property_value is None:
                 raise InvalidArgumentValueError("Both --user-key and --user-value must be set or both must be unset.")
-            persistence["dynamicSettings"] = {}
-            if user_property_key is not None:
-                persistence["dynamicSettings"]["userPropertyKey"] = user_property_key
-            if user_property_value is not None:
-                persistence["dynamicSettings"]["userPropertyValue"] = user_property_value
+            persistence["dynamicSettings"] = {
+                "userPropertyKey": user_property_key,
+                "userPropertyValue": user_property_value,
+            }
 
+        # Handle dynamic disabling
         if disable_dynamic:
             for key in disable_dynamic:
-                if key not in valid_mode_keys:
+                if key not in VALID_MODE_KEYS:
                     raise InvalidArgumentValueError(
-                        f"Invalid disable dynamic key: {key}. Valid keys are {valid_mode_keys}."
+                        f"Invalid disable dynamic key: {key}. Valid keys are {VALID_MODE_KEYS}."
                     )
                 if persistence[key]["mode"] != "Custom":
                     raise InvalidArgumentValueError(
-                        f"To disable dynamic persistence for {key}, the {key} mode must be set to 'Custom'."
+                        f"To disable dynamic persistence for {key}, {key} mode must be set to 'Custom'."
                     )
                 persistence[key][f"{key}Settings"]["dynamic"] = {"mode": "Disabled"}
 

--- a/azext_edge/edge/providers/orchestration/resources/brokers.py
+++ b/azext_edge/edge/providers/orchestration/resources/brokers.py
@@ -77,7 +77,7 @@ class Brokers(Queryable):
         state_store_bin_keys: Optional[List[List[str]]] = None,
         user_property_key: Optional[str] = None,
         user_property_value: Optional[str] = None,
-        disable_dynamic: Optional[List[bool]] = None,
+        disable_dynamic: Optional[List[str]] = None,
         **kwargs,
     ) -> dict:
         broker_config = self.show(name=name, instance_name=instance_name, resource_group_name=resource_group_name)
@@ -88,7 +88,6 @@ class Brokers(Queryable):
                 "Use 'az iot ops create' with '--persist-max-size' to enable."
             )
         new_persist_config = self.build_broker_config(
-            persist_max_size=existing_persist_config["maxSize"],
             persist_mode=persist_mode,
             retain_topics=retain_topics,
             subscriber_queue_client_ids=subscriber_queue_client_ids,
@@ -98,6 +97,7 @@ class Brokers(Queryable):
             user_property_key=user_property_key,
             user_property_value=user_property_value,
             disable_dynamic=disable_dynamic,
+            existing_persist_config=existing_persist_config,
         )
         for key in new_persist_config["persistence"]:
             if key not in ["maxSize", "persistentVolumeClaimSpec"]:
@@ -154,29 +154,32 @@ class Brokers(Queryable):
             InvalidArgumentValueError: If persistence is enabled but max size is not provided,
                 or if invalid modes are specified.
         """
-        if any([persist_pvc_sc, persist_mode]) and not persist_max_size:
-            raise InvalidArgumentValueError(
-                "Provide a persist max size value to enable and customize broker disk persistence."
-            )
-        if isinstance(persist_mode, list):
-            persist_mode = parse_kvp_nargs(persist_mode)
 
         config = {}
         persistence = existing_persist_config or {}
+        if isinstance(persist_mode, list):
+            persist_mode = parse_kvp_nargs(persist_mode)
+
+        if not existing_persist_config:
+            if any([persist_pvc_sc, persist_mode]) and not persist_max_size:
+                raise InvalidArgumentValueError(
+                    "Provide a persist max size value to enable and customize broker disk persistence."
+                )
+            if persist_max_size:
+                persistence["maxSize"] = persist_max_size
+                persistence["retain"] = {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Enabled"}}}
+                persistence["stateStore"] = {"mode": "Custom", "stateStoreSettings": {"dynamic": {"mode": "Enabled"}}}
+                persistence["subscriberQueue"] = {
+                    "mode": "Custom",
+                    "subscriberQueueSettings": {"dynamic": {"mode": "Enabled"}},
+                }
+            if persist_pvc_sc:
+                persistence["persistentVolumeClaimSpec"] = {
+                    "storageClassName": persist_pvc_sc,
+                    "accessModes": ["ReadWriteOncePod"],
+                }
+
         valid_mode_keys = ["stateStore", "retain", "subscriberQueue"]
-        if persist_max_size:
-            persistence["maxSize"] = persist_max_size
-            persistence["retain"] = {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Enabled"}}}
-            persistence["stateStore"] = {"mode": "Custom", "stateStoreSettings": {"dynamic": {"mode": "Enabled"}}}
-            persistence["subscriberQueue"] = {
-                "mode": "Custom",
-                "subscriberQueueSettings": {"dynamic": {"mode": "Enabled"}},
-            }
-        if persist_pvc_sc:
-            persistence["persistentVolumeClaimSpec"] = {
-                "storageClassName": persist_pvc_sc,
-                "accessModes": ["ReadWriteOncePod"],
-            }
         if persist_mode:
             valid_mode_values = ["None", "All", "Custom"]
             for key, value in persist_mode.items():
@@ -219,8 +222,8 @@ class Brokers(Queryable):
                 (state_store_glob_keys, "Pattern"),
                 (state_store_bin_keys, "Binary"),
             ]:
-                for item in collection or []:
-                    state_store_resources.append({"key": item, "type": key_type})
+                for items in collection or []:
+                    state_store_resources.append({"keys": items, "keyType": key_type})
             persistence["stateStore"]["stateStoreSettings"] = {"stateStoreResources": state_store_resources}
 
         if any([user_property_key is not None, user_property_value is not None]):

--- a/azext_edge/edge/providers/orchestration/resources/brokers.py
+++ b/azext_edge/edge/providers/orchestration/resources/brokers.py
@@ -7,7 +7,7 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Iterable, List, Optional
 
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azure.core.exceptions import ResourceNotFoundError
 from knack.log import get_logger
 from rich.console import Console
@@ -64,12 +64,69 @@ class Brokers(Queryable):
             )
             return wait_for_terminal_state(poller, **kwargs)
 
+    def update_persist_config(
+        self,
+        name: str,
+        instance_name: str,
+        resource_group_name: str,
+        persist_mode: Optional[List[str]] = None,
+        retain_topics: Optional[List[str]] = None,
+        subscriber_queue_client_ids: Optional[List[str]] = None,
+        state_store_str_keys: Optional[List[List[str]]] = None,
+        state_store_glob_keys: Optional[List[List[str]]] = None,
+        state_store_bin_keys: Optional[List[List[str]]] = None,
+        user_property_key: Optional[str] = None,
+        user_property_value: Optional[str] = None,
+        disable_dynamic: Optional[List[bool]] = None,
+        **kwargs,
+    ) -> dict:
+        broker_config = self.show(name=name, instance_name=instance_name, resource_group_name=resource_group_name)
+        existing_persist_config = broker_config.get("properties", {}).get("persistence")
+        if not existing_persist_config:
+            raise ValidationError(
+                "The broker is not enabled for disk persistence which must be configured at create time.\n"
+                "Use 'az iot ops create' with '--persist-max-size' to enable."
+            )
+        new_persist_config = self.build_broker_config(
+            persist_max_size=existing_persist_config["maxSize"],
+            persist_mode=persist_mode,
+            retain_topics=retain_topics,
+            subscriber_queue_client_ids=subscriber_queue_client_ids,
+            state_store_str_keys=state_store_str_keys,
+            state_store_glob_keys=state_store_glob_keys,
+            state_store_bin_keys=state_store_bin_keys,
+            user_property_key=user_property_key,
+            user_property_value=user_property_value,
+            disable_dynamic=disable_dynamic,
+        )
+        for key in new_persist_config["persistence"]:
+            if key not in ["maxSize", "persistentVolumeClaimSpec"]:
+                existing_persist_config[key] = new_persist_config["persistence"][key]
+
+        with console.status("Working..."):
+            poller = self.ops.begin_create_or_update(
+                resource_group_name=resource_group_name,
+                instance_name=instance_name,
+                broker_name=name,
+                resource=broker_config,
+            )
+            return wait_for_terminal_state(poller, **kwargs)
+
     @classmethod
     def build_broker_config(
         cls,
         persist_max_size: Optional[str] = None,
         persist_pvc_sc: Optional[str] = None,
-        persist_mode: Optional[dict[str, str]] = None,
+        persist_mode: Optional[List[str]] = None,
+        retain_topics: Optional[List[str]] = None,
+        subscriber_queue_client_ids: Optional[List[str]] = None,
+        state_store_str_keys: Optional[List[List[str]]] = None,
+        state_store_glob_keys: Optional[List[List[str]]] = None,
+        state_store_bin_keys: Optional[List[List[str]]] = None,
+        user_property_key: Optional[str] = None,
+        user_property_value: Optional[str] = None,
+        disable_dynamic: Optional[List[str]] = None,
+        existing_persist_config: Optional[dict] = None,
     ) -> dict:
         """
         Build the broker configuration dict. Only data persistence is supported at the moment.
@@ -80,6 +137,15 @@ class Brokers(Queryable):
             persist_pvc_sc (str, optional): Storage class for the persistent volume claim.
             persist_mode (dict[str, str], optional): Dictionary specifying the persistence modes for state store,
                 retain, and subscriber queue.
+            retain_topics (list[str], optional): List of topics to retain for persistence.
+            subscriber_queue_client_ids (list[str], optional): List of client IDs for the subscriber queue.
+            state_store_str_keys (list[list[str]], optional): List of string keys for the state store.
+            state_store_glob_keys (list[list[str]], optional): List of glob keys for the state store.
+            state_store_bin_keys (list[list[str]], optional): List of binary keys for the state store.
+            user_property_key (str, optional): User property key for dynamic persistence.
+            user_property_value (str, optional): User property value for dynamic persistence.
+            disable_dynamic (list[str], optional): List of key types to disable dynamic persistence for.
+            existing_persist_config (dict, optional): Existing persistence configuration to update.
 
         Returns:
             dict: A dictionary representing the broker configuration.
@@ -90,11 +156,14 @@ class Brokers(Queryable):
         """
         if any([persist_pvc_sc, persist_mode]) and not persist_max_size:
             raise InvalidArgumentValueError(
-                "Provide a persist max size value to enable and customize broker data persistence."
+                "Provide a persist max size value to enable and customize broker disk persistence."
             )
+        if isinstance(persist_mode, list):
+            persist_mode = parse_kvp_nargs(persist_mode)
 
         config = {}
-        persistence = {}
+        persistence = existing_persist_config or {}
+        valid_mode_keys = ["stateStore", "retain", "subscriberQueue"]
         if persist_max_size:
             persistence["maxSize"] = persist_max_size
             persistence["retain"] = {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Enabled"}}}
@@ -109,7 +178,6 @@ class Brokers(Queryable):
                 "accessModes": ["ReadWriteOncePod"],
             }
         if persist_mode:
-            valid_mode_keys = ["stateStore", "retain", "subscriberQueue"]
             valid_mode_values = ["None", "All", "Custom"]
             for key, value in persist_mode.items():
                 if key not in valid_mode_keys:
@@ -121,6 +189,60 @@ class Brokers(Queryable):
                         f"Invalid persistence mode value: {value}. Valid values are {valid_mode_values}."
                     )
                 persistence[key] = {"mode": value}
+                if value == "Custom":
+                    persistence[key][f"{key}Settings"] = {"dynamic": {"mode": "Enabled"}}
+
+        if retain_topics:
+            if persistence["retain"]["mode"] != "Custom":
+                raise InvalidArgumentValueError(
+                    "To set retain topics for persistence, the retain mode must be set to 'Custom'."
+                )
+            persistence["retain"]["retainSettings"] = {"topics": retain_topics}
+
+        if subscriber_queue_client_ids:
+            if persistence["subscriberQueue"]["mode"] != "Custom":
+                raise InvalidArgumentValueError(
+                    "To set subscriber queue client Ids for persistence, the subscriber queue mode must be set to 'Custom'."
+                )
+            persistence["subscriberQueue"]["subscriberQueueSettings"] = {
+                "subscriberClientIds": subscriber_queue_client_ids
+            }
+
+        if any([state_store_str_keys, state_store_glob_keys, state_store_bin_keys]):
+            if persistence["stateStore"]["mode"] != "Custom":
+                raise InvalidArgumentValueError(
+                    "To set state store keys for persistence, the state store mode must be set to 'Custom'."
+                )
+            state_store_resources: list[dict] = []
+            for collection, key_type in [
+                (state_store_str_keys, "String"),
+                (state_store_glob_keys, "Pattern"),
+                (state_store_bin_keys, "Binary"),
+            ]:
+                for item in collection or []:
+                    state_store_resources.append({"key": item, "type": key_type})
+            persistence["stateStore"]["stateStoreSettings"] = {"stateStoreResources": state_store_resources}
+
+        if any([user_property_key is not None, user_property_value is not None]):
+            if (user_property_key is None) != (user_property_value is None):
+                raise InvalidArgumentValueError("Both --user-key and --user-value must be set or both must be unset.")
+            persistence["dynamicSettings"] = {}
+            if user_property_key is not None:
+                persistence["dynamicSettings"]["userPropertyKey"] = user_property_key
+            if user_property_value is not None:
+                persistence["dynamicSettings"]["userPropertyValue"] = user_property_value
+
+        if disable_dynamic:
+            for key in disable_dynamic:
+                if key not in valid_mode_keys:
+                    raise InvalidArgumentValueError(
+                        f"Invalid disable dynamic key: {key}. Valid keys are {valid_mode_keys}."
+                    )
+                if persistence[key]["mode"] != "Custom":
+                    raise InvalidArgumentValueError(
+                        f"To disable dynamic persistence for {key}, the {key} mode must be set to 'Custom'."
+                    )
+                persistence[key][f"{key}Settings"]["dynamic"] = {"mode": "Disabled"}
 
         if persistence:
             config["persistence"] = persistence

--- a/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
+++ b/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
@@ -162,7 +162,7 @@ class RegistryEndpoints(Queryable):
         # Ensure mutual exclusivity
         if trusted_signing_configmap_key and trusted_signing_secret_key:
             raise MutuallyExclusiveArgumentError(
-                "Cannot specify both config map and secret for trusted signing key settings."
+                "Cannot specify both config map and secret for trusted signing key settings. "
                 "Choose one trusted signing key type."
             )
 

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -98,9 +98,22 @@ class InitTargets:
     ):
         self.cluster_name = cluster_name
         self.resource_group_name = resource_group_name
-        self.schema_registry_resource_id = ensure_resource_id(schema_registry_resource_id)
+        self.schema_registry_resource_id = ensure_resource_id(
+            schema_registry_resource_id,
+            match_context={
+                "resource_provider": "Microsoft.DeviceRegistry",
+                "resource_type": "schemaRegistries",
+            },
+            parameter="--sr-resource-id",
+        )
         self.adr_namespace_resource_id = ensure_resource_id(
-            adr_namespace_resource_id, match_context={"resource_group": resource_group_name}
+            adr_namespace_resource_id,
+            match_context={
+                "resource_group": resource_group_name,
+                "resource_provider": "Microsoft.DeviceRegistry",
+                "resource_type": "namespaces",
+            },
+            parameter="--ns-resource-id",
         )
         self.cluster_namespace = self._sanitize_k8s_name(cluster_namespace)
         self.location = location
@@ -467,24 +480,37 @@ def get_default_instance_config(
     }
 
 
-def ensure_resource_id(resource_id: Optional[str], match_context: Optional[dict] = None) -> Optional[str]:
+def ensure_resource_id(
+    resource_id: Optional[str], match_context: Optional[dict] = None, parameter: Optional[str] = None
+) -> Optional[str]:
     if not resource_id:
         return
+    parameter = parameter or f"Resource Id '{resource_id}'"
     if is_valid_resource_id(resource_id):
         parsed_id = parse_resource_id(resource_id)  # Validate the resource ID format
         resource_name = parsed_id.get("name")
         if resource_name:
             if match_context:
                 match_resource_group: str = match_context.get("resource_group", "")
+                match_rp = match_context.get("resource_provider", "")
+                match_type = match_context.get("resource_type", "")
                 if match_resource_group:
                     if parsed_id.get("resource_group", "").lower() != match_resource_group.lower():
                         raise InvalidArgumentValueError(
-                            f"Resource Id '{resource_id}' does not match the "
-                            f"instance resource group '{match_resource_group}'."
+                            f"{parameter} value must match the resource group '{match_resource_group}'."
                         )
+                if match_rp and match_type:
+                    if any(
+                        [
+                            parsed_id.get("namespace", "").lower() != match_rp.lower(),
+                            parsed_id.get("type", "").lower() != match_type.lower(),
+                        ]
+                    ):
+                        raise InvalidArgumentValueError(f"{parameter} value must be of type {match_rp}/{match_type}.")
             return resource_id
+
     raise InvalidArgumentValueError(
-        f"Malformed resource Id '{resource_id}'. An Azure resource Id has the form:\n"
-        "/subscription/{subscriptionId}/resourceGroups/{resourceGroup}"
-        "/providers/Microsoft.Provider/{resourcePath}/{resourceName}"
+        f"{parameter} is malformed. An Azure resource Id has the form:\n"
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}"
+        "/providers/Microsoft.Provider/{resourceType}/{resourceName}"
     )

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -688,7 +688,7 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
 )
 
 TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
-    commit_id="707e047b4b791a300abb6dc18d8a99966c995b54",
+    commit_id="80722ecb1626537266efeb276f8143035fead5f1",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
@@ -1307,7 +1307,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.2.30"},
+            "VERSIONS": {"iotOperations": "1.2.31"},
             "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -289,8 +289,8 @@ def parse_resource_id(resource_id: str) -> Optional[ResourceIdContainer]:
     if len(parts) < 9:
         raise ValidationError(
             f"Malformed resource Id '{resource_id}'. An Azure resource Id has the form:\n"
-            "/subscription/{subscriptionId}/resourceGroups/{resourceGroup}"
-            "/providers/Microsoft.Provider/{resourcePath}/{resourceName}"
+            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}"
+            "/providers/Microsoft.Provider/{resourceType}/{resourceName}"
         )
 
     # Extract the subscription, resource group, and resource name

--- a/azext_edge/edge/util/common.py
+++ b/azext_edge/edge/util/common.py
@@ -20,7 +20,7 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-def parse_kvp_nargs(kvp_nargs: List[str]) -> dict:
+def parse_kvp_nargs(kvp_nargs: Optional[List[str]]) -> dict:
     """
     Parses kvp nargs into a dict handling values of null and empty string.
     """

--- a/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
@@ -189,7 +189,8 @@ def test_broker_delete(mocked_cmd, mocked_responses: responses):
             "persistence_required": True,
             "error": (
                 ValidationError,
-                "The broker is not enabled for disk persistence which must be configured at create time.\nUse 'az iot ops create' with '--persist-max-size' to enable.",
+                "The broker is not enabled for disk persistence which must be configured at create time.\n"
+                "Use 'az iot ops create' with '--persist-max-size' to enable.",
             ),
         },
         # Test basic mode updates
@@ -352,21 +353,21 @@ def test_broker_delete(mocked_cmd, mocked_responses: responses):
             "input": {"retain_topics": ["topic1"]},
             "error": (
                 InvalidArgumentValueError,
-                "To set retain topics for persistence, the retain mode must be set to 'Custom'.",
+                "To set retain topics for persistence, retain mode must be set to 'Custom'.",
             ),
         },
         {
             "input": {"subscriber_queue_client_ids": ["client1"]},
             "error": (
                 InvalidArgumentValueError,
-                "To set subscriber queue client Ids for persistence, the subscriber queue mode must be set to 'Custom'.",
+                "To set subscriber queue client Ids for persistence, subscriberQueue mode must be set to 'Custom'.",
             ),
         },
         {
             "input": {"state_store_str_keys": [["key1"]]},
             "error": (
                 InvalidArgumentValueError,
-                "To set state store keys for persistence, the state store mode must be set to 'Custom'.",
+                "To set state store keys for persistence, stateStore mode must be set to 'Custom'.",
             ),
         },
         {
@@ -381,7 +382,7 @@ def test_broker_delete(mocked_cmd, mocked_responses: responses):
             "input": {"persist_mode": ["retain=All"], "disable_dynamic": ["retain"]},
             "error": (
                 InvalidArgumentValueError,
-                "To disable dynamic persistence for retain, the retain mode must be set to 'Custom'.",
+                "To disable dynamic persistence for retain, retain mode must be set to 'Custom'.",
             ),
         },
         {
@@ -416,7 +417,7 @@ def test_update_broker_persist(
     # Setup test data
     instance_name = generate_random_string()
     resource_group_name = generate_random_string()
-    scenario_inputs = scenario.get("input", {})
+    scenario_inputs: dict = scenario.get("input", {})
     broker_name = scenario_inputs.get("broker_name", DEFAULT_BROKER)
     test_inputs = {k: v for k, v in scenario_inputs.items() if k != "broker_name"}
 
@@ -520,8 +521,5 @@ def test_update_broker_persist(
 
         # Verify PUT request payload
         request_payload = mocked_responses.calls[1].request.body
-        if isinstance(request_payload, bytes):
-            request_payload = json.loads(request_payload.decode())
-        else:
-            request_payload = json.loads(request_payload)
+        request_payload = json.loads(request_payload)
         assert request_payload == expected_broker_record

--- a/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_brokers_unit.py
@@ -4,12 +4,21 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import json
+from copy import deepcopy
 from typing import Optional
 
 import pytest
 import responses
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 
-from azext_edge.edge.commands_mq import list_brokers, show_broker, delete_broker
+from azext_edge.edge.commands_mq import (
+    delete_broker,
+    list_brokers,
+    show_broker,
+    update_broker_persist,
+)
+from azext_edge.edge.common import DEFAULT_BROKER
 
 from ....generators import generate_random_string
 from .conftest import get_base_endpoint, get_mock_resource
@@ -22,31 +31,38 @@ def get_broker_endpoint(instance_name: str, resource_group_name: str, broker_nam
     return get_base_endpoint(resource_group_name=resource_group_name, resource_path=resource_path)
 
 
-def get_mock_broker_record(broker_name: str, instance_name: str, resource_group_name: str) -> dict:
+def get_mock_broker_record(
+    broker_name: str, instance_name: str, resource_group_name: str, properties: Optional[dict] = None
+) -> dict:
+    default_properties = {
+        "advanced": {"encryptInternalTraffic": "Enabled"},
+        "cardinality": {
+            "backendChain": {"partitions": 2, "redundancyFactor": 2, "workers": 2},
+            "frontend": {"replicas": 2, "workers": 2},
+        },
+        "diagnostics": {
+            "logs": {"level": "info"},
+            "metrics": {"prometheusPort": 9600},
+            "selfCheck": {"intervalSeconds": 30, "mode": "Enabled", "timeoutSeconds": 15},
+            "traces": {
+                "cacheSizeMegabytes": 16,
+                "mode": "Enabled",
+                "selfTracing": {"intervalSeconds": 30, "mode": "Enabled"},
+                "spanChannelCapacity": 1000,
+            },
+        },
+        "generateResourceLimits": {"cpu": "Disabled"},
+        "memoryProfile": "Medium",
+        "provisioningState": "Succeeded",
+    }
+
+    if properties:
+        default_properties.update(properties)
+
     return get_mock_resource(
         name=broker_name,
         resource_path=f"/instances/{instance_name}/brokers/{broker_name}",
-        properties={
-            "advanced": {"encryptInternalTraffic": "Enabled"},
-            "cardinality": {
-                "backendChain": {"partitions": 2, "redundancyFactor": 2, "workers": 2},
-                "frontend": {"replicas": 2, "workers": 2},
-            },
-            "diagnostics": {
-                "logs": {"level": "info"},
-                "metrics": {"prometheusPort": 9600},
-                "selfCheck": {"intervalSeconds": 30, "mode": "Enabled", "timeoutSeconds": 15},
-                "traces": {
-                    "cacheSizeMegabytes": 16,
-                    "mode": "Enabled",
-                    "selfTracing": {"intervalSeconds": 30, "mode": "Enabled"},
-                    "spanChannelCapacity": 1000,
-                },
-            },
-            "generateResourceLimits": {"cpu": "Disabled"},
-            "memoryProfile": "Medium",
-            "provisioningState": "Succeeded",
-        },
+        properties=default_properties,
         resource_group_name=resource_group_name,
         qualified_type="microsoft.iotoperations/instances/brokers",
         is_proxy_resource=True,
@@ -134,3 +150,378 @@ def test_broker_delete(mocked_cmd, mocked_responses: responses):
         wait_sec=0.25,
     )
     assert len(mocked_responses.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "existing_persistence_config",
+    [
+        # No persistence configuration - should raise ValidationError
+        None,
+        # Basic persistence configuration with maxSize
+        {
+            "maxSize": "10Gi",
+            "retain": {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Enabled"}}},
+            "stateStore": {"mode": "Custom", "stateStoreSettings": {"dynamic": {"mode": "Enabled"}}},
+            "subscriberQueue": {"mode": "Custom", "subscriberQueueSettings": {"dynamic": {"mode": "Enabled"}}},
+        },
+        # Persistence with All modes
+        {
+            "maxSize": "5Gi",
+            "retain": {"mode": "All"},
+            "stateStore": {"mode": "All"},
+            "subscriberQueue": {"mode": "All"},
+        },
+        # Persistence with None modes
+        {
+            "maxSize": "20Gi",
+            "retain": {"mode": "None"},
+            "stateStore": {"mode": "None"},
+            "subscriberQueue": {"mode": "None"},
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        # Test error case - no persistence enabled
+        {
+            "input": {"persist_mode": ["retain=Custom"]},
+            "persistence_required": True,
+            "error": (
+                ValidationError,
+                "The broker is not enabled for disk persistence which must be configured at create time.\nUse 'az iot ops create' with '--persist-max-size' to enable.",
+            ),
+        },
+        # Test basic mode updates
+        {
+            "input": {"persist_mode": ["retain=All", "stateStore=None"]},
+            "expected_updates": {
+                "retain": {"mode": "All"},
+                "stateStore": {"mode": "None"},
+            },
+        },
+        {
+            "input": {"persist_mode": ["subscriberQueue=Custom"]},
+            "expected_updates": {
+                "subscriberQueue": {"mode": "Custom", "subscriberQueueSettings": {"dynamic": {"mode": "Enabled"}}},
+            },
+        },
+        # Test retain topics configuration
+        {
+            "input": {"persist_mode": ["retain=Custom"], "retain_topics": ["topic1", "topic2", "topic3"]},
+            "expected_updates": {
+                "retain": {"mode": "Custom", "retainSettings": {"topics": ["topic1", "topic2", "topic3"]}},
+            },
+        },
+        # Test subscriber queue client IDs
+        {
+            "input": {
+                "persist_mode": ["subscriberQueue=Custom"],
+                "subscriber_queue_client_ids": ["client1", "client2"],
+            },
+            "expected_updates": {
+                "subscriberQueue": {
+                    "mode": "Custom",
+                    "subscriberQueueSettings": {"subscriberClientIds": ["client1", "client2"]},
+                },
+            },
+        },
+        # Test state store keys - simple case
+        {
+            "input": {
+                "persist_mode": ["stateStore=Custom"],
+                "state_store_str_keys": [["key1"], ["key2"]],
+                "state_store_glob_keys": [["pattern*"], ["*.json"]],
+                "state_store_bin_keys": [["binkey1"]],
+            },
+            "expected_updates": {
+                "stateStore": {
+                    "mode": "Custom",
+                    "stateStoreSettings": {
+                        "stateStoreResources": [
+                            {"keys": ["key1"], "keyType": "String"},
+                            {"keys": ["key2"], "keyType": "String"},
+                            {"keys": ["pattern*"], "keyType": "Pattern"},
+                            {"keys": ["*.json"], "keyType": "Pattern"},
+                            {"keys": ["binkey1"], "keyType": "Binary"},
+                        ]
+                    },
+                },
+            },
+        },
+        # Test state store keys - complex multiple keys per group
+        {
+            "input": {
+                "persist_mode": ["stateStore=Custom"],
+                "state_store_str_keys": [["key1", "key2", "key3"], ["key4"], ["key5", "key6"]],
+                "state_store_glob_keys": [["sensor/*", "device/*"], ["*.json", "*.xml", "*.csv"]],
+                "state_store_bin_keys": [["binkey1", "binkey2"], ["binkey3"]],
+            },
+            "expected_updates": {
+                "stateStore": {
+                    "mode": "Custom",
+                    "stateStoreSettings": {
+                        "stateStoreResources": [
+                            {"keys": ["key1", "key2", "key3"], "keyType": "String"},
+                            {"keys": ["key4"], "keyType": "String"},
+                            {"keys": ["key5", "key6"], "keyType": "String"},
+                            {"keys": ["sensor/*", "device/*"], "keyType": "Pattern"},
+                            {"keys": ["*.json", "*.xml", "*.csv"], "keyType": "Pattern"},
+                            {"keys": ["binkey1", "binkey2"], "keyType": "Binary"},
+                            {"keys": ["binkey3"], "keyType": "Binary"},
+                        ]
+                    },
+                },
+            },
+        },
+        # Test state store keys - only string keys with multiple groups
+        {
+            "input": {
+                "persist_mode": ["stateStore=Custom"],
+                "state_store_str_keys": [
+                    ["user:1001", "user:1002", "user:1003"],
+                    ["session:active"],
+                    ["config:database", "config:cache", "config:logging", "config:security"],
+                    ["temp:cleanup"],
+                ],
+            },
+            "expected_updates": {
+                "stateStore": {
+                    "mode": "Custom",
+                    "stateStoreSettings": {
+                        "stateStoreResources": [
+                            {"keys": ["user:1001", "user:1002", "user:1003"], "keyType": "String"},
+                            {"keys": ["session:active"], "keyType": "String"},
+                            {
+                                "keys": ["config:database", "config:cache", "config:logging", "config:security"],
+                                "keyType": "String",
+                            },
+                            {"keys": ["temp:cleanup"], "keyType": "String"},
+                        ]
+                    },
+                },
+            },
+        },
+        # Test user property configuration
+        {
+            "input": {"user_property_key": "myKey", "user_property_value": "myValue"},
+            "expected_updates": {
+                "dynamicSettings": {
+                    "userPropertyKey": "myKey",
+                    "userPropertyValue": "myValue",
+                },
+            },
+        },
+        # Test disable dynamic configuration
+        {
+            "input": {
+                "persist_mode": ["retain=Custom", "stateStore=Custom"],
+                "disable_dynamic": ["retain", "stateStore"],
+            },
+            "expected_updates": {
+                "retain": {"mode": "Custom", "retainSettings": {"dynamic": {"mode": "Disabled"}}},
+                "stateStore": {"mode": "Custom", "stateStoreSettings": {"dynamic": {"mode": "Disabled"}}},
+            },
+        },
+        # Test complex scenario with multiple configurations
+        {
+            "input": {
+                "persist_mode": ["retain=Custom", "subscriberQueue=All"],
+                "retain_topics": ["sensor/*", "telemetry/+"],
+                "user_property_key": "persistence",
+                "user_property_value": "enabled",
+            },
+            "expected_updates": {
+                "retain": {"mode": "Custom", "retainSettings": {"topics": ["sensor/*", "telemetry/+"]}},
+                "subscriberQueue": {"mode": "All"},
+                "dynamicSettings": {
+                    "userPropertyKey": "persistence",
+                    "userPropertyValue": "enabled",
+                },
+            },
+        },
+        # Test custom broker name
+        {
+            "input": {"persist_mode": ["retain=None"], "broker_name": "custom-broker"},
+            "expected_updates": {
+                "retain": {"mode": "None"},
+            },
+        },
+        # Test error cases for invalid configurations
+        {
+            "input": {"retain_topics": ["topic1"]},
+            "error": (
+                InvalidArgumentValueError,
+                "To set retain topics for persistence, the retain mode must be set to 'Custom'.",
+            ),
+        },
+        {
+            "input": {"subscriber_queue_client_ids": ["client1"]},
+            "error": (
+                InvalidArgumentValueError,
+                "To set subscriber queue client Ids for persistence, the subscriber queue mode must be set to 'Custom'.",
+            ),
+        },
+        {
+            "input": {"state_store_str_keys": [["key1"]]},
+            "error": (
+                InvalidArgumentValueError,
+                "To set state store keys for persistence, the state store mode must be set to 'Custom'.",
+            ),
+        },
+        {
+            "input": {"user_property_key": "key"},
+            "error": (InvalidArgumentValueError, "Both --user-key and --user-value must be set or both must be unset."),
+        },
+        {
+            "input": {"user_property_value": "value"},
+            "error": (InvalidArgumentValueError, "Both --user-key and --user-value must be set or both must be unset."),
+        },
+        {
+            "input": {"persist_mode": ["retain=All"], "disable_dynamic": ["retain"]},
+            "error": (
+                InvalidArgumentValueError,
+                "To disable dynamic persistence for retain, the retain mode must be set to 'Custom'.",
+            ),
+        },
+        {
+            "input": {"persist_mode": ["invalid=Custom"]},
+            "error": (
+                InvalidArgumentValueError,
+                "Invalid persistence mode key: invalid. Valid keys are ['stateStore', 'retain', 'subscriberQueue'].",
+            ),
+        },
+        {
+            "input": {"persist_mode": ["retain=Invalid"]},
+            "error": (
+                InvalidArgumentValueError,
+                "Invalid persistence mode value: Invalid. Valid values are ['None', 'All', 'Custom'].",
+            ),
+        },
+    ],
+)
+def test_update_broker_persist(
+    mocked_cmd,
+    mocked_responses: responses,
+    scenario: dict,
+    existing_persistence_config: Optional[dict],
+):
+    # Skip incompatible test combinations
+    persistence_required = scenario.get("persistence_required", False)
+    if (existing_persistence_config is None and not persistence_required) or (
+        persistence_required and existing_persistence_config is not None
+    ):
+        return
+
+    # Setup test data
+    instance_name = generate_random_string()
+    resource_group_name = generate_random_string()
+    scenario_inputs = scenario.get("input", {})
+    broker_name = scenario_inputs.get("broker_name", DEFAULT_BROKER)
+    test_inputs = {k: v for k, v in scenario_inputs.items() if k != "broker_name"}
+
+    # Create mock broker
+    broker_properties = {"persistence": deepcopy(existing_persistence_config)} if existing_persistence_config else {}
+    mock_broker_record = get_mock_broker_record(
+        broker_name=broker_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        properties=broker_properties,
+    )
+
+    endpoint = get_broker_endpoint(
+        resource_group_name=resource_group_name, instance_name=instance_name, broker_name=broker_name
+    )
+
+    # Add GET mock
+    mocked_responses.add(method=responses.GET, url=endpoint, json=mock_broker_record, status=200)
+
+    # Determine expected outcome
+    error_info = scenario.get("error")
+    expected_updates = scenario.get("expected_updates", {})
+
+    # Handle dynamic error-to-success conversion for configuration-dependent scenarios
+    if error_info and existing_persistence_config:
+        # Check if error scenario should actually succeed based on existing persistence modes
+        should_succeed = False
+
+        if "retain_topics" in scenario_inputs:
+            should_succeed = existing_persistence_config.get("retain", {}).get("mode") == "Custom"
+            if should_succeed:
+                expected_updates = {
+                    "retain": {"mode": "Custom", "retainSettings": {"topics": scenario_inputs["retain_topics"]}}
+                }
+        elif "subscriber_queue_client_ids" in scenario_inputs:
+            should_succeed = existing_persistence_config.get("subscriberQueue", {}).get("mode") == "Custom"
+            if should_succeed:
+                expected_updates = {
+                    "subscriberQueue": {
+                        "mode": "Custom",
+                        "subscriberQueueSettings": {
+                            "subscriberClientIds": scenario_inputs["subscriber_queue_client_ids"]
+                        },
+                    }
+                }
+        elif any(
+            k in scenario_inputs for k in ["state_store_str_keys", "state_store_glob_keys", "state_store_bin_keys"]
+        ):
+            should_succeed = existing_persistence_config.get("stateStore", {}).get("mode") == "Custom"
+            if should_succeed:
+                resources = []
+                for collection, key_type in zip(
+                    [
+                        scenario_inputs.get("state_store_str_keys", []),
+                        scenario_inputs.get("state_store_glob_keys", []),
+                        scenario_inputs.get("state_store_bin_keys", []),
+                    ],
+                    ["String", "Pattern", "Binary"],
+                ):
+                    for item in collection:
+                        resources.append({"keys": item, "keyType": key_type})
+                expected_updates = {
+                    "stateStore": {"mode": "Custom", "stateStoreSettings": {"stateStoreResources": resources}}
+                }
+
+        if should_succeed:
+            error_info = None
+
+    # Execute test
+    if error_info:
+        # Test error case
+        error_type, error_msg = error_info
+        with pytest.raises(error_type) as exc:
+            update_broker_persist(
+                cmd=mocked_cmd,
+                instance_name=instance_name,
+                resource_group_name=resource_group_name,
+                broker_name=broker_name,
+                **test_inputs,
+            )
+        assert str(exc.value) == error_msg
+    else:
+        # Test success case
+        expected_broker_record = deepcopy(mock_broker_record)
+        if expected_updates:
+            expected_broker_record["properties"]["persistence"].update(expected_updates)
+
+        mocked_responses.add(method=responses.PUT, url=endpoint, json=expected_broker_record, status=200)
+
+        result = update_broker_persist(
+            cmd=mocked_cmd,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            broker_name=broker_name,
+            wait_sec=0.1,
+            **test_inputs,
+        )
+
+        assert result == expected_broker_record
+        assert len(mocked_responses.calls) == 2
+
+        # Verify PUT request payload
+        request_payload = mocked_responses.calls[1].request.body
+        if isinstance(request_payload, bytes):
+            request_payload = json.loads(request_payload.decode())
+        else:
+            request_payload = json.loads(request_payload)
+        assert request_payload == expected_broker_record

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -329,7 +329,11 @@ def verify_broker_config(target_scenario: dict, parameters: dict):
 
     if "persist_mode" in target_scenario:
         for k, v in target_scenario["persist_mode"].items():
-            assert parameters["brokerConfig"]["value"]["persistence"][k] == {"mode": v}
+            expected_payload = {"mode": v}
+            if v == "Custom":
+                expected_payload[k + "Settings"] = {"dynamic": {"mode": "Enabled"}}
+
+            assert parameters["brokerConfig"]["value"]["persistence"][k] == expected_payload
             explicit_mode_keys[k] = True
 
     for k in explicit_mode_keys:
@@ -489,7 +493,7 @@ def test_get_merged_acs_config(enable_fault_tolerance: bool, acs_config: Optiona
                 resource_group_name=generate_random_string(),
                 persist_mode=["a=b", "c=d"],
             ),
-            "Provide a persist max size value to enable and customize broker data persistence.",
+            "Provide a persist max size value to enable and customize broker disk persistence.",
         ),
         (
             build_target_scenario(
@@ -508,6 +512,64 @@ def test_get_merged_acs_config(enable_fault_tolerance: bool, acs_config: Optiona
                 persist_mode=["stateStore=All", "retain=d"],
             ),
             "Invalid persistence mode value: d. Valid values are ['None', 'All', 'Custom'].",
+        ),
+        (
+            build_target_scenario(
+                cluster_name=generate_random_string(),
+                resource_group_name=generate_random_string(),
+                schema_registry_resource_id=generate_random_string(),
+            ),
+            "--sr-resource-id is malformed. An Azure resource Id has the form:\n"
+            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers"
+            "/Microsoft.Provider/{resourceType}/{resourceName}",
+        ),
+        (
+            build_target_scenario(
+                cluster_name=generate_random_string(),
+                resource_group_name=generate_random_string(),
+                schema_registry_resource_id=get_schema_registry_id(),
+                adr_namespace_resource_id=generate_random_string(),
+            ),
+            "--ns-resource-id is malformed. An Azure resource Id has the form:\n"
+            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers"
+            "/Microsoft.Provider/{resourceType}/{resourceName}",
+        ),
+        (
+            build_target_scenario(
+                cluster_name=generate_random_string(),
+                resource_group_name=generate_random_string(),
+                schema_registry_resource_id=get_resource_id(
+                    resource_provider="Microsoft.Storage",
+                    resource_group_name=generate_random_string(),
+                    resource_path="/storageAccounts/mystorageaccount",
+                ),
+                adr_namespace_resource_id=get_ns_resource_id(
+                    resource_group_name="myresourcegroup",
+                ),
+            ),
+            "--sr-resource-id value must be of type Microsoft.DeviceRegistry/schemaRegistries.",
+        ),
+        (
+            build_target_scenario(
+                cluster_name=generate_random_string(),
+                resource_group_name="instancegroup",
+                schema_registry_resource_id=get_schema_registry_id(),
+                adr_namespace_resource_id=get_ns_resource_id(),
+            ),
+            "--ns-resource-id value must match the resource group 'instancegroup'.",
+        ),
+        (
+            build_target_scenario(
+                cluster_name=generate_random_string(),
+                resource_group_name="myresourcegroup",
+                schema_registry_resource_id=get_schema_registry_id(),
+                adr_namespace_resource_id=get_resource_id(
+                    resource_provider="Microsoft.Storage",
+                    resource_group_name="myresourcegroup",
+                    resource_path="/storageAccounts/mystorageaccount",
+                ),
+            ),
+            "--ns-resource-id value must be of type Microsoft.DeviceRegistry/namespaces.",
         ),
     ],
 )

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -607,7 +607,7 @@ def assert_cluster_prechecks(mock_prechecks: Dict[str, Mock], target_scenario: d
             persist_pvc_sc="default",
             raises=ExceptionMeta(
                 exc_type=InvalidArgumentValueError,
-                exc_msg="Provide a persist max size value to enable and customize broker data persistence.",
+                exc_msg="Provide a persist max size value to enable and customize broker disk persistence.",
             ),
             omit_http_methods=frozenset([responses.PUT, responses.POST, responses.GET, responses.HEAD]),
         ),
@@ -759,7 +759,7 @@ def assert_cluster_prechecks(mock_prechecks: Dict[str, Mock], target_scenario: d
             },
             raises=ExceptionMeta(
                 exc_type=InvalidArgumentValueError,
-                exc_msg=re.compile(r"Resource Id '(.+)' does not match the instance resource group '(.+)'."),
+                exc_msg=re.compile(r"--ns-resource-id value must match the resource group '(.+)'."),
             ),
             omit_http_methods=frozenset([responses.PUT, responses.POST, responses.GET, responses.HEAD]),
         ),

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -33,3 +33,8 @@ iot ops ns device create:
     instance_resource_group:
       rule_exclusions:
       - parameter_should_not_end_in_resource_group
+iot ops broker update:
+  parameters:
+    broker_name:
+      rule_exclusions:
+      - no_parameter_defaults_for_update_commands

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -33,7 +33,7 @@ iot ops ns device create:
     instance_resource_group:
       rule_exclusions:
       - parameter_should_not_end_in_resource_group
-iot ops broker update:
+iot ops broker persist update:
   parameters:
     broker_name:
       rule_exclusions:


### PR DESCRIPTION
* Adds `az iot ops broker persist update` for post-deploy update.
* Adds test coverage for above.
* Adds resource Id validation by adding context dict responsibility to `targets.ensure_resource_id`.
* Set default broker name to `default` for `broker show` and `broker delete`.