### PR TITLE
fix: update schema delete operations to accept 200 status codes per GA API spec

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -257,9 +257,10 @@ class Schemas(Queryable):
             return
 
         with console.status("Working..."):
-            return self.ops.begin_delete(
+            poller = self.ops.begin_delete(
                 resource_group_name=resource_group_name, schema_registry_name=schema_registry_name, schema_name=name
             )
+            return poller.result()
 
     def add_version(
         self,
@@ -333,12 +334,13 @@ class Schemas(Queryable):
         resource_group_name: str,
     ):
         with console.status("Working..."):
-            return self.version_ops.begin_delete(
+            poller = self.version_ops.begin_delete(
                 resource_group_name=resource_group_name,
                 schema_registry_name=schema_registry_name,
                 schema_name=schema_name,
                 schema_version_name=name,
             )
+            return poller.result()
 
     def list_dataflow_friendly_versions(
         self,

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -252,6 +252,7 @@ class Schemas(Queryable):
         schema_registry_name: str,
         resource_group_name: str,
         confirm_yes: Optional[bool] = None,
+        **kwargs
     ):
         if not should_continue_prompt(confirm_yes=confirm_yes):
             return
@@ -260,7 +261,7 @@ class Schemas(Queryable):
             poller = self.ops.begin_delete(
                 resource_group_name=resource_group_name, schema_registry_name=schema_registry_name, schema_name=name
             )
-            return poller.result()
+            wait_for_terminal_state(poller, **kwargs)
 
     def add_version(
         self,
@@ -332,6 +333,7 @@ class Schemas(Queryable):
         schema_name: str,
         schema_registry_name: str,
         resource_group_name: str,
+        **kwargs
     ):
         with console.status("Working..."):
             poller = self.version_ops.begin_delete(
@@ -340,7 +342,7 @@ class Schemas(Queryable):
                 schema_name=schema_name,
                 schema_version_name=name,
             )
-            return poller.result()
+            wait_for_terminal_state(poller, **kwargs)
 
     def list_dataflow_friendly_versions(
         self,

--- a/azext_edge/edge/vendor/clients/deviceregistrymgmt/v20251001/operations/_operations.py
+++ b/azext_edge/edge/vendor/clients/deviceregistrymgmt/v20251001/operations/_operations.py
@@ -24825,7 +24825,7 @@ class SchemasOperations:
 
         response = pipeline_response.http_response
 
-        if response.status_code not in [202, 204]:
+        if response.status_code not in [200, 204]:
             if _stream:
                 response.read()  # Load the body in memory and close the socket
             map_error(status_code=response.status_code, response=response, error_map=error_map)
@@ -25546,7 +25546,7 @@ class SchemaVersionsOperations:
 
         response = pipeline_response.http_response
 
-        if response.status_code not in [202, 204]:
+        if response.status_code not in [200, 204]:
             if _stream:
                 response.read()  # Load the body in memory and close the socket
             map_error(status_code=response.status_code, response=response, error_map=error_map)

--- a/azext_edge/tests/edge/orchestration/resources/test_schema_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_schema_unit.py
@@ -178,7 +178,8 @@ def test_schema_list(mocked_cmd, mocked_responses: responses, records: int):
     assert len(mocked_responses.calls) == 1
 
 
-def test_schema_delete(mocked_cmd, mocked_responses: responses):
+@pytest.mark.parametrize("status_code", [200, 204])
+def test_schema_delete(mocked_cmd, mocked_responses: responses, status_code: int):
     schema_name = generate_random_string()
     registry_name = generate_random_string()
     resource_group_name = generate_random_string()
@@ -190,7 +191,7 @@ def test_schema_delete(mocked_cmd, mocked_responses: responses):
             registry_name=registry_name,
             schema_name=schema_name
         ),
-        status=202,
+        status=status_code,
         content_type="application/json",
     )
     delete_schema(
@@ -382,7 +383,8 @@ def test_version_list(mocked_cmd, mocked_responses: responses, records: int):
     assert len(mocked_responses.calls) == 1
 
 
-def test_version_remove(mocked_cmd, mocked_responses: responses):
+@pytest.mark.parametrize("status_code", [200, 204])
+def test_version_remove(mocked_cmd, mocked_responses: responses, status_code: int):
     version_num = randint(1, 10)
     schema_name = generate_random_string()
     registry_name = generate_random_string()
@@ -396,7 +398,7 @@ def test_version_remove(mocked_cmd, mocked_responses: responses):
             schema_name=schema_name,
             schema_version=version_num
         ),
-        status=202,
+        status=status_code,
         content_type="application/json",
     )
     remove_version(


### PR DESCRIPTION
Issue: 
Schema delete operations were failing with "Operation returned an invalid status 'OK'" error when using the GA API v2025-10-01.

Root Cause: 
The Azure SDK client was expecting asynchronous response codes [202, 204] but the GA API specification returns synchronous codes [200, 204] for successful delete operations.

Solution:
- Updated SchemasOperations._delete_initial() to accept [200, 204] status codes
- Updated SchemaVersionsOperations._delete_initial() to accept [200, 204] status codes
- Updated corresponding unit tests to validate correct status codes
- Fixed application code to properly handle LRO responses using poller.result() pattern

Impact: 
Both az iot ops schema delete and az iot ops schema version remove commands now work correctly with the GA API.

Reference:
https://github.com/Azure/azure-rest-api-specs/commit/da641063f45bf0784b0e7be1680d7398130a623b#diff-8a80aa7ace699df85d9ad53b603ea8c9c113e3210e45b9a03b0f97001cc1e66a