### PR TITLE
feat(check): require at least one linux node for prechecks to pass

### DIFF
--- a/azext_edge/edge/providers/check/base/node.py
+++ b/azext_edge/edge/providers/check/base/node.py
@@ -24,6 +24,7 @@ from ..common import (
     NODE_CONTROL_PLANE_LABEL,
 )
 from .check_manager import CheckManager
+from .display import colorize_string
 from .user_strings import NO_NODES_MSG, UNABLE_TO_FETCH_NODES_MSG
 
 logger = get_logger(__name__)
@@ -37,7 +38,9 @@ def check_nodes(
     check_manager = CheckManager(check_name="evalClusterNodes", check_desc="Evaluate cluster nodes")
     padding = (0, 0, 0, 8)
     target = "cluster/nodes"
-    check_manager.add_target(target_name=target, conditions=["len(cluster/nodes)>=1"])
+    check_manager.add_target(
+        target_name=target, conditions=["len(cluster/nodes)>=1", "any(cluster/nodes, operating_system='linux')"]
+    )
 
     try:
         core_client = client.CoreV1Api()
@@ -64,6 +67,29 @@ def check_nodes(
         check_manager.add_target_eval(
             target_name=target, status=CheckTaskStatus.success.value, value={"len(cluster/nodes)": len(nodes.items)}
         )
+
+        # validate at least one node is a linux node
+        linux_nodes = [node for node in nodes.items if node.status.node_info.operating_system == "linux"]
+        linux_node_status = CheckTaskStatus.success if linux_nodes else CheckTaskStatus.error
+        linux_node_color = linux_node_status.color
+        check_manager.add_target_eval(
+            target_name=target,
+            status=linux_node_status.value,
+            value={"any(cluster/nodes, operating_system='linux')": bool(linux_nodes)},
+        )
+        required_display = f"{colorize_string(value='Linux nodes', color='bright_blue')} >=[cyan]{1}[/cyan]"
+        detected_display = colorize_string(value=len(linux_nodes), color=linux_node_color)
+        check_manager.add_display(
+            target_name=target,
+            display=Padding(
+                f"Required {required_display}, detected {detected_display}.",
+                padding,
+            ),
+        )
+
+        # new line
+        check_manager.add_display(target_name=target, display="")
+
         table = _generate_node_table(
             check_manager=check_manager,
             nodes=nodes,

--- a/azext_edge/tests/edge/checks/base/test_nodes_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_nodes_unit.py
@@ -29,7 +29,7 @@ def mocked_node_client(mocked_client, mocker, request):
     nodes = []
     for node_params in params:
         arch = node_params.pop("architecture", generate_random_string(size=5))
-        operating_system = node_params.pop("operating_system", "linux")
+        operating_system = node_params.pop("operating_system", "")
         # Too annoying to make a valid one
         node_info = mocker.Mock(
             architecture=arch,

--- a/azext_edge/tests/edge/checks/base/test_nodes_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_nodes_unit.py
@@ -29,8 +29,13 @@ def mocked_node_client(mocked_client, mocker, request):
     nodes = []
     for node_params in params:
         arch = node_params.pop("architecture", generate_random_string(size=5))
+        operating_system = node_params.pop("operating_system", "linux")
         # Too annoying to make a valid one
-        node_info = mocker.Mock(architecture=arch, kernel_version=node_params.pop("kernel_version", "0.0.0"))
+        node_info = mocker.Mock(
+            architecture=arch,
+            kernel_version=node_params.pop("kernel_version", "0.0.0"),
+            operating_system=operating_system,
+        )
         control_plane = node_params.pop("control_plane", False)
         labels = {NODE_CONTROL_PLANE_LABEL: ""} if control_plane else None
         node = V1Node(
@@ -79,8 +84,62 @@ def mocked_node_client(mocked_client, mocker, request):
             {"control_plane": True, "architecture": "amd64", "cpu": 1, "memory": "2G", "ephemeral-storage": "5G"},
             {"architecture": "amd64", "cpu": 4, "memory": "16G", "ephemeral-storage": "30G"},
         ],
+        # Test cases for Linux node validation
+        [
+            {
+                "architecture": "amd64",
+                "cpu": 4,
+                "memory": "16G",
+                "ephemeral-storage": "30G",
+                "operating_system": "windows",
+            }
+        ],
+        [
+            {
+                "architecture": "amd64",
+                "cpu": 4,
+                "memory": "16G",
+                "ephemeral-storage": "30G",
+                "operating_system": "linux",
+            },
+            {
+                "architecture": "arm64",
+                "cpu": 4,
+                "memory": "16G",
+                "ephemeral-storage": "30G",
+                "operating_system": "windows",
+            },
+        ],
+        [
+            {
+                "architecture": "amd64",
+                "cpu": 4,
+                "memory": "16G",
+                "ephemeral-storage": "30G",
+                "operating_system": "linux",
+            },
+            {
+                "architecture": "arm64",
+                "cpu": 4,
+                "memory": "16G",
+                "ephemeral-storage": "30G",
+                "operating_system": "linux",
+            },
+        ],
     ],
-    ids=["none", "min reqs", "storage", "memory", "cpu", "architecture", "multi-node", "control-plane-multinode"],
+    ids=[
+        "none",
+        "min reqs",
+        "storage",
+        "memory",
+        "cpu",
+        "architecture",
+        "multi-node",
+        "control-plane-multinode",
+        "windows-only",
+        "mixed-linux-windows",
+        "all-linux-nodes",
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -113,8 +172,24 @@ def test_check_nodes(mocked_node_client, kernel_version_check, storage_space_che
         assert result["status"] == "error"
         assert evaluation[0]["value"] == "No nodes detected."
         return
-    else:
-        assert result["targets"]["cluster/nodes"]["_all_"]["status"] == "success"
+
+    # Validate Linux node requirements
+    linux_nodes = [node for node in nodes if node.status.node_info.operating_system == "linux"]
+    has_linux_nodes = len(linux_nodes) > 0
+
+    # Check the Linux node evaluation in the result
+    linux_evaluation = None
+    for eval_item in evaluation:
+        if "any(cluster/nodes, operating_system='linux')" in str(eval_item.get("value", {})):
+            linux_evaluation = eval_item
+            break
+
+    assert linux_evaluation is not None, "Linux node evaluation should be present"
+    assert linux_evaluation["value"]["any(cluster/nodes, operating_system='linux')"] == has_linux_nodes
+
+    # Overall cluster target status should be success only if there are Linux nodes and regular node count is ok
+    expected_cluster_status = "success" if has_linux_nodes else "error"
+    assert result["targets"]["cluster/nodes"]["_all_"]["status"] == expected_cluster_status
 
     assert len(result["targets"]) == (len(nodes) + 1)
     table = result["targets"]["cluster/nodes"]["_all_"]["displays"][-1].renderable


### PR DESCRIPTION
Adds a pre-check that requires at least one node to report an `operating_system` value of `linux`

<img width="706" height="277" alt="image" src="https://github.com/user-attachments/assets/9bbd11e6-973e-4b08-bce4-66ce1c06c5ab" />

<img width="353" height="74" alt="image" src="https://github.com/user-attachments/assets/ac28d318-c484-42f3-9e70-8f0fcc9c92ef" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
