### PR TITLE
fix: draft github release from non-default branches

### DIFF
--- a/.github/workflows/stage_release.yml
+++ b/.github/workflows/stage_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-            python-version: "3.13"
+          python-version: "3.13"
       - name: Install and determine version
         run: |
           wheel=$(find ./release/*.whl)
@@ -39,6 +39,14 @@ jobs:
           echo tag: "${{ env.tag }}"
           echo version: "${{ env.version }}"
           echo wheel: "${{ env.wheel }}"
-          gh release create "${{ env.tag }}" --generate-notes -d -t "azure-iot-ops ${{ env.version }}" "${{ env.wheel }}" "./SBOM.zip#SBOM" --repo "${{ github.repository }}"
+          echo target: "${{ github.ref }}"
+          gh release create --draft \
+          "${{ env.tag }}" \
+          "${{ env.wheel }}" \
+          "./SBOM.zip#SBOM" \
+          --repo "${{ github.repository }}" \
+          --target "${{ github.ref }}" \
+          --title "azure-iot-ops ${{ env.version }}" \
+          --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This spaces out the github CLI release create args so we can tweak individual values, but the main thing here is:
` --target "${{ github.ref }}"` 

This ensures our draft release tags and release notes target the branch that the workflow was run against rather than the default `dev`

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
