### PR TITLE
refactor: improve namespace device inbound endpoint list; namespace asset and device query commands

### DIFF
--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -371,13 +371,15 @@ def list_inbound_device_endpoints(
     cmd,
     device_name: str,
     instance_name: str,
-    instance_resource_group: str
+    instance_resource_group: str,
+    inbound_endpoint_type: Optional[str] = None,
 ) -> dict:
     return NamespaceDevices(cmd).list_endpoints(
         device_name=device_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
-        inbound=True
+        inbound=True,
+        inbound_endpoint_type=inbound_endpoint_type
     )
 
 

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -99,17 +99,25 @@ def create_namespace_device(
 def query_namespace_devices(
     cmd,
     device_name: Optional[str] = None,
+    instance_name: Optional[str] = None,
+    instance_resource_group: Optional[str] = None,
     custom_query: Optional[str] = None,
+    disabled: Optional[bool] = None,
     manufacturer: Optional[str] = None,
     model: Optional[str] = None,
     operating_system: Optional[str] = None,
+    operating_system_version: Optional[str] = None,
 ) -> dict:
     return NamespaceDevices(cmd).query_devices(
         device_name=device_name,
+        disabled=disabled,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
         custom_query=custom_query,
         manufacturer=manufacturer,
         model=model,
-        operating_system=operating_system
+        operating_system=operating_system,
+        operating_system_version=operating_system_version,
     )
 
 
@@ -1050,15 +1058,41 @@ def update_namespace_rest_asset(
 def query_namespace_assets(
     cmd,
     asset_name: Optional[str] = None,
+    instance_name: Optional[str] = None,
+    instance_resource_group: Optional[str] = None,
     custom_query: Optional[str] = None,
     device_name: Optional[str] = None,
     device_endpoint_name: Optional[str] = None,
+    disabled: Optional[bool] = None,
+    display_name: Optional[str] = None,
+    documentation_uri: Optional[str] = None,
+    external_asset_id: Optional[str] = None,
+    hardware_revision: Optional[str] = None,
+    manufacturer: Optional[str] = None,
+    manufacturer_uri: Optional[str] = None,
+    model: Optional[str] = None,
+    product_code: Optional[str] = None,
+    serial_number: Optional[str] = None,
+    software_revision: Optional[str] = None,
 ) -> dict:
     return NamespaceAssets(cmd).query_assets(
         asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
         custom_query=custom_query,
         device_name=device_name,
-        device_endpoint_name=device_endpoint_name
+        device_endpoint_name=device_endpoint_name,
+        disabled=disabled,
+        display_name=display_name,
+        documentation_uri=documentation_uri,
+        external_asset_id=external_asset_id,
+        hardware_revision=hardware_revision,
+        manufacturer=manufacturer,
+        manufacturer_uri=manufacturer_uri,
+        model=model,
+        product_code=product_code,
+        serial_number=serial_number,
+        software_revision=software_revision,
     )
 
 

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -671,7 +671,7 @@ def load_iotops_adr_help():
             az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup --endpoint-type media
         - name: List all Media endpoints of a device using the full endpoint type
           text: >
-            az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup --endpoint-type Microsft.Media
+            az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup --endpoint-type Microsoft.Media
     """
 
     helps[

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -852,7 +852,7 @@ def load_iotops_adr_help():
 
         - name: Query for assets associated with a specific device and endpoint
           text: >
-            az iot ops ns asset query --device mydevice --endpoint-name myEndpoint
+            az iot ops ns asset query --device mydevice --endpoint myEndpoint
 
         - name: Use a custom query to search for assets
           text: >
@@ -888,24 +888,24 @@ def load_iotops_adr_help():
         - name: Create a basic custom asset
           text: >
             az iot ops ns asset custom create --name mycustomasset --instance myInstance -g myInstanceResourceGroup
-            --device mydevice --endpoint-name myEndpoint
+            --device mydevice --endpoint myEndpoint
 
         - name: Create a custom asset with additional metadata
           text: >
             az iot ops ns asset custom create --name mycustomasset --instance myInstance -g myInstanceResourceGroup
-            --device mydevice --endpoint-name myEndpoint --description "Factory sensor" --display-name "Temperature Sensor"
+            --device mydevice --endpoint myEndpoint --description "Factory sensor" --display-name "Temperature Sensor"
             --model "TempSensor-X1" --manufacturer "Contoso" --serial-number "SN12345"
 
         - name: Create a custom asset with dataset and events configuration using inline JSON
           text: >
             az iot ops ns asset custom create --name mycustomasset --instance myInstance -g myInstanceResourceGroup
-            --device mydevice --endpoint-name myEndpoint --dataset-config "{\\\"publishingInterval\\\": 1000}"
+            --device mydevice --endpoint myEndpoint --dataset-config "{\\\"publishingInterval\\\": 1000}"
             --event-config "{\\\"queueSize\\\": 5}"
 
         - name: Create a custom asset with datasets use a BrokerStateStore destination, events use a Mqtt destination, and streams use a Storage destination.
           text: >
             az iot ops ns asset custom create --name mycustomasset --instance myInstance -g myInstanceResourceGroupmyResourceGroup
-            --device mydevice --endpoint-name myEndpoint
+            --device mydevice --endpoint myEndpoint
             --dataset-dest key="myKey"
             --event-dest topic="factory/events/temperature/updated" qos=Qos0 retain=Never ttl=3600
             --stream-dest path="my/storage/path"
@@ -1526,31 +1526,31 @@ def load_iotops_adr_help():
         - name: Create a basic media asset
           text: >
             az iot ops ns asset media create --name mymediaasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myCameraEndpoint
+            --device myCamera --endpoint myCameraEndpoint
 
         - name: Create a media asset for MQTT snapshots with an MQTT destination
           text: >
             az iot ops ns asset media create --name mymediaasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myCameraEndpoint --task-type snapshot-to-mqtt
+            --device myCamera --endpoint myCameraEndpoint --task-type snapshot-to-mqtt
             --task-format jpeg --snapshots-per-sec 1
             --stream-dest topic="factory/cameras/snapshots" qos=Qos1 retain=Never ttl=60
 
         - name: Create a media asset for file system snapshots
           text: >
             az iot ops ns asset media create --name mymediaasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myCameraEndpoint --task-type snapshot-to-fs
+            --device myCamera --endpoint myCameraEndpoint --task-type snapshot-to-fs
             --task-format png --snapshots-per-sec 5 --path "/data/snapshots"
 
         - name: Create a media asset for file system clips
           text: >
             az iot ops ns asset media create --name mymediaasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myCameraEndpoint --task-type clip-to-fs
+            --device myCamera --endpoint myCameraEndpoint --task-type clip-to-fs
             --task-format mp4 --duration 300 --path "/data/clips"
 
         - name: Create a media asset for RTSP streaming
           text: >
             az iot ops ns asset media create --name mymediaasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myCameraEndpoint --task-type stream-to-rtsp
+            --device myCamera --endpoint myCameraEndpoint --task-type stream-to-rtsp
             --media-server-address "media-server.media-server.svc.cluster.local"
             --media-server-port 8554 --media-server-path "myCamera/stream"
     """
@@ -1745,19 +1745,19 @@ def load_iotops_adr_help():
         - name: Create a basic ONVIF asset
           text: >
             az iot ops ns asset onvif create --name myonvifasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myOnvifEndpoint
+            --device myCamera --endpoint myOnvifEndpoint
 
         - name: Create an ONVIF asset with additional metadata
           text: >
             az iot ops ns asset onvif create --name myonvifasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myOnvifEndpoint --description "Surveillance Camera"
+            --device myCamera --endpoint myOnvifEndpoint --description "Surveillance Camera"
             --display-name "Entry Camera" --model "SecureCam Pro" --manufacturer "SecurityCo"
             --serial-number "CAM-12345" --documentation-uri "https://example.com/docs/camera"
 
         - name: Create an ONVIF asset with custom attributes
           text: >
             az iot ops ns asset onvif create --name myonvifasset --instance myInstance -g myInstanceResourceGroup
-            --device myCamera --endpoint-name myOnvifEndpoint --attribute location=entrance
+            --device myCamera --endpoint myOnvifEndpoint --attribute location=entrance
             --attribute resolution=1080p --attribute ptz=true
     """
 
@@ -1989,24 +1989,24 @@ def load_iotops_adr_help():
         - name: Create a basic OPC UA asset
           text: >
             az iot ops ns asset opcua create --name myopcuaasset --instance myInstance -g myInstanceResourceGroup
-            --device myOpcuaDevice --endpoint-name myOpcuaEndpoint
+            --device myOpcuaDevice --endpoint myOpcuaEndpoint
 
         - name: Create an OPC UA asset with dataset configuration
           text: >
             az iot ops ns asset opcua create --name myopcuaasset --instance myInstance -g myInstanceResourceGroup
-            --device myOpcuaDevice --endpoint-name myOpcuaEndpoint --dataset-publish-int 1000
+            --device myOpcuaDevice --endpoint myOpcuaEndpoint --dataset-publish-int 1000
             --dataset-sampling-int 500 --dataset-queue-size 5 --dataset-key-frame-count 1
 
         - name: Create an OPC UA asset with event configuration
           text: >
             az iot ops ns asset opcua create --name myopcuaasset --instance myInstance -g myInstanceResourceGroup
-            --device myOpcuaDevice --endpoint-name myOpcuaEndpoint --event-publish-int 2000
+            --device myOpcuaDevice --endpoint myOpcuaEndpoint --event-publish-int 2000
             --event-queue-size 10
 
         - name: Create an OPC UA asset with MQTT destinations for datasets and events
           text: >
             az iot ops ns asset opcua create --name myopcuaasset --instance myInstance -g myInstanceResourceGroup
-            --device myOpcuaDevice --endpoint-name myOpcuaEndpoint
+            --device myOpcuaDevice --endpoint myOpcuaEndpoint
             --dataset-dest topic="factory/opcua/data" retain=Keep qos=Qos1 ttl=3600
             --event-dest topic="factory/opcua/events" retain=Never qos=Qos1 ttl=3600
     """
@@ -2485,36 +2485,36 @@ def load_iotops_adr_help():
         - name: Create a basic REST asset
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint
+            --device myrestdevice --endpoint myRestEndpoint
 
         - name: Create a REST asset with dataset configuration
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint --sampling-int 5000
+            --device myrestdevice --endpoint myRestEndpoint --sampling-int 5000
 
         - name: Create a REST asset with dataset destination
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint
+            --device myrestdevice --endpoint myRestEndpoint
             --dataset-dest topic="factory/rest/data" retain=Never qos=Qos1 ttl=3600
 
         - name: Create a REST asset with custom configuration and BrokerStateStore destination
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint --sampling-int 2000
+            --device myrestdevice --endpoint myRestEndpoint --sampling-int 2000
             --dataset-dest key="rest-data-cache"
 
         - name: Create a REST asset with additional metadata
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint --description "Temperature sensor API"
+            --device myrestdevice --endpoint myRestEndpoint --description "Temperature sensor API"
             --display-name "Facility Temperature Monitor" --model "TempSensor-3000" --manufacturer "SensorCorp"
             --serial-number "TS-12345" --documentation-uri "https://example.com/docs/api"
 
         - name: Create a REST asset with custom attributes
           text: >
             az iot ops ns asset rest create --name myrestasset --instance myInstance -g myInstanceResourceGroup
-            --device myrestdevice --endpoint-name myRestEndpoint --attribute location=warehouse
+            --device myrestdevice --endpoint myRestEndpoint --attribute location=warehouse
             --attribute sensor-type=temperature --attribute units=celsius
     """
 

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -553,6 +553,10 @@ def load_iotops_adr_help():
           manufacturer, model, and more.
 
         examples:
+        - name: Query for devices in an IoT Operations instance
+          text: >
+            az iot ops ns device query --instance myInstance -g myInstanceResourceGroup
+
         - name: Query for a specific device by name
           text: >
             az iot ops ns device query --name mydevice
@@ -662,6 +666,12 @@ def load_iotops_adr_help():
         - name: List all inbound endpoints of a device
           text: >
             az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup
+        - name: List all Media endpoints of a device using a keyword
+          text: >
+            az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup --endpoint-type media
+        - name: List all Media endpoints of a device using the full endpoint type
+          text: >
+            az iot ops ns device endpoint inbound list --device mydevice --instance myInstance -g myInstanceResourceGroup --endpoint-type Microsft.Media
     """
 
     helps[
@@ -832,6 +842,10 @@ def load_iotops_adr_help():
           device name, endpoint name and more.
 
         examples:
+        - name: Query for assets in an IoT Operations instance
+          text: >
+            az iot ops ns asset query --instance myInstance -g myInstanceResourceGroup
+
         - name: Query for a specific asset by name
           text: >
             az iot ops ns asset query --name myasset

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -103,6 +103,34 @@ def get_namespace_for_instance(
     return parse_resource_id(rid=namespace)
 
 
+def get_instance_query(
+    query: str,
+    instance_name: Optional[str] = None,
+    instance_resource_group: Optional[str] = None,
+    project_away_custom_location: bool = True
+) -> str:
+    """
+    Appends and returns query with instance filtering.
+    """
+    if any([instance_name, instance_resource_group]):
+        instance_query = "Resources | where type =~ 'microsoft.iotoperations/instances' "
+        if instance_name:
+            instance_query += f"| where name =~ \"{instance_name}\""
+        if instance_resource_group:
+            instance_query += f"| where resourceGroup =~ \"{instance_resource_group}\""
+
+        # fetch the custom location + join on innerunique. Then remove the extra customLocation1 generated
+        query = (
+            f"{instance_query} | extend customLocation = tostring(extendedLocation.name) "
+            "| project customLocation | join kind=innerunique "
+            f"({query} | extend customLocation = tostring(extendedLocation.name)) on customLocation "
+            "| project-away customLocation1"
+        )
+        if project_away_custom_location:
+            query += ", customLocation"
+    return query
+
+
 def get_default_dataset(asset: dict, dataset_name: str, create_if_none: bool = False):
     """
     Temporary helper function to get a dataset from an asset.

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -119,16 +119,37 @@ def get_instance_query(
         if instance_resource_group:
             instance_query += f"| where resourceGroup =~ \"{instance_resource_group}\" "
 
+        # make sure the custom location is extended
+        if "| extend customLocation = tostring(extendedLocation.name)" not in query:
+            query += " | extend customLocation = tostring(extendedLocation.name)"
+
         # fetch the custom location + join on innerunique. Then remove the extra customLocation1 generated
         query = (
             f"{instance_query}| extend customLocation = tostring(extendedLocation.name) "
             "| project customLocation | join kind=innerunique "
-            f"({query} | extend customLocation = tostring(extendedLocation.name)) on customLocation "
+            f"({query}) on customLocation "
             "| project-away customLocation1"
         )
         if project_away_custom_location:
             query += ", customLocation"
     return query
+
+
+def get_query(param_mapping: Dict[str, str], params: Dict[str, Union[str, bool]]) -> str:
+    """
+    Returns a query string based on the provided parameters and their mappings.
+
+    Disabled is treated as a boolean and should not be in the param mapping.
+    """
+    query = []
+    if "disabled" in params:
+        query.append(f"| where properties.enabled == {not params.pop('disabled')}")
+    for param, value in params.items():
+        # TODO: later, add in null support (ex: no os set)
+        if value is not None:
+            query.append(f"| where {param_mapping.get(param)} =~ \"{value}\"")
+
+    return " ".join(query)
 
 
 def get_default_dataset(asset: dict, dataset_name: str, create_if_none: bool = False):

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -115,13 +115,13 @@ def get_instance_query(
     if any([instance_name, instance_resource_group]):
         instance_query = "Resources | where type =~ 'microsoft.iotoperations/instances' "
         if instance_name:
-            instance_query += f"| where name =~ \"{instance_name}\""
+            instance_query += f"| where name =~ \"{instance_name}\" "
         if instance_resource_group:
-            instance_query += f"| where resourceGroup =~ \"{instance_resource_group}\""
+            instance_query += f"| where resourceGroup =~ \"{instance_resource_group}\" "
 
         # fetch the custom location + join on innerunique. Then remove the extra customLocation1 generated
         query = (
-            f"{instance_query} | extend customLocation = tostring(extendedLocation.name) "
+            f"{instance_query}| extend customLocation = tostring(extendedLocation.name) "
             "| project customLocation | join kind=innerunique "
             f"({query} | extend customLocation = tostring(extendedLocation.name)) on customLocation "
             "| project-away customLocation1"

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -208,30 +208,78 @@ class NamespaceAssets(Queryable):
     def query_assets(
         self,
         asset_name: Optional[str] = None,
+        instance_name: Optional[str] = None,
+        instance_resource_group: Optional[str] = None,
         custom_query: Optional[str] = None,
         device_name: Optional[str] = None,
         device_endpoint_name: Optional[str] = None,
+        disabled: Optional[bool] = None,
+        display_name: Optional[str] = None,
+        documentation_uri: Optional[str] = None,
+        external_asset_id: Optional[str] = None,
+        hardware_revision: Optional[str] = None,
+        manufacturer: Optional[str] = None,
+        manufacturer_uri: Optional[str] = None,
+        model: Optional[str] = None,
+        product_code: Optional[str] = None,
+        serial_number: Optional[str] = None,
+        software_revision: Optional[str] = None,
     ) -> dict:
         """
         Queries the asset using Azure Resource Graph.
         """
+        from .helpers import get_instance_query
         query = "Resources | where type =~ '{}'".format(NAMESPACE_ASSET_RESOURCE_TYPE)
 
         # for now, keep it simple
-        # later on, add namespace (needs id parsing), location, device endpoint type (will need to add joins)
+        # ideas for later on, add namespace (needs id parsing), device endpoint type (will need to add joins)
         def _build_query_body(
             asset_name: Optional[str] = None,
             device_name: Optional[str] = None,
-            device_endpoint_name: Optional[str] = None
+            device_endpoint_name: Optional[str] = None,
+            disabled: Optional[bool] = None,
+            display_name: Optional[str] = None,
+            documentation_uri: Optional[str] = None,
+            external_asset_id: Optional[str] = None,
+            hardware_revision: Optional[str] = None,
+            manufacturer: Optional[str] = None,
+            manufacturer_uri: Optional[str] = None,
+            model: Optional[str] = None,
+            product_code: Optional[str] = None,
+            serial_number: Optional[str] = None,
+            software_revision: Optional[str] = None,
         ) -> str:
             query_body = ""
-            # add in namespace name
+            if disabled is not None:
+                query_body += f"| where properties.enabled == {not disabled}"
             if asset_name:
                 query_body += f' | where name =~ "{asset_name}"'
             if device_name:
                 query_body += f' | where properties.deviceRef.deviceName =~ "{device_name}"'
             if device_endpoint_name:
                 query_body += f' | where properties.deviceRef.endpointName =~ "{device_endpoint_name}"'
+            if disabled is not None:
+                query_body += f"| where properties.enabled == {not disabled}"
+            if display_name:
+                query_body += f' | where properties.displayName =~ "{display_name}"'
+            if documentation_uri:
+                query_body += f' | where properties.documentationUri =~ "{documentation_uri}"'
+            if external_asset_id:
+                query_body += f' | where properties.externalAssetId =~ "{external_asset_id}"'
+            if hardware_revision:
+                query_body += f' | where properties.hardwareRevision =~ "{hardware_revision}"'
+            if manufacturer:
+                query_body += f' | where properties.manufacturer =~ "{manufacturer}"'
+            if manufacturer_uri:
+                query_body += f' | where properties.manufacturerUri =~ "{manufacturer_uri}"'
+            if model:
+                query_body += f' | where properties.model =~ "{model}"'
+            if product_code:
+                query_body += f' | where properties.productCode =~ "{product_code}"'
+            if serial_number:
+                query_body += f' | where properties.serialNumber =~ "{serial_number}"'
+            if software_revision:
+                query_body += f' | where properties.softwareRevision =~ "{software_revision}"'
             return (
                 f"{query_body} | extend customLocation = tostring(extendedLocation.name) "
                 "| extend provisioningState = properties.provisioningState "
@@ -242,8 +290,27 @@ class NamespaceAssets(Queryable):
         query += custom_query or _build_query_body(
             asset_name=asset_name,
             device_name=device_name,
-            device_endpoint_name=device_endpoint_name
+            device_endpoint_name=device_endpoint_name,
+            disabled=disabled,
+            display_name=display_name,
+            documentation_uri=documentation_uri,
+            external_asset_id=external_asset_id,
+            hardware_revision=hardware_revision,
+            manufacturer=manufacturer,
+            manufacturer_uri=manufacturer_uri,
+            model=model,
+            product_code=product_code,
+            serial_number=serial_number,
+            software_revision=software_revision,
         )
+
+        query = get_instance_query(
+            query=query,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            project_away_custom_location=False
+        )
+        logger.info(f"Querying assets with query: {query}")
 
         return self.query(query=query)
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -228,59 +228,39 @@ class NamespaceAssets(Queryable):
         """
         Queries the asset using Azure Resource Graph.
         """
-        from .helpers import get_instance_query
+        from .helpers import get_instance_query, get_query
         query = "Resources | where type =~ '{}'".format(NAMESPACE_ASSET_RESOURCE_TYPE)
 
         # for now, keep it simple
         # ideas for later on, add namespace (needs id parsing), device endpoint type (will need to add joins)
         def _build_query_body(
-            asset_name: Optional[str] = None,
-            device_name: Optional[str] = None,
-            device_endpoint_name: Optional[str] = None,
-            disabled: Optional[bool] = None,
-            display_name: Optional[str] = None,
-            documentation_uri: Optional[str] = None,
-            external_asset_id: Optional[str] = None,
-            hardware_revision: Optional[str] = None,
-            manufacturer: Optional[str] = None,
-            manufacturer_uri: Optional[str] = None,
-            model: Optional[str] = None,
-            product_code: Optional[str] = None,
-            serial_number: Optional[str] = None,
-            software_revision: Optional[str] = None,
+            **params: dict
         ) -> str:
-            query_body = ""
-            if disabled is not None:
-                query_body += f"| where properties.enabled == {not disabled}"
-            if asset_name:
-                query_body += f' | where name =~ "{asset_name}"'
-            if device_name:
-                query_body += f' | where properties.deviceRef.deviceName =~ "{device_name}"'
-            if device_endpoint_name:
-                query_body += f' | where properties.deviceRef.endpointName =~ "{device_endpoint_name}"'
-            if disabled is not None:
-                query_body += f"| where properties.enabled == {not disabled}"
-            if display_name:
-                query_body += f' | where properties.displayName =~ "{display_name}"'
-            if documentation_uri:
-                query_body += f' | where properties.documentationUri =~ "{documentation_uri}"'
-            if external_asset_id:
-                query_body += f' | where properties.externalAssetId =~ "{external_asset_id}"'
-            if hardware_revision:
-                query_body += f' | where properties.hardwareRevision =~ "{hardware_revision}"'
-            if manufacturer:
-                query_body += f' | where properties.manufacturer =~ "{manufacturer}"'
-            if manufacturer_uri:
-                query_body += f' | where properties.manufacturerUri =~ "{manufacturer_uri}"'
-            if model:
-                query_body += f' | where properties.model =~ "{model}"'
-            if product_code:
-                query_body += f' | where properties.productCode =~ "{product_code}"'
-            if serial_number:
-                query_body += f' | where properties.serialNumber =~ "{serial_number}"'
-            if software_revision:
-                query_body += f' | where properties.softwareRevision =~ "{software_revision}"'
-            return query_body
+            param_mapping = {
+                "asset_name": "name",
+                "device_name": "properties.deviceRef.deviceName",
+                "device_endpoint_name": "properties.deviceRef.endpointName",
+                "display_name": "properties.displayName",
+                "documentation_uri": "properties.documentationUri",
+                "external_asset_id": "properties.externalAssetId",
+                "hardware_revision": "properties.hardwareRevision",
+                "manufacturer": "properties.manufacturer",
+                "manufacturer_uri": "properties.manufacturerUri",
+                "model": "properties.model",
+                "product_code": "properties.productCode",
+                "serial_number": "properties.serialNumber",
+                "software_revision": "properties.softwareRevision",
+            }
+            query_body = get_query(
+                param_mapping=param_mapping,
+                params=params
+            )
+            return (
+                query_body + " | extend customLocation = tostring(extendedLocation.name) "
+                "| extend provisioningState = properties.provisioningState "
+                "| project id, customLocation, location, name, resourceGroup, provisioningState, "
+                "tags, type, subscriptionId"
+            )
 
         query += custom_query or _build_query_body(
             asset_name=asset_name,
@@ -304,11 +284,6 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             instance_resource_group=instance_resource_group,
             project_away_custom_location=False
-        )
-        query += (
-            "| extend provisioningState = properties.provisioningState "
-            "| project id, customLocation, location, name, resourceGroup, provisioningState, "
-            "tags, type, subscriptionId"
         )
         logger.info(f"Querying assets with query: {query}")
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -280,12 +280,7 @@ class NamespaceAssets(Queryable):
                 query_body += f' | where properties.serialNumber =~ "{serial_number}"'
             if software_revision:
                 query_body += f' | where properties.softwareRevision =~ "{software_revision}"'
-            return (
-                f"{query_body} | extend customLocation = tostring(extendedLocation.name) "
-                "| extend provisioningState = properties.provisioningState "
-                "| project id, customLocation, location, name, resourceGroup, provisioningState, "
-                "tags, type, subscriptionId"
-            )
+            return query_body
 
         query += custom_query or _build_query_body(
             asset_name=asset_name,
@@ -309,6 +304,11 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             instance_resource_group=instance_resource_group,
             project_away_custom_location=False
+        )
+        query += (
+            "| extend provisioningState = properties.provisioningState "
+            "| project id, customLocation, location, name, resourceGroup, provisioningState, "
+            "tags, type, subscriptionId"
         )
         logger.info(f"Querying assets with query: {query}")
 

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -43,9 +43,13 @@ class DeviceEndpointType(ListableEnum):
     REST = "Microsoft.Http"
 
     @classmethod
-    def get_type_from_keyword(cls, keyword: str) -> Optional[str]:
+    def get_type_from_keyword(cls, keyword: str, return_custom_keyword: bool = True) -> Optional[str]:
         """
-        Returns the endpoint type based on the keyword. Mainly used for testing.
+        Returns the endpoint type based on the keyword.
+
+        For listing endpoint purposes, if the keyword does not match any known type, it will return
+        the keyword itself.
+        For testing purposes, if the keyword does not match any known type, it will return "custom".
         """
         mapped_types = {
             "opcua": cls.OPCUA.value,
@@ -53,7 +57,7 @@ class DeviceEndpointType(ListableEnum):
             "media": cls.MEDIA.value,
             "rest": cls.REST.value
         }
-        return mapped_types.get(keyword.lower(), "custom")
+        return mapped_types.get(keyword.lower(), "custom" if return_custom_keyword else keyword)
 
 
 class NamespaceDevices(Queryable):
@@ -368,15 +372,25 @@ class NamespaceDevices(Queryable):
         device_name: str,
         instance_name: str,
         instance_resource_group: str,
-        inbound: bool = False
+        inbound: bool = False,
+        inbound_endpoint_type: Optional[str] = None
     ) -> dict:
-        # TODO: for inbound endponts, see if we can also filter by type
         device = self.show(
             device_name=device_name,
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        return _get_endpoints(device, inbound=inbound)
+        endpoints = _get_endpoints(device, inbound=inbound)
+        if inbound and inbound_endpoint_type:
+            # support inputs of just "opcua", "onvif", etc.
+            inbound_endpoint_type = DeviceEndpointType.get_type_from_keyword(
+                inbound_endpoint_type, return_custom_keyword=False
+            )
+            endpoints = {
+                name: body for name, body in endpoints.items()
+                if body.get("endpointType", "").lower() == inbound_endpoint_type.lower()
+            }
+        return endpoints
 
     def inbound_remove_endpoint(
         self,

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -200,44 +200,62 @@ class NamespaceDevices(Queryable):
     def query_devices(
         self,
         device_name: Optional[str] = None,
+        instance_name: Optional[str] = None,
+        instance_resource_group: Optional[str] = None,
+        disabled: Optional[bool] = None,
         custom_query: Optional[str] = None,
         manufacturer: Optional[str] = None,
         model: Optional[str] = None,
         operating_system: Optional[str] = None,
+        operating_system_version: Optional[str] = None,
     ) -> dict:
         """
         Queries the devices using Azure Resource Graph.
         """
+        from .helpers import get_instance_query
         query = "Resources | where type =~ '{}'".format(NAMESPACE_DEVICE_RESOURCE_TYPE)
 
         # for now, keep it simple
-        # later on, add namespace (needs id parsing), location, endpoint types (will need to add joins)
-        # instance names
+        # ideas for later on, add namespace (needs id parsing), endpoint types (will need to add joins)
         def _build_query_body(
             device_name: Optional[str] = None,
+            disabled: Optional[bool] = None,
             manufacturer: Optional[str] = None,
             model: Optional[str] = None,
-            operating_system: Optional[str] = None
+            operating_system: Optional[str] = None,
+            operating_system_version: Optional[str] = None,
         ) -> str:
             query_body = ""
-            # add filters
             if device_name:
                 query_body += f' | where name =~ "{device_name}"'
+            if disabled is not None:
+                query_body += f"| where properties.enabled == {not disabled}"
             if manufacturer:
                 query_body += f' | where properties.manufacturer =~ "{manufacturer}"'
             if model:
                 query_body += f' | where properties.model =~ "{model}"'
             if operating_system:
                 query_body += f' | where properties.operatingSystem =~ "{operating_system}"'
+            if operating_system_version:
+                query_body += f' | where properties.operatingSystemVersion =~ "{operating_system_version}"'
+
             return query_body
 
         query += custom_query or _build_query_body(
             device_name=device_name,
+            disabled=disabled,
             manufacturer=manufacturer,
             model=model,
-            operating_system=operating_system
+            operating_system=operating_system,
+            operating_system_version=operating_system_version
         )
 
+        query = get_instance_query(
+            query=query,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group
+        )
+        logger.info(f"Querying devices with query: {query}")
         return self.query(query=query)
 
     def update(

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -212,34 +212,25 @@ class NamespaceDevices(Queryable):
         """
         Queries the devices using Azure Resource Graph.
         """
-        from .helpers import get_instance_query
+        from .helpers import get_instance_query, get_query
         query = "Resources | where type =~ '{}'".format(NAMESPACE_DEVICE_RESOURCE_TYPE)
 
         # for now, keep it simple
         # ideas for later on, add namespace (needs id parsing), endpoint types (will need to add joins)
         def _build_query_body(
-            device_name: Optional[str] = None,
-            disabled: Optional[bool] = None,
-            manufacturer: Optional[str] = None,
-            model: Optional[str] = None,
-            operating_system: Optional[str] = None,
-            operating_system_version: Optional[str] = None,
+            **params: dict
         ) -> str:
-            query_body = ""
-            if device_name:
-                query_body += f' | where name =~ "{device_name}"'
-            if disabled is not None:
-                query_body += f"| where properties.enabled == {not disabled}"
-            if manufacturer:
-                query_body += f' | where properties.manufacturer =~ "{manufacturer}"'
-            if model:
-                query_body += f' | where properties.model =~ "{model}"'
-            if operating_system:
-                query_body += f' | where properties.operatingSystem =~ "{operating_system}"'
-            if operating_system_version:
-                query_body += f' | where properties.operatingSystemVersion =~ "{operating_system_version}"'
-
-            return query_body
+            param_mapping = {
+                "device_name": "name",
+                "manufacturer": "properties.manufacturer",
+                "model": "properties.model",
+                "operating_system": "properties.operatingSystem",
+                "operating_system_version": "properties.operatingSystemVersion",
+            }
+            return get_query(
+                param_mapping=param_mapping,
+                params=params,
+            )
 
         query += custom_query or _build_query_body(
             device_name=device_name,

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -723,6 +723,14 @@ def load_adr_arguments(self, _):
             arg_type=get_three_state_flag(),
         )
 
+    with self.argument_context("iot ops ns device endpoint inbound list") as context:
+        context.argument(
+            "inbound_endpoint_type",
+            options_list=["--endpoint-type", "--et"],
+            help="Filter inbound endpoints by type. Both full endpoint name `Microsoft.OpcUa` "
+            "and short name `opcua` are supported.",
+        )
+
     with self.argument_context("iot ops ns device endpoint inbound remove") as context:
         context.argument(
             "endpoint_names",
@@ -893,7 +901,7 @@ def load_adr_arguments(self, _):
         )
         context.argument(
             "device_endpoint_name",
-            options_list=["--endpoint-name", "--endpoint", "--ep"],
+            options_list=["--endpoint", "--ep"],
             help="Device endpoint name.",
         )
         context.argument(

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -621,33 +621,39 @@ def load_adr_arguments(self, _):
         context.argument(
             "disabled",
             options_list=["--disabled"],
-            help="Disable the device. By default, no change will be made to the device's enabled/disabled state.",
+            help="Disable the device.",
             arg_type=get_three_state_flag(),
+            arg_group="Additional Info",
         )
         context.argument(
             "operating_system_version",
-            options_list=["--os-version"],
+            options_list=["--os-version", "--osv"],
             help="The device operating system version.",
+            arg_group="Additional Info",
         )
         context.argument(
             "manufacturer",
             options_list=["--manufacturer"],
             help="The device manufacturer.",
+            arg_group="Additional Info",
         )
         context.argument(
             "model",
             options_list=["--model"],
             help="The device model.",
+            arg_group="Additional Info",
         )
         context.argument(
             "operating_system",
             options_list=["--os"],
             help="The device operating system.",
+            arg_group="Additional Info",
         )
         context.argument(
             "custom_query",
             options_list=["--custom-query", "--cq"],
-            help="Custom query to use. All other query arguments will be ignored.",
+            help="Custom query to use. All other query arguments, aside from instance name and "
+            "resource group, will be ignored.",
         )
 
     with self.argument_context("iot ops ns device create") as context:
@@ -656,6 +662,15 @@ def load_adr_arguments(self, _):
             options_list=["--instance-subscription", "--isub"],
             help="The subscription ID of the Azure IoT Operations instance. If not provided, the current "
             "subscription will be used.",
+        )
+
+    with self.argument_context("iot ops ns device query") as context:
+        context.argument(
+            "disabled",
+            options_list=["--disabled"],
+            help="State of asset.",
+            arg_group="Additional Info",
+            arg_type=get_three_state_flag(),
         )
 
     with self.argument_context("iot ops ns device endpoint") as context:
@@ -910,6 +925,7 @@ def load_adr_arguments(self, _):
             help="Space-separated list of asset type references.",
             nargs="+",
             action="extend",
+            arg_group="Additional Info"
         )
         context.argument(
             "attributes",
@@ -923,17 +939,20 @@ def load_adr_arguments(self, _):
             "description",
             options_list=["--description"],
             help="Description of the asset.",
+            arg_group="Additional Info"
         )
         context.argument(
             "disabled",
             options_list=["--disable"],
             help="Disable the asset.",
             arg_type=get_three_state_flag(),
+            arg_group="Additional Info"
         )
         context.argument(
             "display_name",
             options_list=["--display-name", "--dn"],
             help="Display name for the asset.",
+            arg_group="Additional Info"
         )
         context.argument(
             "documentation_uri",
@@ -992,7 +1011,17 @@ def load_adr_arguments(self, _):
         context.argument(
             "custom_query",
             options_list=["--custom-query", "--cq"],
-            help="Custom query to use. All other query arguments will be ignored.",
+            help="Custom query to use. All other query arguments, aside from instance name and "
+            "resource group, will be ignored.",
+        )
+
+    with self.argument_context("iot ops ns asset query") as context:
+        context.argument(
+            "disabled",
+            options_list=["--disabled"],
+            help="State of asset.",
+            arg_group="Additional Info",
+            arg_type=get_three_state_flag(),
         )
 
     for command in ("create", "update"):

--- a/azext_edge/tests/edge/adr/test_helpers_unit.py
+++ b/azext_edge/tests/edge/adr/test_helpers_unit.py
@@ -311,6 +311,112 @@ def test_get_namespace_for_instance_error(
     assert str(exc_info.value) == expected_error
 
 
+@pytest.mark.parametrize("input_query", [
+    # base
+    "Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/assets'",
+    # with some props
+    "Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/assets' | where properties.enabled == true",
+    # with custom location
+    "Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/assets' "
+    "| extend customLocation = tostring(extendedLocation.name)",
+])
+@pytest.mark.parametrize("instance_name", [None, generate_random_string()])
+@pytest.mark.parametrize("instance_resource_group", [None, generate_random_string()])
+@pytest.mark.parametrize("project_away_custom_location", [True, False])
+def test_get_instance_query(
+    input_query: str, instance_name: str, instance_resource_group: str, project_away_custom_location: bool
+):
+    from azext_edge.edge.providers.adr.helpers import get_instance_query
+    result = get_instance_query(
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        query=input_query,
+        project_away_custom_location=project_away_custom_location
+    )
+
+    # nothing changes
+    if not instance_name and not instance_resource_group:
+        assert result == input_query
+        return
+
+    # make sure the query starts with the expected base
+    assert result.startswith("Resources | where type =~ 'microsoft.iotoperations/instances'")
+
+    # ensure there is customLocation defined (needed for query to join correctly)
+    if "extend customLocation = tostring(extendedLocation.name)" not in input_query:
+        input_query += " | extend customLocation = tostring(extendedLocation.name)"
+    assert f"join kind=innerunique ({input_query}) on customLocation" in result
+
+    # split the query and check for instance name and resource group
+    split_query = [q.strip() for q in result.split("|")]
+    if instance_name:
+        assert f"where name =~ \"{instance_name}\"" in split_query
+    if instance_resource_group:
+        assert f"where resourceGroup =~ \"{instance_resource_group}\"" in split_query
+
+    # make sure we got only the correct project-away
+    assert ("project-away customLocation1, customLocation" in split_query) is project_away_custom_location
+    assert ("project-away customLocation1" in split_query) is not project_away_custom_location
+
+
+@pytest.mark.parametrize("param_mapping", [
+    {},
+    {  # lifted from assets
+        "asset_name": "name",
+        "device_name": "properties.deviceRef.deviceName",
+        "device_endpoint_name": "properties.deviceRef.endpointName",
+        "display_name": "properties.displayName",
+        "documentation_uri": "properties.documentationUri",
+        "external_asset_id": "properties.externalAssetId",
+        "hardware_revision": "properties.hardwareRevision",
+        "manufacturer": "properties.manufacturer",
+        "manufacturer_uri": "properties.manufacturerUri",
+        "model": "properties.model",
+        "product_code": "properties.productCode",
+        "serial_number": "properties.serialNumber",
+        "software_revision": "properties.softwareRevision",
+    }
+])
+@pytest.mark.parametrize("params", [
+    {},
+    {
+        "asset_name": generate_random_string(),
+        "device_name": generate_random_string(),
+        "device_endpoint_name": generate_random_string(),
+        "display_name": generate_random_string(),
+        "documentation_uri": generate_random_string(),
+        "external_asset_id": generate_random_string(),
+        "hardware_revision": generate_random_string(),
+        "manufacturer": generate_random_string(),
+        "manufacturer_uri": generate_random_string(),
+        "model": generate_random_string(),
+        "product_code": generate_random_string(),
+        "serial_number": generate_random_string(),
+        "software_revision": generate_random_string(),
+        "disabled": False
+    },
+    {  # mix ok and not ok params
+        "asset_name": generate_random_string(),
+        "operating_system": generate_random_string(),
+        "disabled": True
+    }
+])
+def test_get_query(param_mapping, params):
+    from azext_edge.edge.providers.adr.helpers import get_query
+    query = get_query(
+        param_mapping=param_mapping,
+        params=params
+    )
+    split_query = [q.strip() for q in query.split("|")]
+    if "disabled" in params:
+        disabled = params.pop("disabled")
+        assert f"where properties.enabled == {not disabled}" in split_query
+
+    for param, value in params.items():
+        if param in param_mapping:
+            assert f"where {param_mapping[param]} =~ \"{value}\"" in split_query
+
+
 @pytest.mark.parametrize("datasets", [
     [{"name": "", "dataPoints": generate_random_string()}],
     [{"name": "default", "dataPoints": generate_random_string()}],

--- a/azext_edge/tests/edge/adr/test_namespace_assets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_int.py
@@ -61,7 +61,7 @@ def test_namespace_asset_smoke_test(require_init, tracked_resources: List[str], 
     # Create Custom asset with maximum inputs
     asset_custom = run(
         f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
-        f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_custom} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_custom} "
         "--description \"Custom Device\" --display-name \"Multi-Sensor\" --model \"Custom-MS100\" "
         "--manufacturer \"CustomDevices\" --serial-number \"CUST123456\" "
         f"--dataset-config \"{{\\\"publishingInterval\\\": 1000}}\" "
@@ -340,7 +340,7 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
     # 1. Create ONVIF asset with maximum inputs
     asset_onvif = run(
         f"az iot ops ns asset onvif create --name {asset_name_onvif} --instance {instance_name} "
-        f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_onvif} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_onvif} "
         "--description \"ONVIF Camera\" --display-name \"Entrance Camera\" --model \"Camera-X1\" "
         "--manufacturer \"SecurityCo\" --serial-number \"CAM123456\" "
         "--documentation-uri \"https://example.com/docs/camera\" "
@@ -370,7 +370,7 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
     # 2. Create OPCUA asset with maximum inputs
     asset_opcua = run(
         f"az iot ops ns asset opcua create --name {asset_name_opcua} --instance {instance_name} "
-        f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_opcua} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_opcua} "
         "--description \"OPC UA Sensor\" --display-name \"Temperature Sensor\" --model \"Sensor-T2000\" "
         "--manufacturer \"Contoso\" --serial-number \"OPCUA987654\" "
         "--dataset-publish-int 2000 --dataset-sampling-int 1000 --dataset-queue-size 5 "
@@ -399,7 +399,7 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
     # 3. Create Media asset with maximum inputs
     asset_media = run(
         f"az iot ops ns asset media create --name {asset_name_media} --instance {instance_name} "
-        f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_media} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_media} "
         "--description \"Media Camera\" --display-name \"Monitoring Camera\" --model \"MediaCam-4K\" "
         "--manufacturer \"MediaCorp\" --serial-number \"MEDIA567890\" "
         "--task-type \"snapshot-to-mqtt\" --task-format \"jpeg\" --snapshots-per-sec 1 "
@@ -426,7 +426,7 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
     # 4. Create Rest asset with maximum inputs
     asset_rest = run(
         f"az iot ops ns asset rest create --name {asset_name_rest} --instance {instance_name} "
-        f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_rest} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_rest} "
         "--description \"Rest Camera\" --display-name \"Main Entrance Camera\" "
         "--model \"Camera-X1\" --manufacturer \"SecurityCo\" --serial-number \"CAM123456\" "
         "--documentation-uri \"https://example.com/docs/camera\" "

--- a/azext_edge/tests/edge/adr/test_namespace_assets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_int.py
@@ -62,12 +62,12 @@ def test_namespace_asset_smoke_test(require_init, tracked_resources: List[str], 
     asset_custom = run(
         f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint-name {endpoint_name_custom} "
-        f"--description \"Custom Device\" --display-name \"Multi-Sensor\" --model \"Custom-MS100\" "
-        f"--manufacturer \"CustomDevices\" --serial-number \"CUST123456\" "
+        "--description \"Custom Device\" --display-name \"Multi-Sensor\" --model \"Custom-MS100\" "
+        "--manufacturer \"CustomDevices\" --serial-number \"CUST123456\" "
         f"--dataset-config \"{{\\\"publishingInterval\\\": 1000}}\" "
         f"--event-config \"{{\\\"queueSize\\\": 5}}\" "
-        f"--dataset-dest topic=\"custom/data\" qos=Qos1 retain=Keep ttl=3600 "
-        f"--event-dest topic=\"custom/events\" qos=Qos0 retain=Never ttl=3600 "
+        "--dataset-dest topic=\"custom/data\" qos=Qos1 retain=Keep ttl=3600 "
+        "--event-dest topic=\"custom/events\" qos=Qos0 retain=Never ttl=3600 "
         f"--attribute {' '.join(common_attrs)} --tags {' '.join([f'{k}={v}' for k, v in common_tags.items()])}"
     )
     tracked_resources.append(asset_custom["id"])
@@ -112,6 +112,13 @@ def test_namespace_asset_smoke_test(require_init, tracked_resources: List[str], 
     # Test query operation
     queried_assets = run(
         "az iot ops ns asset query"
+    )
+
+    asset_names = [asset["name"] for asset in queried_assets]
+    assert asset_name in asset_names
+
+    queried_assets = run(
+        f"az iot ops ns asset query -i {instance_name} -g {resource_group}"
     )
 
     asset_names = [asset["name"] for asset in queried_assets]

--- a/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
@@ -858,7 +858,11 @@ def test_query_namespace_assets(mocked_cmd, mocker, reqs):
             assert f"| where name =~ \"{reqs['instance_name']}\"" in query
         if "instance_resource_group" in reqs:
             assert f"| where resourceGroup =~ \"{reqs['instance_resource_group']}\"" in query
+        # asset start should be included still
         assert asset_start in query
+        # project away only custom location 1
+        assert "| project-away customLocation1" in query
+        assert "| project-away customLocation1, customLocation" not in query
     else:
         assert query.startswith(asset_start)
 

--- a/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
@@ -803,6 +803,22 @@ def test_update_namespace_asset(
         "asset_name": generate_random_string(),
         "device_name": generate_random_string(),
         "device_endpoint_name": generate_random_string(),
+        "display_name": "Test Display Name",
+        "documentation_uri": "http://test-docs.com",
+        "external_asset_id": "external-id-123",
+        "hardware_revision": "HW-Rev-1",
+        "manufacturer": "Test Manufacturer",
+        "manufacturer_uri": "http://manufacturer.com",
+        "model": "TestModel",
+        "product_code": "PROD-123",
+        "serial_number": "SN12345",
+        "software_revision": "SW-Rev-1",
+        "disabled": True,
+    },
+    {
+        "disabled": False,
+        "instance_name": generate_random_string(),
+        "instance_resource_group": generate_random_string(),
     },
     {
         "custom_query": "| where resouceGroupName == 'test-rg' | project name, type",
@@ -810,6 +826,8 @@ def test_update_namespace_asset(
     {
         "asset_name": generate_random_string(),
         "custom_query": "| where resouceGroupName == 'test-rg' | project name, type",
+        "instance_name": generate_random_string(),
+        "instance_resource_group": generate_random_string(),
     }
 ])
 def test_query_namespace_assets(mocked_cmd, mocker, reqs):
@@ -832,8 +850,17 @@ def test_query_namespace_assets(mocked_cmd, mocker, reqs):
     # Check the query string that was passed to the query method
     query = mock_query.call_args[1]["query"]
 
+    asset_start = "Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/assets'"
     # Assert that the query starts with the expected base
-    assert query.startswith("Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/assets'")
+    if "instance_name" in reqs or "instance_resource_group" in reqs:
+        assert query.startswith("Resources | where type =~ 'microsoft.iotoperations/instances'")
+        if "instance_name" in reqs:
+            assert f"| where name =~ \"{reqs['instance_name']}\"" in query
+        if "instance_resource_group" in reqs:
+            assert f"| where resourceGroup =~ \"{reqs['instance_resource_group']}\"" in query
+        assert asset_start in query
+    else:
+        assert query.startswith(asset_start)
 
     custom = "custom_query" in reqs
     # If a custom query was specified, verify it overrides other parameters
@@ -842,14 +869,26 @@ def test_query_namespace_assets(mocked_cmd, mocker, reqs):
 
     # Check that each specified parameter is included in the query if the query is not custom
     # otherwise, the specified parameter should not be there
-    if "asset_name" in reqs:
-        assert (f'| where name =~ "{reqs["asset_name"]}"' in query) is not custom
-    if "resource_group_name" in reqs:
-        assert (f'| where resourceGroup =~ "{reqs["resource_group_name"]}"' in query) is not custom
-    if "device_name" in reqs:
-        assert (f'| where properties.deviceRef.deviceName =~ "{reqs["device_name"]}"' in query) is not custom
-    if "device_endpoint_name" in reqs:
-        assert (f'| where properties.deviceRef.endpointName =~ "{reqs["device_endpoint_name"]}"' in query) is not custom
+    for param, prop in [
+        ("asset_name", "name"),
+        ("device_name", "properties.deviceRef.deviceName"),
+        ("device_endpoint_name", "properties.deviceRef.endpointName"),
+        ("display_name", "properties.displayName"),
+        ("documentation_uri", "properties.documentationUri"),
+        ("external_asset_id", "properties.externalAssetId"),
+        ("hardware_revision", "properties.hardwareRevision"),
+        ("manufacturer", "properties.manufacturer"),
+        ("manufacturer_uri", "properties.manufacturerUri"),
+        ("model", "properties.model"),
+        ("product_code", "properties.productCode"),
+        ("serial_number", "properties.serialNumber"),
+        ("software_revision", "properties.softwareRevision"),
+    ]:
+        if param in reqs:
+            assert (f'| where {prop} =~ "{reqs[param]}"' in query) is not custom
+
+    if "disabled" in reqs:
+        assert (f'| where properties.enabled == {not reqs["disabled"]}' in query) is not custom
 
     # Verify the standard projection part is included
     assert ("| project id, customLocation, location, name, resourceGroup, provisioningState" in query) is not custom

--- a/azext_edge/tests/edge/adr/test_namespace_devices_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_int.py
@@ -280,6 +280,15 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     assert endpoint_name_opcua in result_1
     assert endpoint_name_custom in result_1
 
+    # List inbound endpoints with specific type
+    result = run(
+        f"az iot ops ns device endpoint inbound list --device {device_name_2} "
+        f"--instance {instance_name} -g {resource_group} --endpoint-type media"
+    )
+    assert len(result) == 1
+    assert endpoint_name_media in result
+    assert endpoint_name_custom not in result
+
     # Remove endpoints
     result = run(
         f"az iot ops ns device endpoint inbound remove --device {device_name_2} "
@@ -299,6 +308,14 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     )
     assert len(result) == 1
     assert result[0]["name"] == device_name_1
+
+    # Query for devices by instance
+    result = run(
+        f"az iot ops ns device query -i {instance_name} -g {resource_group}"
+    )
+    device_names = [d["name"] for d in result]
+    assert device_name_2 in device_names
+    assert device_name_1 in device_names
 
     # Query for devices by manufacturer
     result = run(

--- a/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
@@ -244,14 +244,24 @@ def test_create_namespace_device(
         "device_name": "test-device",
         "manufacturer": "Contoso",
         "model": "Model X",
-        "operating_system": "Linux"
+        "operating_system": "Linux",
+        "operating_system_version": "1.0",
+        "disabled": True
+    },
+    {
+        "disabled": False,
+        "instance_name": "test-instance",
+        "instance_resource_group": "test-rg"
     },
     {
         "custom_query": " | where name contains 'special' | project name, location"
     },
     {
         "device_name": "another-device",
-        "manufacturer": "Fabrikam"
+        "manufacturer": "Fabrikam",
+        "custom_query": " | where resourceGroup == 'test-rg' | project name, type",
+        "instance_name": "test-instance",
+        "instance_resource_group": "test-rg"
     }
 ])
 def test_query_namespace_devices(mocked_cmd, mocker, req: Dict):
@@ -275,27 +285,38 @@ def test_query_namespace_devices(mocked_cmd, mocker, req: Dict):
     assert mock_query.call_count == 1
 
     # Check the query string that was passed to the query method
-    actual_query = mock_query.call_args[1]["query"]
+    query = mock_query.call_args[1]["query"]
 
+    device_start = "Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/devices'"
     # Assert that the query starts with the expected base
-    assert actual_query.startswith("Resources | where type =~ 'Microsoft.DeviceRegistry/namespaces/devices'")
-
-    # Verify specific filters based on request parameters
-    if "custom_query" in req:
-        # Custom query should be used as-is after the base query
-        assert req["custom_query"] in actual_query
+    if "instance_name" in req or "instance_resource_group" in req:
+        assert query.startswith("Resources | where type =~ 'microsoft.iotoperations/instances'")
+        if "instance_name" in req:
+            assert f"| where name =~ \"{req['instance_name']}\"" in query
+        if "instance_resource_group" in req:
+            assert f"| where resourceGroup =~ \"{req['instance_resource_group']}\"" in query
+        assert device_start in query
     else:
-        # Verify individual filters are applied
-        if "device_name" in req:
-            assert f'where name =~ "{req["device_name"]}"' in actual_query
-        if "resource_group_name" in req:
-            assert f'where resourceGroup =~ "{req["resource_group_name"]}"' in actual_query
-        if "manufacturer" in req:
-            assert f'where properties.manufacturer =~ "{req["manufacturer"]}"' in actual_query
-        if "model" in req:
-            assert f'where properties.model =~ "{req["model"]}"' in actual_query
-        if "operating_system" in req:
-            assert f'where properties.operatingSystem =~ "{req["operating_system"]}"' in actual_query
+        assert query.startswith(query)
+
+    custom = "custom_query" in req
+    # Verify specific filters based on request parameters
+    if custom:
+        # Custom query should be used as-is after the base query
+        assert req["custom_query"] in query
+    # Verify individual filters are applied
+    for param, prop in [
+        ("device_name", "name"),
+        ("manufacturer", "properties.manufacturer"),
+        ("model", "properties.model"),
+        ("operating_system", "properties.operatingSystem"),
+        ("operating_system_version", "properties.operatingSystemVersion"),
+    ]:
+        if param in req:
+            assert (f'| where {prop} =~ "{req[param]}"' in query) is not custom
+
+    if "disabled" in req:
+        assert (f'| where properties.enabled == {not req["disabled"]}' in query) is not custom
 
 
 @pytest.mark.parametrize("response_status", [202, 443])

--- a/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
@@ -20,6 +20,7 @@ from azext_edge.edge.commands_namespaces import (
     update_namespace_device,
     list_namespace_device_endpoints,
     remove_inbound_device_endpoints,
+    list_inbound_device_endpoints,
     add_inbound_custom_device_endpoint,
     add_inbound_media_device_endpoint,
     add_inbound_onvif_device_endpoint,
@@ -552,10 +553,12 @@ def test_namespace_device_update(
         }
     }
 ])
+@pytest.mark.parametrize("inbound", [True, False])
 def test_list_namespace_device_endpoints(
     mocked_cmd,
     mocked_responses: responses,
     endpoints: dict,
+    inbound: bool,
     response_status: int,
     mocked_get_namespace_for_instance
 ):
@@ -597,6 +600,7 @@ def test_list_namespace_device_endpoints(
                 device_name=device_name,
                 instance_name=instance_name,
                 instance_resource_group=instance_resource_group,
+                inbound=inbound
             )
         return
 
@@ -606,10 +610,129 @@ def test_list_namespace_device_endpoints(
         device_name=device_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
+        inbound=inbound
     )
 
     # Verify result matches the endpoints in the mock response
-    assert result == {"inbound": endpoints}
+    assert result == (endpoints if inbound else {"inbound": endpoints})
+
+    # Verify the GET call was made
+    assert len(mocked_responses.calls) == 1
+    assert mocked_responses.calls[0].request.method == "GET"
+
+
+@pytest.mark.parametrize("response_status", [200, 443])
+@pytest.mark.parametrize("endpoints", [
+    {},
+    {  # Test with one endpoint
+        "endpoint1": {
+            "endpointType": "Microsoft.Media",
+            "address": "mqtt://example.com:1883",
+            "authentication": {"type": "Anonymous"},
+            "additionalConfiguration": "{\"publishingInterval\": 500, \"samplingInterval\": 500, \"queueSize\": 1}"
+        }
+    },
+    {  # Test with multiple endpoints
+        "endpoint1": {
+            "endpointType": "Microsoft.Media",
+            "address": "mqtt://example.com:1883",
+            "authentication": {"type": "Anonymous"},
+            "additionalConfiguration": "{\"publishingInterval\": 500, \"samplingInterval\": 500, \"queueSize\": 1}"
+        },
+        "endpoint2": {
+            "endpointType": "Microsoft.Media",
+            "address": "mqtt://example.com:1883",
+            "authentication": {"type": "Anonymous"},
+            "additionalConfiguration": "{\"publishingInterval\": 500, \"samplingInterval\": 500, \"queueSize\": 1}"
+        },
+        "endpoint3": {
+            "endpointType": "MyCustomType",
+            "address": "mqtt://example.com:1883",
+            "authentication": {"type": "Anonymous"},
+            "additionalConfiguration": "{\"publishingInterval\": 500, \"samplingInterval\": 500, \"queueSize\": 1}"
+        },
+        "endpoint4": {
+            "endpointType": "Microsoft.Onvif",
+            "address": "mqtt://example.com:1883",
+            "authentication": {"type": "Anonymous"},
+            "additionalConfiguration": "{\"publishingInterval\": 500, \"samplingInterval\": 500, \"queueSize\": 1}"
+        },
+    },
+])
+@pytest.mark.parametrize("endpoint_type", [
+    None,
+    "media",
+    "Microsoft.Media",
+    "mEdia",
+    "mycustomtype"
+])
+def test_list_namespace_device_inbound_endpoints(
+    mocked_cmd,
+    mocked_responses: responses,
+    endpoints: dict,
+    endpoint_type: Optional[str],
+    response_status: int,
+    mocked_get_namespace_for_instance
+):
+    # Setup test data
+    device_name = generate_random_string()
+    instance_name = f"test-inst-{generate_random_string()}"
+    instance_resource_group = f"inst-rg-{generate_random_string()}"
+
+    # Mock namespace information returned by get_namespace_for_instance
+    namespace_name = mocked_get_namespace_for_instance.return_value["name"]
+    resource_group_name = mocked_get_namespace_for_instance.return_value["resource_group"]
+
+    # Create mock device record with the specified endpoints
+    device_record = get_namespace_device_record(
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    device_record["properties"]["endpoints"] = {"inbound": endpoints}
+
+    # Mock the GET call to show_namespace_device
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_device_mgmt_uri(
+            namespace_name=namespace_name,
+            resource_group_name=resource_group_name,
+            device_name=device_name
+        ),
+        json=device_record if response_status == 200 else {"error": "Unauthorized"},
+        status=response_status,
+        content_type="application/json",
+    )
+
+    # Execute test based on status code
+    if response_status != 200:
+        with pytest.raises(Exception):
+            list_inbound_device_endpoints(
+                cmd=mocked_cmd,
+                device_name=device_name,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                inbound_endpoint_type=endpoint_type
+            )
+        return
+
+    # Test list_inbound_device_endpoints for success case
+    result = list_inbound_device_endpoints(
+        cmd=mocked_cmd,
+        device_name=device_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        inbound_endpoint_type=endpoint_type
+    )
+
+    # Verify result matches the endpoints in the mock response
+    if endpoint_type:
+        endpoint_type = DeviceEndpointType.get_type_from_keyword(endpoint_type, return_custom_keyword=False)
+        endpoints = {
+            name: endpoint for name, endpoint in endpoints.items()
+            if not endpoint_type or endpoint["endpointType"].lower() == endpoint_type.lower()
+        }
+    assert result == endpoints
 
     # Verify the GET call was made
     assert len(mocked_responses.calls) == 1

--- a/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
@@ -295,7 +295,10 @@ def test_query_namespace_devices(mocked_cmd, mocker, req: Dict):
             assert f"| where name =~ \"{req['instance_name']}\"" in query
         if "instance_resource_group" in req:
             assert f"| where resourceGroup =~ \"{req['instance_resource_group']}\"" in query
+        # there still will be the device query part
         assert device_start in query
+        # make sure both locations are projected away
+        assert "| project-away customLocation1, customLocation" in query
     else:
         assert query.startswith(query)
 

--- a/massoutput.txt
+++ b/massoutput.txt
@@ -1,0 +1,3 @@
+{"dev": 1, "asset": 8}
+exact:
+{"dev0n85": {"endpoint0x3": {"dev0asset0n3": {"datasets": 4, "datasetPoints": 9, "events": 3, "eventPoints": 4, "mgmt": 2, "mgmtActions": 3, "stream": 5}, "dev0asset0n15": {"datasets": 3, "datasetPoints": 0, "events": 3, "eventPoints": 9, "mgmt": 4, "mgmtActions": 2, "stream": 7}}}}

--- a/massoutput.txt
+++ b/massoutput.txt
@@ -1,3 +1,0 @@
-{"dev": 1, "asset": 8}
-exact:
-{"dev0n85": {"endpoint0x3": {"dev0asset0n3": {"datasets": 4, "datasetPoints": 9, "events": 3, "eventPoints": 4, "mgmt": 2, "mgmtActions": 3, "stream": 5}, "dev0asset0n15": {"datasets": 3, "datasetPoints": 0, "events": 3, "eventPoints": 9, "mgmt": 4, "mgmtActions": 2, "stream": 7}}}}


### PR DESCRIPTION
For namespace device and asset query commands:
- add in base props for filtering
- add in instance + instance rg
- add in a helper function for overall query processes

also shoved in some other improvements
- inbound endpoint filtering by type 
- remove endpoint-name as a param for asset

im sorry - I thought the query stuff would be smaller

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
