### PR TITLE
feat: add extra labels for akri pods and stateful sets

### DIFF
--- a/azext_edge/edge/providers/support/akri.py
+++ b/azext_edge/edge/providers/support/akri.py
@@ -21,11 +21,12 @@ from .base import (
     process_v1_pods,
     process_validating_webhook_configurations,
 )
-from .common import NAME_LABEL_FORMAT
+from .common import NAME_LABEL_FORMAT, MANAGED_BY_LABEL_FORMAT
 
 logger = get_logger(__name__)
 
 AKRI_NAME_LABEL_V2 = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-akri")
+AKRI_MANAGED_BY_OPERATOR_LABEL = MANAGED_BY_LABEL_FORMAT.format(label="aio-akri-operator")
 AKRI_DIRECTORY_PATH = "akri"
 
 
@@ -37,11 +38,16 @@ def fetch_services():
 
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
-    return process_v1_pods(
-        directory_path=AKRI_DIRECTORY_PATH,
-        label_selector=AKRI_NAME_LABEL_V2,
-        since_seconds=since_seconds,
-    )
+    pods = []
+    for label in [AKRI_NAME_LABEL_V2, AKRI_MANAGED_BY_OPERATOR_LABEL]:
+        pods.extend(
+            process_v1_pods(
+                directory_path=AKRI_DIRECTORY_PATH,
+                label_selector=label,
+                since_seconds=since_seconds,
+            )
+        )
+    return pods
 
 
 def fetch_deployments():
@@ -52,10 +58,15 @@ def fetch_deployments():
 
 
 def fetch_statefulsets():
-    return process_statefulset(
-        directory_path=AKRI_DIRECTORY_PATH,
-        label_selector=AKRI_NAME_LABEL_V2,
-    )
+    pods = []
+    for label in [AKRI_NAME_LABEL_V2, AKRI_MANAGED_BY_OPERATOR_LABEL]:
+        pods.extend(
+            process_statefulset(
+                directory_path=AKRI_DIRECTORY_PATH,
+                label_selector=label,
+            )
+        )
+    return pods
 
 
 def fetch_replicasets():

--- a/azext_edge/edge/providers/support/common.py
+++ b/azext_edge/edge/providers/support/common.py
@@ -7,6 +7,7 @@
 # resource label formats
 COMPONENT_LABEL_FORMAT = "app.kubernetes.io/component in ({label})"
 NAME_LABEL_FORMAT = "app.kubernetes.io/name in ({label})"
+MANAGED_BY_LABEL_FORMAT = "app.kubernetes.io/managed-by in ({label})"
 
 # resource field formats
 RESOURCE_NAME_FIELD_FORMAT = "metadata.name={name}"

--- a/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
@@ -13,8 +13,19 @@ from .helpers import check_workload_resource_files, get_file_map, run_bundle_com
 logger = get_logger(__name__)
 
 pytestmark = pytest.mark.e2e
-AKRI_PREFIXES = ["aio-akri"]
-AKRI_WORKLOAD_TYPES = ["deployment", "pod", "replicaset", "statefulset", "service", "vwc", "mwc"]
+AKRI_PREFIXES = ["aio-akri", "aiomedia", "aioonvif"]
+AKRI_WORKLOAD_TYPES = [
+    "deployment",
+    "pod",
+    "replicaset",
+    "statefulset",
+    "service",
+    "vwc",
+    "mwc",
+    "connectorinstance",
+    "connectortemplate",
+    "discoveryhandler",
+]
 
 
 def test_create_bundle_akri(cluster_connection, tracked_files):

--- a/azext_edge/tests/edge/support/test_akri_support_unit.py
+++ b/azext_edge/tests/edge/support/test_akri_support_unit.py
@@ -10,6 +10,7 @@ from azext_edge.edge.commands_edge import support_bundle
 from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.support.akri import (
     AKRI_DIRECTORY_PATH,
+    AKRI_MANAGED_BY_OPERATOR_LABEL,
     AKRI_NAME_LABEL_V2,
 )
 from azext_edge.tests.edge.support.test_support_unit import (
@@ -62,6 +63,14 @@ def test_create_bundle_akri(
         directory_path=AKRI_DIRECTORY_PATH,
         since_seconds=since_seconds,
     )
+    assert_list_pods(
+        mocked_client,
+        mocked_zipfile,
+        mocked_list_pods,
+        label_selector=AKRI_MANAGED_BY_OPERATOR_LABEL,
+        directory_path=AKRI_DIRECTORY_PATH,
+        since_seconds=since_seconds,
+    )
     assert_list_deployments(
         mocked_client,
         mocked_zipfile,
@@ -84,6 +93,13 @@ def test_create_bundle_akri(
         mocked_client,
         mocked_zipfile,
         label_selector=AKRI_NAME_LABEL_V2,
+        field_selector=None,
+        directory_path=AKRI_DIRECTORY_PATH,
+    )
+    assert_list_stateful_sets(
+        mocked_client,
+        mocked_zipfile,
+        label_selector=AKRI_MANAGED_BY_OPERATOR_LABEL,
         field_selector=None,
         directory_path=AKRI_DIRECTORY_PATH,
     )


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
