### PR TITLE
feat: use 2025-07-01-preview for ADR across the board.

### DIFF
--- a/azext_edge/edge/providers/adr/asset_endpoint_profiles.py
+++ b/azext_edge/edge/providers/adr/asset_endpoint_profiles.py
@@ -16,11 +16,11 @@ from knack.log import get_logger
 from rich.console import Console
 
 from ...util.az_client import (
-    DeviceRegistryMgmtApiVersion,
     get_registry_mgmt_client,
     wait_for_terminal_state,
 )
 from ...util.queryable import Queryable
+from .common import ADRAuthModes, AEPTypes
 from .user_strings import (
     AUTH_REF_MISMATCH_ERROR,
     GENERAL_AUTH_REF_MISMATCH_ERROR,
@@ -28,7 +28,6 @@ from .user_strings import (
     REMOVED_CERT_REF_MSG,
     REMOVED_USERPASS_REF_MSG,
 )
-from .common import ADRAuthModes, AEPTypes
 
 if TYPE_CHECKING:
     from ...vendor.clients.deviceregistrymgmt.operations import (
@@ -44,8 +43,7 @@ class AssetEndpointProfiles(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20241101
+            subscription_id=self.default_subscription_id
         )
         self.ops: "AEPOperations" = self.deviceregistry_mgmt_client.asset_endpoint_profiles
 

--- a/azext_edge/edge/providers/adr/assets.py
+++ b/azext_edge/edge/providers/adr/assets.py
@@ -14,15 +14,14 @@ from azure.cli.core.azclierror import (
 from knack.log import get_logger
 from rich.console import Console
 
-from .helpers import get_default_dataset
-from .common import FileType
 from ...util import assemble_nargs_to_dict
 from ...util.az_client import (
-    DeviceRegistryMgmtApiVersion,
     get_registry_mgmt_client,
     wait_for_terminal_state,
 )
 from ...util.queryable import Queryable
+from .common import FileType
+from .helpers import get_default_dataset
 from .user_strings import (
     DUPLICATE_EVENT_ERROR,
     DUPLICATE_POINT_ERROR,
@@ -44,8 +43,7 @@ class Assets(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20241101
+            subscription_id=self.default_subscription_id
         )
         self.ops: "AssetsOperations" = self.deviceregistry_mgmt_client.assets
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -4,35 +4,37 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from copy import deepcopy
 import json
-from rich.console import Console
+from copy import deepcopy
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
-from knack.log import get_logger
 
 from azure.cli.core.azclierror import (
     InvalidArgumentValueError,
     MutuallyExclusiveArgumentError,
     RequiredArgumentMissingError,
 )
+from knack.log import get_logger
+from rich.console import Console
 
-from ...util.common import parse_kvp_nargs, should_continue_prompt
 from ...util.az_client import (
     get_registry_mgmt_client,
     get_resource_client,
     wait_for_terminal_state,
-    DeviceRegistryMgmtApiVersion
 )
+from ...util.common import parse_kvp_nargs, should_continue_prompt
 from ...util.id_tools import parse_resource_id
 from ...util.queryable import Queryable
 from .helpers import (
-    process_additional_configuration, ensure_schema_structure, get_default_dataset
+    ensure_schema_structure,
+    get_default_dataset,
+    process_additional_configuration,
 )
 from .namespace_devices import DeviceEndpointType
 
 if TYPE_CHECKING:
     from ...vendor.clients.deviceregistrymgmt.operations import (
-        NamespaceAssetsOperations, NamespaceDevicesOperations
+        NamespaceAssetsOperations,
+        NamespaceDevicesOperations,
     )
     from ...vendor.clients.resourcesmgmt.operations import ResourcesOperations
 
@@ -46,8 +48,7 @@ class NamespaceAssets(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20250701_preview
+            subscription_id=self.default_subscription_id
         )
         self.resource_mgmt_client = get_resource_client(
             subscription_id=self.default_subscription_id
@@ -1984,7 +1985,11 @@ def _process_media_stream_configurations(
     media_server_certificate: Optional[str] = None,
     **_
 ) -> str:
-    from .specs import NAMESPACE_ASSET_MEDIA_STREAM_CONFIGURATION_SCHEMA, MediaFormat, MediaTaskType
+    from .specs import (
+        NAMESPACE_ASSET_MEDIA_STREAM_CONFIGURATION_SCHEMA,
+        MediaFormat,
+        MediaTaskType,
+    )
     result = json.loads(original_stream_configuration) if original_stream_configuration else {}
 
     task_type = task_type or result.get("taskType")

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -5,25 +5,27 @@
 # ----------------------------------------------------------------------------------------------
 
 import json
-from rich.console import Console
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
-from knack.log import get_logger
 
 from azure.cli.core.azclierror import InvalidArgumentValueError
+from knack.log import get_logger
+from rich.console import Console
 
+from ...common import ListableEnum
 from ...util.az_client import (
     get_registry_mgmt_client,
     get_resource_client,
     wait_for_terminal_state,
-    DeviceRegistryMgmtApiVersion
 )
-from ...util.id_tools import parse_resource_id
 from ...util.common import parse_kvp_nargs, should_continue_prompt
+from ...util.id_tools import parse_resource_id
 from ...util.queryable import Queryable
-from ...common import ListableEnum
 
 if TYPE_CHECKING:
-    from ...vendor.clients.deviceregistrymgmt.operations import NamespacesOperations, NamespaceDevicesOperations
+    from ...vendor.clients.deviceregistrymgmt.operations import (
+        NamespaceDevicesOperations,
+        NamespacesOperations,
+    )
     from ...vendor.clients.resourcesmgmt.operations import ResourcesOperations
 
 
@@ -60,8 +62,7 @@ class NamespaceDevices(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20250701_preview
+            subscription_id=self.default_subscription_id
         )
         self.resource_mgmt_client = get_resource_client(
             subscription_id=self.default_subscription_id
@@ -299,7 +300,7 @@ class NamespaceDevices(Queryable):
         replace: Optional[bool] = False,
         **kwargs
     ):
-        from .helpers import process_authentication, process_additional_configuration
+        from .helpers import process_additional_configuration, process_authentication
         # get the original inbound endpoints
         device = self.show(
             device_name=device_name,
@@ -487,8 +488,8 @@ def _process_opcua_configuration(
     Creates a stringified JSON that follows the OPC UA endpoint schema specifications
     defined in NAMESPACE_DEVICE_OPCUA_ENDPOINT_SCHEMA.
     """
-    from .specs import NAMESPACE_DEVICE_OPCUA_ENDPOINT_SCHEMA
     from .helpers import ensure_schema_structure
+    from .specs import NAMESPACE_DEVICE_OPCUA_ENDPOINT_SCHEMA
 
     if security_policy:
         security_policy = "http://opcfoundation.org/UA/SecurityPolicy#" + security_policy

--- a/azext_edge/edge/providers/adr/namespaces.py
+++ b/azext_edge/edge/providers/adr/namespaces.py
@@ -4,12 +4,15 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from rich.console import Console
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
+
 from knack.log import get_logger
+from rich.console import Console
 
 from ...util.az_client import (
-    get_registry_mgmt_client, get_resource_client, wait_for_terminal_state, DeviceRegistryMgmtApiVersion
+    get_registry_mgmt_client,
+    get_resource_client,
+    wait_for_terminal_state,
 )
 from ...util.common import should_continue_prompt
 from ...util.queryable import Queryable
@@ -27,8 +30,7 @@ class Namespaces(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20250701_preview
+            subscription_id=self.default_subscription_id
         )
         self.resource_mgmt_client = get_resource_client(
             subscription_id=self.default_subscription_id

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -22,7 +22,6 @@ from ....util.az_client import (
     get_storage_mgmt_client,
     parse_resource_id,
     wait_for_terminal_state,
-    DeviceRegistryMgmtApiVersion,
 )
 from ....util.common import should_continue_prompt
 from ....util.queryable import Queryable
@@ -56,9 +55,7 @@ class SchemaRegistries(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.registry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            # TODO: Is this preview version still necessary?
-            api_version=DeviceRegistryMgmtApiVersion.V20240901_preview,
+            subscription_id=self.default_subscription_id
         )
         self.ops: "SchemaRegistriesOperations" = self.registry_mgmt_client.schema_registries
 
@@ -187,8 +184,7 @@ class Schemas(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.registry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
-            api_version=DeviceRegistryMgmtApiVersion.V20240901_preview,
+            subscription_id=self.default_subscription_id
         )
         self.ops: "SchemasOperations" = self.registry_mgmt_client.schemas
         self.version_ops: "SchemaVersionsOperations" = self.registry_mgmt_client.schema_versions

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -432,13 +432,13 @@ class WorkManager:
             if self._targets.instance_name:
                 self._headers["CommandName"] = "iot ops create"
                 # Ensure schema registry and namespace resources exist.
-                for resource_id, api_version in [
-                    (self._targets.schema_registry_resource_id, DeviceRegistryMgmtApiVersion.V20240901_preview.value),
-                    (self._targets.adr_namespace_resource_id, DeviceRegistryMgmtApiVersion.V20250701_preview.value),
+                for resource_id in [
+                    self._targets.schema_registry_resource_id,
+                    self._targets.adr_namespace_resource_id,
                 ]:
                     self.resource_client.resources.get_by_id(
                         resource_id=resource_id,
-                        api_version=api_version,
+                        api_version=DeviceRegistryMgmtApiVersion.V20250701_preview.value,
                     )
 
                 self._process_extension_dependencies()

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -144,7 +144,7 @@ class DeviceRegistryMgmtApiVersion(Enum):
 
 def get_registry_mgmt_client(
     subscription_id: str,
-    api_version: Union[DeviceRegistryMgmtApiVersion, str] = DeviceRegistryMgmtApiVersion.V20241101,
+    api_version: Union[DeviceRegistryMgmtApiVersion, str] = DeviceRegistryMgmtApiVersion.V20250701_preview,
     **kwargs,
 ) -> "MicrosoftDeviceRegistryManagementService":
     from ..vendor.clients.deviceregistrymgmt import (

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_registry_unit.py
@@ -22,6 +22,7 @@ from azext_edge.edge.providers.orchestration.resources.schema_registries import 
     STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE_ID,
 )
 from azext_edge.edge.providers.orchestration.rp_namespace import ADR_PROVIDER
+from azext_edge.edge.util.az_client import DeviceRegistryMgmtApiVersion
 
 from ....generators import generate_random_string
 from .conftest import (
@@ -33,7 +34,7 @@ from .conftest import (
 )
 
 SCHEMA_REGISTRY_RP = "Microsoft.DeviceRegistry"
-SCHEMA_REGISTRY_RP_API_VERSION = "2024-09-01-preview"
+SCHEMA_REGISTRY_RP_API_VERSION = DeviceRegistryMgmtApiVersion.V20250701_preview.value
 STORAGE_RP = "Microsoft.Storage"
 STORAGE_API_VERSION = "2023-05-01"
 RESOURCES_API_VERSION = "2024-03-01"

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_unit.py
@@ -12,21 +12,23 @@ import pytest
 import responses
 
 from azext_edge.edge.commands_schema import (
+    add_version,
     create_schema,
     delete_schema,
     list_schemas,
-    show_schema,
-    add_version,
-    show_version,
     list_versions,
-    remove_version
+    remove_version,
+    show_schema,
+    show_version,
 )
 from azext_edge.edge.providers.orchestration.common import SchemaFormat, SchemaType
+from azext_edge.edge.util.az_client import DeviceRegistryMgmtApiVersion
+
 from ....generators import generate_random_string
 from .conftest import get_base_endpoint, get_mock_resource
 
 SCHEMA_RP = "Microsoft.DeviceRegistry"
-SCHEMA_REGISTRY_RP_API_VERSION = "2024-09-01-preview"
+SCHEMA_REGISTRY_RP_API_VERSION = DeviceRegistryMgmtApiVersion.V20250701_preview.value
 
 
 def get_schema_endpoint(
@@ -455,7 +457,7 @@ def test_version_add(mocked_cmd, mocked_responses: responses, description: Optio
 
 
 def test_version_add_error(mocked_cmd, mocked_responses: responses):
-    from azure.cli.core.azclierror import InvalidArgumentValueError, ForbiddenError
+    from azure.cli.core.azclierror import ForbiddenError, InvalidArgumentValueError
     from azure.core.exceptions import HttpResponseError
     # bad version
     with pytest.raises(InvalidArgumentValueError):

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -79,7 +79,7 @@ class ExpectedAPIVersion(Enum):
     CONNECTED_CLUSTER = "2024-07-15-preview"
     CLUSTER_EXTENSION = "2023-05-01"
     RESOURCE = "2024-03-01"
-    SCHEMA_REGISTRY = "2024-09-01-preview"
+    SCHEMA_REGISTRY = "2025-07-01-preview"
     ADR_NAMESPACE = "2025-07-01-preview"
     AUTHORIZATION = "2022-04-01"
     CUSTOM_LOCATION = "2021-08-31-preview"


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
