### PR TITLE
fix: fix bug in namespace asset and device query

### DIFF
--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -142,7 +142,7 @@ def get_query(param_mapping: Dict[str, str], params: Dict[str, Union[str, bool]]
     Disabled is treated as a boolean and should not be in the param mapping.
     """
     query = []
-    if "disabled" in params:
+    if "disabled" in params and params["disabled"] is not None:
         query.append(f"| where properties.enabled == {not params.pop('disabled')}")
     for param, value in params.items():
         # TODO: later, add in null support (ex: no os set)

--- a/azext_edge/tests/edge/adr/test_helpers_unit.py
+++ b/azext_edge/tests/edge/adr/test_helpers_unit.py
@@ -399,6 +399,9 @@ def test_get_instance_query(
         "asset_name": generate_random_string(),
         "operating_system": generate_random_string(),
         "disabled": True
+    },
+    {
+        "disabled": None
     }
 ])
 def test_get_query(param_mapping, params):
@@ -408,7 +411,7 @@ def test_get_query(param_mapping, params):
         params=params
     )
     split_query = [q.strip() for q in query.split("|")]
-    if "disabled" in params:
+    if "disabled" in params and params["disabled"] is not None:
         disabled = params.pop("disabled")
         assert f"where properties.enabled == {not disabled}" in split_query
 


### PR DESCRIPTION
Disabled was getting used even though it is None. Updated the unit tests. The integration tests (device) caught this.

This should fix the failing test.
<img width="1534" height="354" alt="image" src="https://github.com/user-attachments/assets/72050e88-f117-4437-9948-8ad646f76c57" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
