### PR TITLE
feat: add multi dataset support for `az iot ops ns assets`

### DIFF
--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -959,36 +959,35 @@ def load_iotops_adr_help():
     ] = """
         type: command
         short-summary: Add a dataset to a custom namespaced asset in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
 
         examples:
         - name: Add a basic custom dataset
           text: >
             az iot ops ns asset custom dataset add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "customDataSource"
+            -g myInstanceResourceGroup --name myDataset --data-source "customDataSource"
 
         - name: Add a custom dataset with configuration
           text: >
             az iot ops ns asset custom dataset add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "sensor/pressure"
+            -g myInstanceResourceGroup --name myDataset --data-source "sensor/pressure"
             --config "{\\\"publishingInterval\\\": 1000, \\\"queueSize\\\": 5}"
 
         - name: Add a custom dataset with MQTT destination
           text: >
             az iot ops ns asset custom dataset add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "sensor/temp"
+            -g myInstanceResourceGroup --name myDataset --data-source "sensor/temp"
             --destination topic="factory/temperature" retain=Keep qos=Qos1 ttl=3600
 
         - name: Add a custom dataset with BrokerStateStore destination
           text: >
             az iot ops ns asset custom dataset add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "device/state"
+            -g myInstanceResourceGroup --name myDataset --data-source "device/state"
             --destination key="deviceState"
 
         - name: Add a custom dataset with Storage destination
           text: >
             az iot ops ns asset custom dataset add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "device/logs"
+            -g myInstanceResourceGroup --name myDataset --data-source "device/logs"
             --destination path="data/logs/device001"
     """
 
@@ -1015,7 +1014,7 @@ def load_iotops_adr_help():
         - name: Remove a dataset from a custom asset
           text: >
             az iot ops ns asset custom dataset remove --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default
+            -g myInstanceResourceGroup --name myDataset
     """
 
     helps[
@@ -1028,7 +1027,7 @@ def load_iotops_adr_help():
         - name: Show dataset details
           text: >
             az iot ops ns asset custom dataset show --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default
+            -g myInstanceResourceGroup --name myDataset
     """
 
     helps[
@@ -1041,13 +1040,13 @@ def load_iotops_adr_help():
         - name: Update dataset configuration
           text: >
             az iot ops ns asset custom dataset update --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default --data-source "updated/source"
+            -g myInstanceResourceGroup --name myDataset --data-source "updated/source"
             --config "{\\\"publishingInterval\\\": 2000}"
 
         - name: Update dataset destination to MQTT
           text: >
             az iot ops ns asset custom dataset update --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --name default
+            -g myInstanceResourceGroup --name myDataset
             --destination topic="factory/updated/temperature" retain=Never qos=Qos0 ttl=7200
     """
 
@@ -1068,18 +1067,18 @@ def load_iotops_adr_help():
         - name: Add a basic datapoint
           text: >
             az iot ops ns asset custom datapoint add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "sensor.temp1"
+            -g myInstanceResourceGroup --dataset myDataset --name temp1 --data-source "sensor.temp1"
 
         - name: Add a datapoint with custom configuration
           text: >
             az iot ops ns asset custom datapoint add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --dataset default --name pressure1 --data-source "sensor.pressure1"
+            -g myInstanceResourceGroup --dataset myDataset --name pressure1 --data-source "sensor.pressure1"
             --config "{\\\"samplingInterval\\\": 500, \\\"priority\\\": \\\"high\\\"}"
 
         - name: Add a datapoint and replace existing one with same name
           text: >
             az iot ops ns asset custom datapoint add --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "sensor.temp1.v2"
+            -g myInstanceResourceGroup --dataset myDataset --name temp1 --data-source "sensor.temp1.v2"
             --replace
     """
 
@@ -1093,7 +1092,7 @@ def load_iotops_adr_help():
         - name: List all data points for a dataset
           text: >
             az iot ops ns asset custom datapoint list --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --dataset default
+            -g myInstanceResourceGroup --dataset myDataset
     """
 
     helps[
@@ -1106,7 +1105,7 @@ def load_iotops_adr_help():
         - name: Remove a datapoint from a dataset
           text: >
             az iot ops ns asset custom datapoint remove --asset mycustomasset --instance myInstance
-            -g myInstanceResourceGroup --dataset default --name temp1
+            -g myInstanceResourceGroup --dataset myDataset --name temp1
     """
 
     helps[
@@ -2066,7 +2065,6 @@ def load_iotops_adr_help():
     ] = """
         type: command
         short-summary: Add a dataset to an OPC UA namespaced asset in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
 
         examples:
         - name: Add a basic OPC UA dataset
@@ -2578,7 +2576,6 @@ def load_iotops_adr_help():
     ] = """
         type: command
         short-summary: Add a dataset to a REST namespaced asset in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
 
         examples:
         - name: Add a basic REST dataset

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -419,7 +419,7 @@ class NamespaceAssets(Queryable):
             default=False,
             **kwargs
         )
-        unmatched_datasets.append([
+        unmatched_datasets.append(
             {
                 "name": dataset_name,
                 "dataSource": data_source,
@@ -428,7 +428,7 @@ class NamespaceAssets(Queryable):
                 "dataPoints": [],  # TODO: future pr, add datapoints
                 "typeRef": type_ref
             }
-        ])
+        )
 
         update_payload = {
             "properties": {
@@ -912,7 +912,7 @@ class NamespaceAssets(Queryable):
         )
 
         # check if event exists
-        event_group = _get_sub_property(asset, event_name, property_key="eventGroups")
+        event_group = _get_sub_property(asset, group_name, property_key="eventGroups")
 
         # get the events
         og_events = event_group.get("events", [])
@@ -1819,6 +1819,7 @@ def _get_sub_property(asset: dict, name: str, property_key: str) -> dict:
 
     Raises InvalidArgumentValueError if the subproperty is not found.
     """
+    # TODO: could have partial functions (_get_event_group) for ease
     props = asset["properties"].get(property_key, [])
     matched_props = [event for event in props if event["name"] == name]
     # TODO: would we want to prompt user to create if not found?

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -26,7 +26,6 @@ from ...util.id_tools import parse_resource_id
 from ...util.queryable import Queryable
 from .helpers import (
     ensure_schema_structure,
-    get_default_dataset,
     process_additional_configuration,
 )
 from .namespace_devices import DeviceEndpointType
@@ -397,12 +396,6 @@ class NamespaceAssets(Queryable):
         # TODO: future pr, import datapoints from file
         **kwargs
     ):
-        # TODO: future, multi data support
-        if dataset_name != "default":
-            raise InvalidArgumentValueError(
-                "Currently only one dataset with the name 'default' is supported. "
-                "Please use 'default' as the dataset name."
-            )
         asset, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
             instance_name=instance_name,
@@ -411,13 +404,12 @@ class NamespaceAssets(Queryable):
         )
         # get the datasets from the asset
         datasets = asset["properties"].get("datasets", [])
-
-        # current restriction to one dataset
-        if datasets and not replace:
+        # remove dataset if it exists
+        unmatched_datasets = [ds for ds in datasets if ds["name"] != dataset_name]
+        if len(unmatched_datasets) < len(datasets) and not replace:
             raise InvalidArgumentValueError(
-                "Currently only one dataset with the name 'default' is supported. "
-                "Please use 'default' as the dataset name. If you want to update the dataset properties, "
-                "please use the update command."
+                f"Dataset '{dataset_name}' already exists in asset '{asset_name}'. "
+                "Use --replace to overwrite the existing dataset."
             )
 
         # create the dataset
@@ -426,7 +418,7 @@ class NamespaceAssets(Queryable):
             default=False,
             **kwargs
         )
-        datasets = [
+        unmatched_datasets.append([
             {
                 "name": dataset_name,
                 "dataSource": dataset_data_source,
@@ -434,11 +426,11 @@ class NamespaceAssets(Queryable):
                 "destinations": processed_configs.get("datasetsDestinations", []),
                 "dataPoints": [],  # TODO: future pr, add datapoints
             }
-        ]
+        ])
 
         update_payload = {
             "properties": {
-                "datasets": datasets
+                "datasets": unmatched_datasets
             }
         }
         with console.status(f"Adding dataset {dataset_name} to asset {asset_name}..."):
@@ -472,7 +464,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        return get_default_dataset(asset, dataset_name)
+        return _get_sub_property(asset, dataset_name, property_key="datasets")
 
     def update_dataset(
         self,
@@ -601,7 +593,7 @@ class NamespaceAssets(Queryable):
             asset_type=asset_type,
             asset_name=asset_name
         )
-        dataset = get_default_dataset(asset, dataset_name, create_if_none=True)
+        dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
 
         # get the datapoints
         datapoints = dataset["dataPoints"]
@@ -642,7 +634,7 @@ class NamespaceAssets(Queryable):
                 namespace_name=namespace["name"],
                 resource_group=namespace["resource_group"],
             )
-            return get_default_dataset(asset, dataset_name)["dataPoints"]
+            return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
 
     def list_dataset_datapoints(
         self, asset_name: str, instance_name: str, instance_resource_group: str, dataset_name: str
@@ -652,7 +644,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        return get_default_dataset(asset, dataset_name)["dataPoints"]
+        return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
 
     def remove_dataset_datapoint(
         self,
@@ -671,7 +663,7 @@ class NamespaceAssets(Queryable):
         )
         namespace = parse_resource_id(asset["id"])
 
-        dataset = get_default_dataset(asset, dataset_name)
+        dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
         datapoints = dataset.get("dataPoints", [])
         # note that delete should be ok with datapoint not there
         dataset["dataPoints"] = [dp for dp in datapoints if dp["name"] != datapoint_name]
@@ -702,7 +694,7 @@ class NamespaceAssets(Queryable):
                 namespace_name=namespace["name"],
                 resource_group=namespace["resource_group"],
             )
-            return get_default_dataset(asset, dataset_name)["dataPoints"]
+            return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
 
     # EVENTS - allowed for opcua, and custom assets
     def add_event(
@@ -784,7 +776,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        return _get_event(asset, event_name)
+        return _get_sub_property(asset, event_name, property_key="eventGroups")
 
     def remove_event(
         self, asset_name: str, instance_name: str, instance_resource_group: str, event_name: str, **kwargs
@@ -844,7 +836,7 @@ class NamespaceAssets(Queryable):
             asset_name=asset_name
         )
         # check if event exists
-        event = _get_event(asset, event_name)
+        event = _get_sub_property(asset, event_name, property_key="eventGroups")
 
         # process the configs + destinations
         processed_configs = _process_configs(
@@ -912,7 +904,7 @@ class NamespaceAssets(Queryable):
         )
 
         # check if event exists
-        event = _get_event(asset, event_name)
+        event = _get_sub_property(asset, event_name, property_key="eventGroups")
 
         # get the datapoints
         datapoints = event.get("dataPoints", [])
@@ -984,7 +976,7 @@ class NamespaceAssets(Queryable):
             check_cluster=True
         )
         namespace = parse_resource_id(asset["id"])
-        event = _get_event(asset, event_name)
+        event = _get_sub_property(asset, event_name, property_key="eventGroups")
         datapoints = event.get("dataPoints", [])
         # note that delete should be ok with datapoint not there
         event["dataPoints"] = [dp for dp in datapoints if dp["name"] != datapoint_name]
@@ -1287,7 +1279,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        return _get_mgmt_group(asset, group_name)
+        return _get_sub_property(asset, group_name, property_key="managementGroups")
 
     def remove_management_group(
         self,
@@ -1351,7 +1343,7 @@ class NamespaceAssets(Queryable):
         )
         # check if management group exists
         mgmt_groups = asset["properties"].get("managementGroups", [])
-        mgmt_group = _get_mgmt_group(asset, group_name)
+        mgmt_group = _get_sub_property(asset, group_name, property_key="managementGroups")
 
         # process the configs + destinations
         processed_configs = _process_configs(
@@ -1415,7 +1407,7 @@ class NamespaceAssets(Queryable):
             asset_type=asset_type,
             asset_name=asset_name
         )
-        mgmt_group = _get_mgmt_group(asset, group_name)
+        mgmt_group = _get_sub_property(asset, group_name, property_key="managementGroups")
 
         actions = mgmt_group.get("actions", [])
         unmatched_actions = [action for action in actions if action["name"] != action_name]
@@ -1469,7 +1461,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
-        mgmt_group = _get_mgmt_group(asset, group_name)
+        mgmt_group = _get_sub_property(asset, group_name, property_key="managementGroups")
         return mgmt_group.get("actions", [])
 
     def remove_management_group_action(
@@ -1488,7 +1480,7 @@ class NamespaceAssets(Queryable):
             check_cluster=True
         )
         namespace = parse_resource_id(asset["id"])
-        mgmt_group = _get_mgmt_group(asset, group_name)
+        mgmt_group = _get_sub_property(asset, group_name, property_key="managementGroups")
 
         actions = mgmt_group.get("actions", [])
         # note that delete should be ok with action not there
@@ -1751,30 +1743,21 @@ def _create_datapoint(
     return datapoint
 
 
-def _get_event(asset: dict, event_name: str) -> dict:
-    """Helper function to get an event from an asset.
+def _get_sub_property(asset: dict, name: str, property_key: str) -> dict:
+    """Helper function to get a dataset, event groups, or management groups from an asset.
 
-    Raises InvalidArgumentValueError if the event is not found.
+    Raises InvalidArgumentValueError if the subproperty is not found.
     """
-    events = asset["properties"].get("events", [])
-    matched_events = [event for event in events if event["name"] == event_name]
-    if not matched_events:
-        raise InvalidArgumentValueError(f"Event '{event_name}' not found in asset '{asset['name']}'.")
-    return matched_events[0]
-
-
-def _get_mgmt_group(asset: dict, management_group_name: str) -> dict:
-    """Helper function to get a management group from an asset.
-
-    Raises InvalidArgumentValueError if the management group is not found.
-    """
-    mgmt_groups = asset["properties"].get("managementGroups", [])
-    matched_mgmt_groups = [mgmt for mgmt in mgmt_groups if mgmt["name"] == management_group_name]
-    if not matched_mgmt_groups:
-        raise InvalidArgumentValueError(
-            f"Management group '{management_group_name}' not found in asset '{asset['name']}'."
-        )
-    return matched_mgmt_groups[0]
+    props = asset["properties"].get(property_key, [])
+    matched_props = [event for event in props if event["name"] == name]
+    # TODO: would we want to prompt user to create if not found?
+    if not matched_props:
+        property_name = property_key.capitalize()[:-1]
+        # deal with managment groups + event groups
+        if property_name.endswith("group"):
+            property_name = property_name[:-5] + " group"
+        raise InvalidArgumentValueError(f"{property_name} '{name}' not found in asset '{asset['name']}'.")
+    return matched_props[0]
 
 
 def _process_configs(

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -1017,7 +1017,7 @@ def load_adr_arguments(self, _):
         context.argument(
             "type_ref",
             options_list=["--type-ref", "--tr"],
-            help="Type Definition ID or URI.",
+            help="Type definition ID or URI.",
         )
 
     with self.argument_context("iot ops ns asset query") as context:

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -25,7 +25,8 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     device_name = f"dev-{generate_random_string(8, force_lower=True)}"
     endpoint_name = f"custom-{generate_random_string(8)}"
     asset_name = f"custom-{generate_random_string(8, force_lower=True)}"
-    dataset_name = "default"
+    dataset_name_1 = f"dataset{generate_random_string(6, force_lower=True)}"
+    dataset_name_2 = f"dataset2{generate_random_string(6, force_lower=True)}"
     datapoint_name_1 = f"dp1-{generate_random_string(6, force_lower=True)}"
     datapoint_name_2 = f"dp2-{generate_random_string(6, force_lower=True)}"
 
@@ -61,7 +62,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     # Add custom asset dataset
     dataset_result = run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {dataset_data_source} "
         f"--destination {dataset_destinations} "
         f"--config {custom_config_path}"
@@ -69,7 +70,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     assert_dataset_properties(
         dataset_result,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="custom",
         custom_configuration=custom_config
@@ -82,18 +83,18 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     )
 
     dataset_names = [dataset["name"] for dataset in datasets_list]
-    assert dataset_name in dataset_names
+    assert dataset_name_1 in dataset_names
     assert len(datasets_list) >= 1
 
     # 3. SHOW DATASET
     shown_dataset = run(
         f"az iot ops ns asset custom dataset show --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     assert_dataset_properties(
         shown_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="custom"
     )
@@ -105,7 +106,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     updated_dataset = run(
         f"az iot ops ns asset custom dataset update --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {updated_data_source} "
         f"--destination {updated_destinations} "
         f"--config {custom_config_path}"
@@ -113,30 +114,47 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     assert_dataset_properties(
         updated_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=updated_data_source,
         asset_type="custom",
         custom_configuration=custom_config
     )
 
-    # 5. TEST DATASET REPLACE FUNCTIONALITY
+    # 5a. TEST DATASET REPLACE FUNCTIONALITY
     # Replace dataset with --replace flag
     replaced_data_source = "sensor/temperature_replaced"
     custom_config_path, custom_config = create_config_file(tracked_files)
 
     replaced_dataset = run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {replaced_data_source} "
         f"--config {custom_config_path} --replace"
     )
 
     assert_dataset_properties(
         replaced_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=replaced_data_source,
         asset_type="custom",
         custom_configuration=custom_config
+    )
+
+    # 5b. TEST MULTIPLE DATASETS
+    data_source = "sensor/temperature_replaced"
+
+    dataset = run(
+        f"az iot ops ns asset custom dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_2} "
+        f"--data-source {data_source} "
+        f"--config {custom_config_path} --replace"
+    )
+
+    assert_dataset_properties(
+        dataset,
+        name=dataset_name_2,
+        data_source=data_source,
+        asset_type="custom",
     )
 
     # 6. ADD DATASET DATAPOINTS
@@ -146,7 +164,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     datapoint_result_1 = run(
         f"az iot ops ns asset custom datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_1} --data-source {datapoint_data_source_1} "
         f"--config {custom_config_path}"
     )
@@ -163,7 +181,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     datapoint_result_2 = run(
         f"az iot ops ns asset custom datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_2} --data-source {datapoint_data_source_2} "
         f"--config {custom_config_path}"
     )
@@ -177,7 +195,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     # 7. LIST DATASET DATAPOINTS
     datapoints_list = run(
         f"az iot ops ns asset custom datapoint list --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1}"
     )
 
     datapoint_names = [dp["name"] for dp in datapoints_list]
@@ -192,7 +210,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
 
     replaced_datapoint = run(
         f"az iot ops ns asset custom datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_1} --data-source {replaced_datapoint_data_source} "
         f"--config {custom_config_path} --replace"
     )
@@ -206,14 +224,14 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     # 9. REMOVE DATASET DATAPOINT
     run(
         f"az iot ops ns asset custom datapoint remove --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_2}"
     )
 
     # Verify datapoint removal
     datapoints_list_after_remove = run(
         f"az iot ops ns asset custom datapoint list --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1}"
     )
 
     remaining_datapoint_names = [dp["name"] for dp in datapoints_list_after_remove]
@@ -223,7 +241,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     # 10. REMOVE DATASET
     run(
         f"az iot ops ns asset custom dataset remove --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     # Verify dataset removal
@@ -233,7 +251,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     )
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
-    assert dataset_name not in remaining_dataset_names
+    assert dataset_name_1 not in remaining_dataset_names
 
 
 def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracked_resources: List[str]):
@@ -244,7 +262,8 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     device_name = f"dev-{generate_random_string(8, force_lower=True)}"
     endpoint_name = f"opcua-{generate_random_string(8)}"
     asset_name = f"opcua-{generate_random_string(8, force_lower=True)}"
-    dataset_name = "default"
+    dataset_name_1 = f"dataset{generate_random_string(6, force_lower=True)}"
+    dataset_name_2 = f"dataset2{generate_random_string(6, force_lower=True)}"
     datapoint_name_1 = f"dp1-{generate_random_string(6, force_lower=True)}"
     datapoint_name_2 = f"dp2-{generate_random_string(6, force_lower=True)}"
 
@@ -278,7 +297,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     # Add OPCUA asset dataset with specific OPCUA parameters
     dataset_result = run(
         f"az iot ops ns asset opcua dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source \"{dataset_data_source}\" "
         f"--destination {dataset_destinations} "
         f"--publish-int 1000 "
@@ -289,7 +308,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     assert_dataset_properties(
         dataset_result,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="opcua",
         publishing_interval=1000,
@@ -302,18 +321,18 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     )
 
     dataset_names = [dataset["name"] for dataset in datasets_list]
-    assert dataset_name in dataset_names
+    assert dataset_name_1 in dataset_names
     assert len(datasets_list) >= 1
 
     # 3. SHOW DATASET
     shown_dataset = run(
         f"az iot ops ns asset opcua dataset show --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     assert_dataset_properties(
         shown_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="opcua",
         publishing_interval=1000,
@@ -325,7 +344,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     updated_dataset = run(
         f"az iot ops ns asset opcua dataset update --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source \"{updated_data_source}\" "
         f"--destination {updated_destinations} "
         f"--publish-int 2000 "
@@ -335,27 +354,45 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     assert_dataset_properties(
         updated_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=updated_data_source,
         asset_type="opcua",
         publishing_interval=2000,
     )
 
-    # 5. TEST DATASET REPLACE FUNCTIONALITY
+    # 5a. TEST DATASET REPLACE FUNCTIONALITY
     # Replace dataset with --replace flag
     replaced_data_source = "ns=2;i=1003"
 
     replaced_dataset = run(
         f"az iot ops ns asset opcua dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source \"{replaced_data_source}\" "
         f"--publish-int 3000 --replace"
     )
 
     assert_dataset_properties(
         replaced_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=replaced_data_source,
+        asset_type="opcua",
+        publishing_interval=3000
+    )
+
+    # 5. TEST MULTIPLE DATASETS
+    data_source = "ns=5;i=1005"
+
+    dataset = run(
+        f"az iot ops ns asset opcua dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_2} "
+        f"--data-source \"{data_source}\" "
+        f"--publish-int 3000 --replace"
+    )
+
+    assert_dataset_properties(
+        dataset,
+        name=dataset_name_2,
+        data_source=data_source,
         asset_type="opcua",
         publishing_interval=3000
     )
@@ -366,7 +403,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     datapoint_result_1 = run(
         f"az iot ops ns asset opcua datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_1} --data-source \"{datapoint_data_source_1}\" "
         f"--queue-size 5 --sampling-int 250"
     )
@@ -382,7 +419,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     datapoint_result_2 = run(
         f"az iot ops ns asset opcua datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_2} --data-source \"{datapoint_data_source_2}\" "
         f"--queue-size 3 --sampling-int 500"
     )
@@ -396,7 +433,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     # 7. LIST DATASET DATAPOINTS
     datapoints_list = run(
         f"az iot ops ns asset opcua datapoint list --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1}"
     )
 
     datapoint_names = [dp["name"] for dp in datapoints_list]
@@ -410,7 +447,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
 
     replaced_datapoint = run(
         f"az iot ops ns asset opcua datapoint add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_1} --data-source \"{replaced_datapoint_data_source}\" "
         f"--queue-size 15 --sampling-int 100 --replace"
     )
@@ -424,14 +461,14 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     # 9. REMOVE DATASET DATAPOINT
     run(
         f"az iot ops ns asset opcua datapoint remove --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1} "
         f"--name {datapoint_name_2}"
     )
 
     # Verify datapoint removal
     datapoints_list_after_remove = run(
         f"az iot ops ns asset opcua datapoint list --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name_1}"
     )
 
     remaining_datapoint_names = [dp["name"] for dp in datapoints_list_after_remove]
@@ -441,7 +478,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     # 10. REMOVE DATASET
     run(
         f"az iot ops ns asset opcua dataset remove --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     # Verify dataset removal
@@ -451,7 +488,7 @@ def test_namespace_opcua_asset_dataset_lifecycle_operations(require_init, tracke
     )
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
-    assert dataset_name not in remaining_dataset_names
+    assert dataset_name_1 not in remaining_dataset_names
 
 
 def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked_resources: List[str]):
@@ -462,7 +499,7 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     device_name = f"dev-{generate_random_string(8, force_lower=True)}"
     endpoint_name = f"rest-{generate_random_string(8)}"
     asset_name = f"rest-{generate_random_string(8, force_lower=True)}"
-    dataset_name = "default"
+    dataset_name_1 = f"dataset{generate_random_string(6, force_lower=True)}"
 
     # Create Device
     result = run(
@@ -494,7 +531,7 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     # Add REST asset dataset with specific REST parameters
     dataset_result = run(
         f"az iot ops ns asset rest dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {dataset_data_source} "
         f"--destination {dataset_destinations} "
         f"--sampling-int 5000"
@@ -502,7 +539,7 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
 
     assert_dataset_properties(
         dataset_result,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="rest",
     )
@@ -514,18 +551,18 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     )
 
     dataset_names = [dataset["name"] for dataset in datasets_list]
-    assert dataset_name in dataset_names
+    assert dataset_name_1 in dataset_names
     assert len(datasets_list) >= 1
 
     # 3. SHOW DATASET
     shown_dataset = run(
         f"az iot ops ns asset rest dataset show --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     assert_dataset_properties(
         shown_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=dataset_data_source,
         asset_type="rest",
     )
@@ -535,14 +572,14 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
 
     updated_dataset = run(
         f"az iot ops ns asset rest dataset update --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--destination {updated_destinations} "
         f"--sampling-int 10000"
     )
 
     assert_dataset_properties(
         updated_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         asset_type="rest",
     )
 
@@ -553,14 +590,14 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
 
     replaced_dataset = run(
         f"az iot ops ns asset rest dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {replaced_data_source} --dest {broker_destinations} "
         f"--sampling-int 15000 --replace"
     )
 
     assert_dataset_properties(
         replaced_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=replaced_data_source,
         asset_type="rest",
     )
@@ -568,7 +605,7 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     # Verify the destination was updated
     shown_broker_dataset = run(
         f"az iot ops ns asset rest dataset show --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     # Check that destination target is BrokerStateStore
@@ -583,13 +620,13 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
 
     minimal_dataset = run(
         f"az iot ops ns asset rest dataset add --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
         f"--data-source {minimal_data_source} --replace"
     )
 
     assert_dataset_properties(
         minimal_dataset,
-        name=dataset_name,
+        name=dataset_name_1,
         data_source=minimal_data_source,
         asset_type="rest"
     )
@@ -597,7 +634,7 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     # 8. REMOVE DATASET
     run(
         f"az iot ops ns asset rest dataset remove --asset {asset_name} "
-        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
     )
 
     # Verify dataset removal
@@ -607,4 +644,4 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
     )
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
-    assert dataset_name not in remaining_dataset_names
+    assert dataset_name_1 not in remaining_dataset_names

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -128,7 +128,7 @@ def test_add_namespace_asset_dataset(
     asset_name = "testAsset"
     instance_name = "testInstance"
     instance_resource_group = "testInstanceResourceGroup"
-    dataset_name = "default"  # Currently only one dataset with name "default" is supported
+    dataset_name = f"dataset{randint(0, 100)}"
     data_source = f"nsu=http://microsoft.com/Opc/OpcPlc/Oven;i={randint(1, 1000)}"
 
     # Get the namespace from the mocked function
@@ -185,7 +185,12 @@ def test_add_namespace_asset_dataset(
 
     # Add previous datasets if needed for the test case
     if previous_datasets:
-        mocked_asset["properties"]["datasets"] = [generate_dataset(num_data_points=randint(0, 2))]
+        mocked_asset["properties"]["datasets"] = [
+            generate_dataset(num_data_points=randint(0, 2)) for _ in range(2)
+        ]
+
+        if replace:
+            mocked_asset["properties"]["datasets"].append(generate_dataset(dataset_name=dataset_name))
 
     # Mock the device endpoint check
     add_device_get_call(
@@ -212,8 +217,14 @@ def test_add_namespace_asset_dataset(
     # Create updated asset for mock response
     updated_asset = deepcopy(mocked_asset)
 
-    # Since we have singular support for now
-    updated_asset["properties"]["datasets"] = [expected_dataset]
+    updated_asset["properties"]["datasets"] = updated_asset["properties"].get("datasets", [])
+
+    if replace:
+        updated_asset["properties"]["datasets"] = [
+            d for d in updated_asset["properties"]["datasets"] if d["name"] != dataset_name
+        ]
+
+    updated_asset["properties"]["datasets"].append(expected_dataset)
 
     # Mock PATCH request
     mocked_responses.add(
@@ -310,15 +321,14 @@ def test_add_namespace_asset_dataset_error(
     """Test error cases for adding asset datasets with different asset types.
 
     Tests the following scenarios:
-    - Adding dataset not named "default"
     - Mismatch between asset type and device endpoint type
-    - Adding dataset to an asset where there is already an existing dataset (more than one dataset)
+    - Adding dataset with the same name with no replace
     """
 
     asset_name = "testAsset"
     instance_name = "testInstance"
     instance_resource_group = "testInstanceResourceGroup"
-    dataset_name = "default"
+    dataset_name = f"dataset{randint(0, 100)}"
     data_source = f"nsu=http://microsoft.com/Opc/OpcPlc/Oven;i={randint(1, 1000)}"
 
     # Get the namespace from the mocked function
@@ -337,19 +347,7 @@ def test_add_namespace_asset_dataset_error(
         "wait_sec": 0
     }
 
-    # 1st non default dataset name
-    with pytest.raises(InvalidArgumentValueError) as exc_info:
-        command_func(
-            # awkward dict update
-            **{**base_params, "dataset_name": generate_random_string()}
-        )
-    error_msg = (
-        "Currently only one dataset with the name 'default' is supported. "
-        "Please use 'default' as the dataset name."
-    )
-    assert error_msg in str(exc_info.value)
-
-    # 2nd mismatch between asset type and device endpoint type
+    # 1st mismatch between asset type and device endpoint type
     # Generate mock asset
     mocked_asset = get_namespace_asset_record(
         asset_name=asset_name,
@@ -415,8 +413,7 @@ def test_add_namespace_asset_dataset_error(
     with pytest.raises(InvalidArgumentValueError) as excinfo:
         command_func(**base_params)
 
-    error_msg += " If you want to update the dataset properties, please use the update command."
-    assert error_msg in str(excinfo.value)
+    assert f"Dataset '{dataset_name}' already exists in asset '{asset_name}'. " in str(excinfo.value)
 
     # Verify that mocked_get_namespace_for_instance was called with correct parameters
     mocked_get_namespace_for_instance.assert_called_with(

--- a/azext_edge/tests/edge/adr/test_namespace_asset_helpers_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_helpers_unit.py
@@ -18,7 +18,7 @@ from azext_edge.edge.providers.adr.namespace_devices import DeviceEndpointType
 from azext_edge.edge.providers.adr.namespace_assets import (
     _build_destination,
     _create_datapoint,
-    _get_event,
+    _get_sub_property,
     _process_configs,
     _process_opcua_dataset_configurations_v1,
     _process_opcua_event_configurations_v1,
@@ -135,65 +135,40 @@ def test_build_destination_error(test_case: dict):
         assert msg in str(excinfo.value)
 
 
-@pytest.mark.parametrize("num_events", [1, 5, 10])
-def test_get_event(num_events: int):
-    from .test_namespace_asset_events_unit import generate_event
-    test_event = generate_random_string()
-    asset = {
-        "name": "testAsset",
-        "properties": {
-            "events": []
-        }
-    }
+@pytest.mark.parametrize("property_key", ["datasets", "eventGroups", "managementGroups"])
+def test_get_sub_property_success(property_key: str):
+    test_name = generate_random_string()
+    asset = {"name": "testAsset", "properties": {property_key: []}}
 
-    for i in range(num_events):
-        asset["properties"]["events"].append(generate_event(f"testEvent{i}"))
+    # add some non-matching entries
+    for i in range(3):
+        asset["properties"][property_key].append({"name": f"other{i}", "dataSource": f"src{i}"})
 
-    # Set up events in asset properties
-    asset["properties"]["events"].append(generate_event(test_event))
+    # append the target entry
+    expected = {"name": test_name, "dataSource": "nsu=test;s=SourceX"}
+    asset["properties"][property_key].append(expected)
 
-    # Test success case
-    result = _get_event(asset, test_event)
-    assert result["name"] == test_event
-    # lazy way cause the event is last
-    assert result == asset["properties"]["events"][-1]
+    result = _get_sub_property(asset, test_name, property_key=property_key)
+    assert result == expected
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "event_name": generate_random_string(),
-        "events": [
-            {
-                "name": f"another{generate_random_string()}",
-                "eventNotifier": "nsu=test;s=FastUInt456",
-            }
-        ],
-    },
-    {
-        "event_name": generate_random_string(),
-        "events": [],
-    },
-    {
-        "event_name": generate_random_string(),
-        "events": None,
-    }
-])
-def test_get_event_error(test_case):
-    """Test error handling when an event is not found in an asset."""
-    asset = {
-        "name": "testAsset",
-        "properties": {}
-    }
+@pytest.mark.parametrize("property_key", ["datasets", "eventGroups", "managementGroups"])
+def test_get_sub_property_error(property_key):
+    name = generate_random_string()
+    asset = {"name": "testAsset", "properties": {}}
 
-    # Set up events in asset properties if provided
-    if test_case["events"] is not None:
-        asset["properties"]["events"] = test_case["events"]
-
-    # Test error cases
+    # when property list missing
     with pytest.raises(InvalidArgumentValueError) as ex:
-        _get_event(asset, test_case["event_name"])
-    error_msg = f"Event '{test_case['event_name']}' not found in asset '{asset['name']}'."
-    assert error_msg in str(ex.value)
+        _get_sub_property(asset, name, property_key=property_key)
+
+    name_map = {
+        "datasets": "Dataset",
+        "eventGroups": "Event group",
+        "managementGroups": "Management group"
+    }
+    property_name = name_map[property_key]
+    expected_msg = f"{property_name} '{name}' not found in asset '{asset['name']}'."
+    assert expected_msg in str(ex.value)
 
 
 @pytest.mark.parametrize("test_case", [


### PR DESCRIPTION
For multi dataset, removed the constraints on having one dataset + the dataset name having to be default.

Int tests not actually tested since service is not there yet.

TODO (in no order):
- fix up int tests
- x509 support for device endpoints
- import/export sub properties
- transfer sub properties between different properties (ex: move all datapoints from one dataset to another)
- dynamic schemas
- remove deletemeasset.json once no longer needed
- make sure schema + registries work with latest API

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
