### PR TITLE
feat: add create and update for Open telemetry dataflow endpoint

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1377,6 +1377,45 @@ def load_iotops_help():
     """
 
     helps[
+        "iot ops dataflow endpoint create otel"
+    ] = """
+        type: command
+        short-summary: Create or replace an OpenTelemetry dataflow endpoint.
+        long-summary: For more information on OpenTelemetry dataflow endpoint, see https://aka.ms/opentelemetry-endpoint.
+
+        examples:
+        - name: Create or replace a dataflow endpoint resource with minimum input.
+          text: >
+            az iot ops dataflow endpoint create otel
+            --name myendpoint
+            --instance mycluster-ops-instance
+            --resource-group myresourcegroup
+            --name myendpoint
+            --hostname https://otel-collector.monitoring.svc.cluster.local
+            --port 4317
+            --no-auth
+        - name: Show config for creating a dataflow endpoint resource.
+          text: >
+            az iot ops dataflow endpoint create otel
+            --name myendpoint
+            --instance mycluster-ops-instance
+            --resource-group myresourcegroup
+            --hostname https://otel-collector.monitoring.svc.cluster.local
+            --port 4317
+            --no-auth
+            --show-config
+        - name: Create or replace a dataflow endpoint resource using X509 authentication method.
+          text: >
+            az iot ops dataflow endpoint create otel
+            --name myendpoint
+            --instance mycluster-ops-instance
+            --resource-group myresourcegroup
+            --hostname https://otel-collector.monitoring.svc.cluster.local
+            --port 4317
+            --secret-name mysecret
+    """
+
+    helps[
         "iot ops dataflow endpoint update"
     ] = """
         type: group
@@ -1622,6 +1661,31 @@ def load_iotops_help():
             --instance mycluster-ops-instance
             --resource-group myresourcegroup
             --pvc-ref newpvc
+    """
+
+    helps[
+        "iot ops dataflow endpoint update otel"
+    ] = """
+        type: command
+        short-summary: Update the properties of an existing OpenTelemetry dataflow endpoint.
+        long-summary: For more information on OpenTelemetry dataflow endpoint, see https://aka.ms/opentelemetry-endpoint.
+
+        examples:
+        - name: Update the config map reference for trusted CA certificate of the dataflow endpoint resource called 'myendpoint'.
+          text: >
+            az iot ops dataflow endpoint update otel
+            --name myendpoint
+            --instance mycluster-ops-instance
+            --resource-group myresourcegroup
+            --config-map-ref mynewconfigmap
+        - name: Update to use Kubernetes Service Account Token authentication method of the dataflow endpoint resource called 'myendpoint'.
+          text: >
+            az iot ops dataflow endpoint update otel
+            --name myendpoint
+            --instance mycluster-ops-instance
+            --resource-group myresourcegroup
+            --auth-type ServiceAccountToken
+            --audience myaudience
     """
 
     helps[

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -170,6 +170,7 @@ def load_iotops_commands(self, _):
         cmd_group.command("local-mqtt", "create_dataflow_endpoint_aio")
         cmd_group.command("eventgrid", "create_dataflow_endpoint_eventgrid")
         cmd_group.command("custom-mqtt", "create_dataflow_endpoint_custom_mqtt")
+        cmd_group.command("otel", "create_dataflow_endpoint_otel")
 
     with self.command_group(
         "iot ops dataflow endpoint update",
@@ -185,6 +186,7 @@ def load_iotops_commands(self, _):
         cmd_group.command("local-mqtt", "update_dataflow_endpoint_aio")
         cmd_group.command("eventgrid", "update_dataflow_endpoint_eventgrid")
         cmd_group.command("custom-mqtt", "update_dataflow_endpoint_custom_mqtt")
+        cmd_group.command("otel", "update_dataflow_endpoint_otel")
 
     with self.command_group(
         "iot ops registry",

--- a/azext_edge/edge/commands_dataflow.py
+++ b/azext_edge/edge/commands_dataflow.py
@@ -658,7 +658,7 @@ def create_dataflow_endpoint_otel(
     secret_name: Optional[str] = None,
     config_map_reference: Optional[str] = None,
     authentication_type: Optional[str] = None,
-    show_config: Optional[str] = None,
+    show_config: Optional[bool] = None,
 ) -> dict:
 
     return DataFlowEndpoints(cmd).create(
@@ -1151,7 +1151,7 @@ def update_dataflow_endpoint_otel(
     secret_name: Optional[str] = None,
     config_map_reference: Optional[str] = None,
     authentication_type: Optional[str] = None,
-    show_config: Optional[str] = None,
+    show_config: Optional[bool] = None,
 ) -> dict:
 
     return DataFlowEndpoints(cmd).update(

--- a/azext_edge/edge/commands_dataflow.py
+++ b/azext_edge/edge/commands_dataflow.py
@@ -643,6 +643,43 @@ def create_dataflow_endpoint_custom_mqtt(
     )
 
 
+def create_dataflow_endpoint_otel(
+    cmd,
+    endpoint_name: str,
+    instance_name: str,
+    resource_group_name: str,
+    hostname: str,
+    port: int,
+    latency: int = 60,
+    message_count: int = 100000,
+    tls_disabled: bool = False,
+    no_auth: bool = False,
+    audience: Optional[str] = None,
+    secret_name: Optional[str] = None,
+    config_map_reference: Optional[str] = None,
+    authentication_type: Optional[str] = None,
+    show_config: Optional[str] = None,
+) -> dict:
+
+    return DataFlowEndpoints(cmd).create(
+        name=endpoint_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        endpoint_type=DataflowEndpointType.OPENTELEMETRY.value,
+        latency=latency,
+        message_count=message_count,
+        tls_disabled=tls_disabled,
+        no_auth=no_auth,
+        port=port,
+        hostname=hostname,
+        sat_audience=audience,
+        x509_secret_name=secret_name,
+        config_map_reference=config_map_reference,
+        authentication_type=authentication_type,
+        show_config=show_config,
+    )
+
+
 def update_dataflow_endpoint_adx(
     cmd,
     endpoint_name: str,
@@ -1094,6 +1131,43 @@ def update_dataflow_endpoint_custom_mqtt(
         config_map_reference=config_map_reference,
         cloud_event_attribute=cloud_event_attribute,
         no_auth=no_auth,
+        authentication_type=authentication_type,
+        show_config=show_config,
+    )
+
+
+def update_dataflow_endpoint_otel(
+    cmd,
+    endpoint_name: str,
+    instance_name: str,
+    resource_group_name: str,
+    hostname: Optional[str] = None,
+    port: Optional[int] = None,
+    latency: Optional[int] = None,
+    message_count: Optional[int] = None,
+    tls_disabled: Optional[bool] = None,
+    no_auth: Optional[bool] = None,
+    audience: Optional[str] = None,
+    secret_name: Optional[str] = None,
+    config_map_reference: Optional[str] = None,
+    authentication_type: Optional[str] = None,
+    show_config: Optional[str] = None,
+) -> dict:
+
+    return DataFlowEndpoints(cmd).update(
+        name=endpoint_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        endpoint_type=DataflowEndpointType.OPENTELEMETRY.value,
+        latency=latency,
+        message_count=message_count,
+        tls_disabled=tls_disabled,
+        no_auth=no_auth,
+        port=port,
+        hostname=hostname,
+        sat_audience=audience,
+        x509_secret_name=secret_name,
+        config_map_reference=config_map_reference,
         authentication_type=authentication_type,
         show_config=show_config,
     )

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -453,6 +453,13 @@ def load_iotops_arguments(self, _):
             help="ID of consumer group that the data flow uses to read messages " "from the Kafka topic.",
         )
         context.argument(
+            "latency",
+            options_list=["--latency", "-l"],
+            help="The batching latency in milliseconds. Min value: 0, max value: 65535.",
+            type=int,
+            arg_group="Batching Configuration",
+        )
+        context.argument(
             "partition_strategy",
             options_list=["--partition-strategy", "--ps"],
             arg_type=get_enum_type(KafkaPartitionStrategyType, default=KafkaPartitionStrategyType.DEFAULT.value),
@@ -465,6 +472,15 @@ def load_iotops_arguments(self, _):
             arg_type=get_enum_type(AuthenticationSaslType, default=None),
             help="The type of SASL authentication.",
             arg_group="SASL Authentication",
+        )
+        context.argument(
+            "secret_name",
+            options_list=["--secret-name", "-s"],
+            help="The name for the kubernetes secret that contains the X509 client certificate, private key "
+            "corresponding to the client certificate, and intermediate certificates for the client certificate "
+            "chain. "
+            "Note: The certificate and private key must be in PEM format and not password protected.",
+            arg_group="X509 Authentication",
         )
         context.argument(
             "tls_disabled",
@@ -617,13 +633,6 @@ def load_iotops_arguments(self, _):
                 help="The name of the Event Hubs namespace.",
             )
             context.argument(
-                "latency",
-                options_list=["--latency", "-l"],
-                help="The batching latency in milliseconds. Min value: 0, max value: 65535.",
-                type=int,
-                arg_group="Batching Configuration",
-            )
-            context.argument(
                 "secret_name",
                 options_list=["--secret-name", "-s"],
                 help="The name for the kubernetes secret that contains event hub connection string. "
@@ -656,13 +665,6 @@ def load_iotops_arguments(self, _):
                 "'Bootstrap server' value. Can be found in "
                 "event stream destination -- 'SAS Key Authentication' "
                 "section. In the form of *.servicebus.windows.net:9093",
-            )
-            context.argument(
-                "latency",
-                options_list=["--latency", "-l"],
-                help="The batching latency in milliseconds. Min value: 0, max value: 65535.",
-                type=int,
-                arg_group="Batching Configuration",
             )
             context.argument(
                 "secret_name",
@@ -700,13 +702,6 @@ def load_iotops_arguments(self, _):
                 options_list=["--port"],
                 help="The port number of the Kafka broker host setting.",
                 type=int,
-            )
-            context.argument(
-                "latency",
-                options_list=["--latency", "-l"],
-                help="The batching latency in milliseconds. Min value: 0, max value: 65535.",
-                type=int,
-                arg_group="Batching Configuration",
             )
             context.argument(
                 "secret_name",
@@ -761,15 +756,6 @@ def load_iotops_arguments(self, _):
                 arg_group="Kubernetes Service Account Token",
             )
             context.argument(
-                "secret_name",
-                options_list=["--secret-name", "-s"],
-                help="The name for the kubernetes secret that contains the X509 client certificate, private key "
-                "corresponding to the client certificate, and intermediate certificates for the client certificate "
-                "chain. "
-                "Note: The certificate and private key must be in PEM format and not password protected.",
-                arg_group="X509 Authentication",
-            )
-            context.argument(
                 "authentication_type",
                 options_list=["--auth-type"],
                 choices=CaseInsensitiveList(
@@ -797,15 +783,6 @@ def load_iotops_arguments(self, _):
                 options_list=["--port"],
                 help="The port number of the event grid namespace.",
                 type=int,
-            )
-            context.argument(
-                "secret_name",
-                options_list=["--secret-name", "-s"],
-                help="The name for the kubernetes secret that contains the X509 client certificate, private key "
-                "corresponding to the client certificate, and intermediate certificates for the client certificate "
-                "chain. "
-                "Note: The certificate and private key must be in PEM format and not password protected.",
-                arg_group="X509 Authentication",
             )
             context.argument(
                 "authentication_type",
@@ -836,15 +813,6 @@ def load_iotops_arguments(self, _):
                 type=int,
             )
             context.argument(
-                "secret_name",
-                options_list=["--secret-name", "-s"],
-                help="The name for the kubernetes secret that contains the X509 client certificate, private key "
-                "corresponding to the client certificate, and intermediate certificates for the client certificate "
-                "chain. "
-                "Note: The certificate and private key must be in PEM format and not password protected.",
-                arg_group="X509 Authentication",
-            )
-            context.argument(
                 "sami_audience",
                 options_list=["--sami-audience", "--sami-aud"],
                 help="The audience of the system assigned managed identity.",
@@ -864,6 +832,33 @@ def load_iotops_arguments(self, _):
                         DataflowEndpointAuthenticationType.SERVICEACCESSTOKEN.value,
                         DataflowEndpointAuthenticationType.SYSTEMASSIGNED.value,
                         DataflowEndpointAuthenticationType.USERASSIGNED.value,
+                        DataflowEndpointAuthenticationType.X509.value,
+                    ]
+                ),
+            )
+
+    for cmd_space in [
+        "iot ops dataflow endpoint create otel",
+        "iot ops dataflow endpoint update otel",
+    ]:
+        with self.argument_context(cmd_space) as context:
+            context.argument(
+                "hostname",
+                options_list=["--hostname"],
+                help="The hostname of the open telemetry setting.",
+            )
+            context.argument(
+                "port",
+                options_list=["--port"],
+                help="The port number of the open telemetry setting.",
+                type=int,
+            )
+            context.argument(
+                "authentication_type",
+                options_list=["--auth-type"],
+                choices=CaseInsensitiveList(
+                    [
+                        DataflowEndpointAuthenticationType.SERVICEACCESSTOKEN.value,
                         DataflowEndpointAuthenticationType.X509.value,
                     ]
                 ),

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -160,6 +160,7 @@ class DataflowEndpointType(Enum):
     EVENTHUB = "EventHub"
     FABRICREALTIME = "FabricRealTime"
     CUSTOMKAFKA = "CustomKafka"
+    OPENTELEMETRY = "OpenTelemetry"
 
 
 class DataflowEndpointAuthenticationType(Enum):
@@ -265,6 +266,11 @@ DATAFLOW_ENDPOINT_AUTHENTICATION_TYPE_MAP = {
         DataflowEndpointAuthenticationType.SASL.value,
         DataflowEndpointAuthenticationType.ANONYMOUS.value,
     },
+    DataflowEndpointType.OPENTELEMETRY.value: {
+        DataflowEndpointAuthenticationType.SERVICEACCESSTOKEN.value,
+        DataflowEndpointAuthenticationType.X509.value,
+        DataflowEndpointAuthenticationType.ANONYMOUS.value,
+    },
 }
 
 DATAFLOW_ENDPOINT_TYPE_SETTINGS = {
@@ -278,6 +284,7 @@ DATAFLOW_ENDPOINT_TYPE_SETTINGS = {
     DataflowEndpointType.AIOLOCALMQTT.value: "mqttSettings",
     DataflowEndpointType.EVENTGRID.value: "mqttSettings",
     DataflowEndpointType.CUSTOMMQTT.value: "mqttSettings",
+    DataflowEndpointType.OPENTELEMETRY.value: "openTelemetrySettings",
     KAFKA_ENDPOINT_TYPE: "kafkaSettings",
     MQTT_ENDPOINT_TYPE: "mqttSettings",
 }

--- a/azext_edge/edge/providers/orchestration/resources/dataflows.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflows.py
@@ -588,6 +588,7 @@ class DataFlowEndpoints(Queryable):
             DataflowEndpointType.AIOLOCALMQTT.value,
             DataflowEndpointType.EVENTGRID.value,
             DataflowEndpointType.CUSTOMMQTT.value,
+            DataflowEndpointType.OPENTELEMETRY.value,
         ]:
             processed_host = f"{hostname}:{port}"
 
@@ -654,7 +655,11 @@ class DataFlowEndpoints(Queryable):
         })
 
         if authentication_method == DataflowEndpointAuthenticationType.ANONYMOUS.value:
-            return
+            if endpoint_type == DataflowEndpointType.OPENTELEMETRY.value:
+                # Only otel enpoint has anonymous settings property
+                settings["authentication"][authentication_method.lower() + "Settings"] = {}
+            else:
+                return
 
         auth_settings = {}
         for param_name, property_name in [

--- a/azext_edge/tests/edge/orchestration/resources/dataflow_endpoint/create_update/test_dataflow_endpoint_create_update_otel.py
+++ b/azext_edge/tests/edge/orchestration/resources/dataflow_endpoint/create_update/test_dataflow_endpoint_create_update_otel.py
@@ -1,0 +1,344 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from unittest.mock import Mock
+
+import pytest
+
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+from azext_edge.edge.commands_dataflow import (
+    create_dataflow_endpoint_otel,
+    update_dataflow_endpoint_otel,
+)
+from ..helpers import assert_dataflow_endpoint_create_update, assert_dataflow_endpoint_create_update_with_error
+
+
+@pytest.mark.parametrize(
+    "params, expected_payload",
+    [
+        # x509 without authentication type
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "secret_name": "secret_name"
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "X509Certificate",
+                        "x509CertificateSettings": {
+                            "secretRef": "secret_name"
+                        }
+                    },
+                    "host": "https://otel-collector.monitoring.svc.cluster.local:4317",
+                    "batching": {
+                        "latencySeconds": 1,
+                        "maxMessages": 1,
+                    },
+                    'tls': {'mode': 'Enabled'}
+                },
+            },
+        ),
+        # x509 with authentication type
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "secret_name": "secret_name",
+                "authentication_type": "X509Certificate"
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "X509Certificate",
+                        "x509CertificateSettings": {
+                            "secretRef": "secret_name"
+                        }
+                    },
+                    "host": "https://otel-collector.monitoring.svc.cluster.local:4317",
+                    "batching": {
+                        "latencySeconds": 1,
+                        "maxMessages": 1,
+                    },
+                    'tls': {'mode': 'Enabled'}
+                },
+            },
+        ),
+        # service account token without authentication type
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "audience": "audience",
+                "tls_disabled": True
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "ServiceAccountToken",
+                        "serviceAccountTokenSettings": {
+                            "audience": "audience"
+                        }
+                    },
+                    "host": "https://otel-collector.monitoring.svc.cluster.local:4317",
+                    "batching": {
+                        "latencySeconds": 1,
+                        "maxMessages": 1,
+                    },
+                    'tls': {'mode': 'Disabled'}
+                },
+            },
+        ),
+        # service account token with authentication type
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "audience": "audience",
+                "tls_disabled": True,
+                "authentication_type": "ServiceAccountToken",
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "ServiceAccountToken",
+                        "serviceAccountTokenSettings": {
+                            "audience": "audience"
+                        }
+                    },
+                    "host": "https://otel-collector.monitoring.svc.cluster.local:4317",
+                    "batching": {
+                        "latencySeconds": 1,
+                        "maxMessages": 1,
+                    },
+                    'tls': {'mode': 'Disabled'}
+                },
+            },
+        ),
+        # no auth
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "tls_disabled": True,
+                "no_auth": True,
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "Anonymous",
+                        "anonymousSettings": {},
+                    },
+                    "host": "https://otel-collector.monitoring.svc.cluster.local:4317",
+                    "batching": {
+                        "latencySeconds": 1,
+                        "maxMessages": 1,
+                    },
+                    'tls': {'mode': 'Disabled'}
+                },
+            },
+        ),
+    ]
+)
+def test_dataflow_endpoint_create_otel(
+    mocked_cmd,
+    params: dict,
+    expected_payload: dict,
+    mocked_responses: Mock,
+):
+    assert_dataflow_endpoint_create_update(
+        mocked_responses=mocked_responses,
+        expected_payload=expected_payload,
+        mocked_cmd=mocked_cmd,
+        params=params,
+        dataflow_endpoint_func=create_dataflow_endpoint_otel,
+    )
+
+
+@pytest.mark.parametrize(
+    "params, expected_error_type, expected_error_text",
+    [
+        # unsupported authentication type
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "audience": "audience",
+                "tls_disabled": True,
+                "authentication_type": "UnsupportedType",
+            },
+            InvalidArgumentValueError,
+            "Authentication method 'UnsupportedType' is "
+            "not allowed for endpoint type 'OpenTelemetry'. "
+            "Allowed methods are: ['ServiceAccountToken', "
+            "'X509Certificate'].",
+        ),
+        # missing required parameters for service account token
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "tls_disabled": True,
+                "authentication_type": "ServiceAccountToken",
+            },
+            InvalidArgumentValueError,
+            "Missing required parameters for authentication method 'ServiceAccountToken': --audience.",
+        ),
+        # missing required parameters for x509 certificate
+        (
+            {
+                "hostname": "https://otel-collector.monitoring.svc.cluster.local",
+                "port": 4317,
+                "latency": 1,
+                "message_count": 1,
+                "tls_disabled": True,
+                "authentication_type": "X509Certificate",
+            },
+            InvalidArgumentValueError,
+            "Missing required parameters for authentication method 'X509Certificate': --secret-name.",
+        ),
+    ]
+)
+def test_dataflow_endpoint_create_otel_with_error(
+    mocked_cmd,
+    params: dict,
+    expected_error_type: type,
+    expected_error_text: str,
+    mocked_responses: Mock,
+):
+    assert_dataflow_endpoint_create_update_with_error(
+        mocked_responses=mocked_responses,
+        expected_error_type=expected_error_type,
+        expected_error_text=expected_error_text,
+        mocked_cmd=mocked_cmd,
+        params=params,
+        dataflow_endpoint_func=create_dataflow_endpoint_otel,
+    )
+
+
+@pytest.mark.parametrize(
+    "params, updating_payload, expected_payload",
+    [
+        # update batching values
+        (
+            {
+                "latency": 2,
+            },
+            {
+                "properties": {
+                    "endpointType": "OpenTelemetry",
+                    "openTelemetrySettings": {
+                        "authentication": {
+                            "method": "ServiceAccountToken",
+                            "serviceAccountTokenSettings": {
+                                "secretRef": "mysecret"
+                            },
+                        },
+                        "batching": {
+                            "latencySeconds": 1,
+                            "maxMessages": 1,
+                        },
+                        "host": "https://mystorageaccount.blob.core.windows.net",
+                    },
+                },
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "ServiceAccountToken",
+                        "serviceAccountTokenSettings": {
+                            "secretRef": "mysecret"
+                        },
+                    },
+                    "batching": {
+                        "latencySeconds": 2,
+                        "maxMessages": 1,
+                    },
+                    "host": "https://mystorageaccount.blob.core.windows.net",
+                },
+            },
+        ),
+        # update authentication settings
+        (
+            {
+                "authentication_type": "X509Certificate",
+                "secret_name": "mysecret"
+            },
+            {
+                "properties": {
+                    "endpointType": "OpenTelemetry",
+                    "openTelemetrySettings": {
+                        "authentication": {
+                            "method": "ServiceAccountToken",
+                            "serviceAccountTokenSettings": {
+                                "secretRef": "mysecret"
+                            },
+                        },
+                        "batching": {
+                            "latencySeconds": 2,
+                            "maxMessages": 1,
+                        },
+                        "host": "https://mystorageaccount.blob.core.windows.net",
+                    },
+                },
+            },
+            {
+                "endpointType": "OpenTelemetry",
+                "openTelemetrySettings": {
+                    "authentication": {
+                        "method": "X509Certificate",
+                        "x509CertificateSettings": {
+                            "secretRef": "mysecret"
+                        },
+                    },
+                    "batching": {
+                        "latencySeconds": 2,
+                        "maxMessages": 1,
+                    },
+                    "host": "https://mystorageaccount.blob.core.windows.net",
+                },
+            },
+        ),
+    ]
+)
+def test_dataflow_endpoint_update_otel(
+    mocked_cmd,
+    params: dict,
+    updating_payload: dict,
+    expected_payload: dict,
+    mocked_responses: Mock,
+):
+    assert_dataflow_endpoint_create_update(
+        mocked_responses=mocked_responses,
+        expected_payload=expected_payload,
+        mocked_cmd=mocked_cmd,
+        params=params,
+        dataflow_endpoint_func=update_dataflow_endpoint_otel,
+        updating_payload=updating_payload,
+        is_update=True,
+    )


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
