### PR TITLE
feat!: updates to registry endpoint management commands for 2510

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -782,14 +782,14 @@ def load_iotops_help():
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --auth-type UserAssignedManagedIdentity --scope myscope --cid myclientid --tid mytenantid
-        - name: Add a registry endpoint with a trusted signing key config map reference
+        - name: Add a registry endpoint with a single code signing CA secret reference
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
-            --trust-config-map-ref my-trust-configmap
-        - name: Add a registry endpoint with a trusted signing key secret reference
+            --cs-secret-refs mysecret
+        - name: Add a registry endpoint with two code signing CA config maps references
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
-            --trust-secret-ref my-trust-secret
+            --cs-config-map-refs myconfigmap1 myconfigmap2
     """
 
     helps[
@@ -802,9 +802,12 @@ def load_iotops_help():
         - name: Update an endpoint's hostname and auth-type to use a system-assigned managed identity
           text: >
             az iot ops registry update -n myregistry --host newregistry.azurecr.io -i myinstance -g myresourcegroup --auth-type SystemAssignedManagedIdentity
-        - name: Update an endpoint to use trusted signing with a config map reference
+        - name: Update an endpoint to use a code signing CA config map reference
           text: >
-            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --trust-config-map-ref my-trust-configmap
+            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs myconfigmap
+        - name: Update an endpoint to use code signing CA config map and secret references
+          text: >
+            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs myconfigmap --cs-secret-refs mysecret
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -782,14 +782,14 @@ def load_iotops_help():
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --auth-type UserAssignedManagedIdentity --scope myscope --cid myclientid --tid mytenantid
-        - name: Add a registry endpoint with a single code signing CA secret reference
+        - name: Add a registry endpoint with a code signing CA secret reference
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --cs-secret-refs mysecret
-        - name: Add a registry endpoint with two code signing CA config maps references
+        - name: Add a registry endpoint with multiple code signing CA secret and configmap references
           text: >
             az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
-            --cs-config-map-refs myconfigmap1 myconfigmap2
+            --cs-config-map-refs configmap1 configmap2 --cs-secret-refs secret1 secret2
     """
 
     helps[
@@ -802,12 +802,12 @@ def load_iotops_help():
         - name: Update an endpoint's hostname and auth-type to use a system-assigned managed identity
           text: >
             az iot ops registry update -n myregistry --host newregistry.azurecr.io -i myinstance -g myresourcegroup --auth-type SystemAssignedManagedIdentity
-        - name: Update an endpoint to use a code signing CA config map reference
+        - name: Update an endpoint to add a code signing CA config map reference
           text: >
             az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs myconfigmap
-        - name: Update an endpoint to use code signing CA config map and secret references
+        - name: Update an endpoint to remove existing code signing CA config map refs and add a new secret reference
           text: >
-            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs myconfigmap --cs-secret-refs mysecret
+            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs --cs-secret-refs mysecret
     """
 
     helps[

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -797,7 +797,8 @@ def load_iotops_help():
     ] = """
         type: command
         short-summary: Update a container registry endpoint.
-        long-summary: Note: updating code signing CA reference properties will overwrite existing config map and secret references.
+        long-summary: |
+          Note: updating code signing CA reference properties will overwrite existing config map and secret references.
 
         examples:
         - name: Update an endpoint's hostname and auth-type to use a system-assigned managed identity

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -797,17 +797,18 @@ def load_iotops_help():
     ] = """
         type: command
         short-summary: Update a container registry endpoint.
+        long-summary: Note: updating code signing CA reference properties will overwrite existing config map and secret references.
 
         examples:
         - name: Update an endpoint's hostname and auth-type to use a system-assigned managed identity
           text: >
             az iot ops registry update -n myregistry --host newregistry.azurecr.io -i myinstance -g myresourcegroup --auth-type SystemAssignedManagedIdentity
-        - name: Update an endpoint to add a code signing CA config map reference
+        - name: Update an endpoint to set a code signing CA config map reference
           text: >
             az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs myconfigmap
-        - name: Update an endpoint to remove existing code signing CA config map refs and add a new secret reference
+        - name: Update an endpoint to set multiple code signing CA secret references
           text: >
-            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-config-map-refs --cs-secret-refs mysecret
+            az iot ops registry update -n myregistry -i myinstance -g myresourcegroup --cs-secret-refs secret1 secret2
     """
 
     helps[

--- a/azext_edge/edge/commands_registry_endpoints.py
+++ b/azext_edge/edge/commands_registry_endpoints.py
@@ -26,8 +26,8 @@ def add_registry_endpoint(
     tenant_id: Optional[str] = None,
     scope: Optional[str] = None,
     no_auth: Optional[bool] = None,
-    trusted_signing_configmap_key: Optional[str] = None,
-    trusted_signing_secret_key: Optional[str] = None,
+    code_signing_configmap_refs: Optional[list] = None,
+    code_signing_secret_refs: Optional[list] = None,
     **kwargs,
 ) -> dict:
     """Add a registry endpoint to an IoT Operations instance."""
@@ -43,8 +43,8 @@ def add_registry_endpoint(
         tenant_id=tenant_id,
         scope=scope,
         no_auth=no_auth,
-        trusted_signing_configmap_key=trusted_signing_configmap_key,
-        trusted_signing_secret_key=trusted_signing_secret_key,
+        code_signing_configmap_refs=code_signing_configmap_refs,
+        code_signing_secret_refs=code_signing_secret_refs,
         **kwargs,
     )
 
@@ -62,8 +62,8 @@ def update_registry_endpoint(
     tenant_id: Optional[str] = None,
     scope: Optional[str] = None,
     no_auth: Optional[bool] = None,
-    trusted_signing_configmap_key: Optional[str] = None,
-    trusted_signing_secret_key: Optional[str] = None,
+    code_signing_configmap_refs: Optional[list] = None,
+    code_signing_secret_refs: Optional[list] = None,
     **kwargs,
 ) -> dict:
     """Update a registry endpoint in an IoT Operations instance."""
@@ -79,8 +79,8 @@ def update_registry_endpoint(
         tenant_id=tenant_id,
         scope=scope,
         no_auth=no_auth,
-        trusted_signing_configmap_key=trusted_signing_configmap_key,
-        trusted_signing_secret_key=trusted_signing_secret_key,
+        code_signing_configmap_refs=code_signing_configmap_refs,
+        code_signing_secret_refs=code_signing_secret_refs,
         **kwargs,
     )
 

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -933,16 +933,18 @@ def load_iotops_arguments(self, _):
             help="Explictly use anonymous authentication.",
         )
         context.argument(
-            "trusted_signing_configmap_key",
-            options_list=["--trust-config-map-ref", "--tcmr"],
-            help="Trusted signing config map reference.",
-            arg_group="Trusted Signing",
+            "code_signing_configmap_refs",
+            options_list=["--cs-config-map-refs", "--cscmr"],
+            nargs="*",
+            help="Code signing ConfigMap references. Space-separated list of ConfigMap names.",
+            arg_group="Code Signing CAs",
         )
         context.argument(
-            "trusted_signing_secret_key",
-            options_list=["--trust-secret-ref", "--tsr"],
-            help="Trusted signing secret reference.",
-            arg_group="Trusted Signing",
+            "code_signing_secret_refs",
+            options_list=["--cs-secret-refs", "--cssr"],
+            nargs="*",
+            help="Code signing Secret references. Space-separated list of Secret names.",
+            arg_group="Code Signing CAs",
         )
 
     with self.argument_context("iot ops broker") as context:

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -936,15 +936,15 @@ def load_iotops_arguments(self, _):
             "code_signing_configmap_refs",
             options_list=["--cs-config-map-refs", "--cscmr"],
             nargs="*",
-            help="Code signing ConfigMap references. Space-separated list of ConfigMap names.",
-            arg_group="Code Signing CAs",
+            help="Space-separated list of code signing CA config map references.",
+            arg_group="Code Signing CA",
         )
         context.argument(
             "code_signing_secret_refs",
             options_list=["--cs-secret-refs", "--cssr"],
             nargs="*",
-            help="Code signing Secret references. Space-separated list of Secret names.",
-            arg_group="Code Signing CAs",
+            help="Space-separated list of code signing CA secret references.",
+            arg_group="Code Signing CA",
         )
 
     with self.argument_context("iot ops broker") as context:

--- a/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
+++ b/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
@@ -144,43 +144,44 @@ class RegistryEndpoints(Queryable):
         auth_config[settings_key] = auth_settings
         return auth_config
 
-    def _process_trusted_signing_key(
+    def _process_code_signing_cas(
         self,
-        trusted_signing_configmap_key: Optional[str] = None,
-        trusted_signing_secret_key: Optional[str] = None,
-    ) -> Optional[dict]:
+        code_signing_configmap_refs: Optional[list] = None,
+        code_signing_secret_refs: Optional[list] = None,
+    ) -> Optional[list]:
         """
-        Process trusted signing key configuration for registry endpoints.
+        Process code signing CA configuration for registry endpoints.
 
-        :param trusted_signing_configmap_key: ConfigMap reference for trusted signing key.
-        :param trusted_signing_secret_key: Secret reference for trusted signing key.
-        :returns: Trusted signing key configuration or None if not provided.
-        :raises MutuallyExclusiveArgumentError: If both configmap and secret keys are provided.
+        :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
+        :param code_signing_secret_refs: List of Secret references for code signing CAs.
+        :returns: List of code signing CAs or None
         """
-        if not trusted_signing_configmap_key and not trusted_signing_secret_key:
+        if not code_signing_configmap_refs and not code_signing_secret_refs:
             return None
 
-        # Ensure mutual exclusivity
-        if trusted_signing_configmap_key and trusted_signing_secret_key:
-            raise MutuallyExclusiveArgumentError(
-                "Cannot specify both config map and secret for trusted signing key settings. "
-                "Choose one trusted signing key type."
-            )
+        cas = []
 
-        if trusted_signing_configmap_key:
-            return {
-                "trustedSigningKeys": {
-                    "configMapRef": trusted_signing_configmap_key,
+        # Add ConfigMap references using list comprehension
+        if code_signing_configmap_refs:
+            cas += [
+                {
                     "type": TrustedSigningKeyType.CONFIGMAP.value,
+                    "configMapRef": configmap_ref,
                 }
-            }
-        elif trusted_signing_secret_key:
-            return {
-                "trustedSigningKeys": {
-                    "secretRef": trusted_signing_secret_key,
+                for configmap_ref in code_signing_configmap_refs
+            ]
+
+        # Add Secret references using list comprehension
+        if code_signing_secret_refs:
+            cas += [
+                {
                     "type": TrustedSigningKeyType.SECRET.value,
+                    "secretRef": secret_ref,
                 }
-            }
+                for secret_ref in code_signing_secret_refs
+            ]
+
+        return cas if cas else None
 
     def add(
         self,
@@ -195,8 +196,8 @@ class RegistryEndpoints(Queryable):
         tenant_id: Optional[str] = None,
         scope: Optional[str] = None,
         no_auth: Optional[bool] = None,
-        trusted_signing_configmap_key: Optional[str] = None,
-        trusted_signing_secret_key: Optional[str] = None,
+        code_signing_configmap_refs: Optional[list] = None,
+        code_signing_secret_refs: Optional[list] = None,
         **kwargs,
     ) -> dict:
         """
@@ -213,8 +214,8 @@ class RegistryEndpoints(Queryable):
         :param tenant_id: Tenant ID for UserAssignedManagedIdentity authentication.
         :param scope: Scope for UserAssignedManagedIdentity authentication.
         :param no_auth: Whether to use anonymous authentication.
-        :param trusted_signing_configmap_key: ConfigMap reference for trusted signing key.
-        :param trusted_signing_secret_key: Secret reference for trusted signing key.
+        :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
+        :param code_signing_secret_refs: List of Secret references for code signing CAs.
         :param kwargs: Additional keyword arguments for the operation.
         :returns: The created registry endpoint.
         """
@@ -235,10 +236,10 @@ class RegistryEndpoints(Queryable):
             no_auth=no_auth,
         )
 
-        # Process trusted signing key configuration
-        trust_settings = self._process_trusted_signing_key(
-            trusted_signing_configmap_key=trusted_signing_configmap_key,
-            trusted_signing_secret_key=trusted_signing_secret_key,
+        # Process code signing CAs configuration
+        code_signing_cas = self._process_code_signing_cas(
+            code_signing_configmap_refs=code_signing_configmap_refs,
+            code_signing_secret_refs=code_signing_secret_refs,
         )
 
         # Build the resource configuration
@@ -247,9 +248,9 @@ class RegistryEndpoints(Queryable):
             "authentication": auth_config,
         }
 
-        # Add trust settings if provided
-        if trust_settings:
-            properties["trustSettings"] = trust_settings
+        # Add code signing CAs if provided
+        if code_signing_cas:
+            properties["codeSigningCas"] = code_signing_cas
 
         resource = {
             "extendedLocation": self.instances.get_ext_loc(
@@ -283,8 +284,8 @@ class RegistryEndpoints(Queryable):
         tenant_id: Optional[str] = None,
         scope: Optional[str] = None,
         no_auth: Optional[bool] = None,
-        trusted_signing_configmap_key: Optional[str] = None,
-        trusted_signing_secret_key: Optional[str] = None,
+        code_signing_configmap_refs: Optional[list] = None,
+        code_signing_secret_refs: Optional[list] = None,
         **kwargs,
     ) -> dict:
         """
@@ -301,8 +302,8 @@ class RegistryEndpoints(Queryable):
         :param tenant_id: Tenant ID for UserAssignedManagedIdentity authentication.
         :param scope: Scope for UserAssignedManagedIdentity authentication.
         :param no_auth: Whether to use anonymous authentication.
-        :param trusted_signing_configmap_key: ConfigMap reference for trusted signing key.
-        :param trusted_signing_secret_key: Secret reference for trusted signing key.
+        :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
+        :param code_signing_secret_refs: List of Secret references for code signing CAs.
         :param kwargs: Additional keyword arguments for the operation.
         :returns: The updated registry endpoint.
         """
@@ -330,14 +331,14 @@ class RegistryEndpoints(Queryable):
             )
             existing_endpoint["properties"]["authentication"] = auth_config
 
-        # Process trusted signing key configuration
-        if any([trusted_signing_configmap_key, trusted_signing_secret_key]):
-            trusted_signing_config = self._process_trusted_signing_key(
-                trusted_signing_configmap_key=trusted_signing_configmap_key,
-                trusted_signing_secret_key=trusted_signing_secret_key,
+        # Process code signing CAs configuration
+        if any([code_signing_configmap_refs, code_signing_secret_refs]):
+            code_signing_cas = self._process_code_signing_cas(
+                code_signing_configmap_refs=code_signing_configmap_refs,
+                code_signing_secret_refs=code_signing_secret_refs,
             )
-            if trusted_signing_config:
-                existing_endpoint["properties"]["trustSettings"] = trusted_signing_config
+            if code_signing_cas:
+                existing_endpoint["properties"]["codeSigningCas"] = code_signing_cas
 
         with console.status("Working..."):
             poller = self.registry_endpoints.begin_create_or_update(

--- a/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
+++ b/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
@@ -154,14 +154,14 @@ class RegistryEndpoints(Queryable):
 
         :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
         :param code_signing_secret_refs: List of Secret references for code signing CAs.
-        :returns: List of code signing CAs or None
+        :returns: List of code signing CA objects
         """
         if not code_signing_configmap_refs and not code_signing_secret_refs:
             return None
 
         cas = []
 
-        # Add ConfigMap references using list comprehension
+        # Add ConfigMap references
         if code_signing_configmap_refs:
             cas += [
                 {
@@ -171,7 +171,7 @@ class RegistryEndpoints(Queryable):
                 for configmap_ref in code_signing_configmap_refs
             ]
 
-        # Add Secret references using list comprehension
+        # Add Secret references
         if code_signing_secret_refs:
             cas += [
                 {
@@ -214,8 +214,8 @@ class RegistryEndpoints(Queryable):
         :param tenant_id: Tenant ID for UserAssignedManagedIdentity authentication.
         :param scope: Scope for UserAssignedManagedIdentity authentication.
         :param no_auth: Whether to use anonymous authentication.
-        :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
-        :param code_signing_secret_refs: List of Secret references for code signing CAs.
+        :param code_signing_configmap_refs: List of code signing CA config map references.
+        :param code_signing_secret_refs: List of code signing CA secret references.
         :param kwargs: Additional keyword arguments for the operation.
         :returns: The created registry endpoint.
         """
@@ -302,8 +302,8 @@ class RegistryEndpoints(Queryable):
         :param tenant_id: Tenant ID for UserAssignedManagedIdentity authentication.
         :param scope: Scope for UserAssignedManagedIdentity authentication.
         :param no_auth: Whether to use anonymous authentication.
-        :param code_signing_configmap_refs: List of ConfigMap references for code signing CAs.
-        :param code_signing_secret_refs: List of Secret references for code signing CAs.
+        :param code_signing_configmap_refs: List of code signing CA config map references.
+        :param code_signing_secret_refs: List of code signing CA secret references.
         :param kwargs: Additional keyword arguments for the operation.
         :returns: The updated registry endpoint.
         """

--- a/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
+++ b/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
@@ -148,7 +148,7 @@ class RegistryEndpoints(Queryable):
         self,
         code_signing_configmap_refs: Optional[list] = None,
         code_signing_secret_refs: Optional[list] = None,
-    ) -> Optional[list]:
+    ) -> list:
         """
         Process code signing CA configuration for registry endpoints.
 
@@ -181,7 +181,7 @@ class RegistryEndpoints(Queryable):
                 for secret_ref in code_signing_secret_refs
             ]
 
-        return cas if cas else None
+        return cas
 
     def add(
         self,
@@ -331,14 +331,12 @@ class RegistryEndpoints(Queryable):
             )
             existing_endpoint["properties"]["authentication"] = auth_config
 
-        # Process code signing CAs configuration
-        if any([code_signing_configmap_refs, code_signing_secret_refs]):
-            code_signing_cas = self._process_code_signing_cas(
+        # Process code signing CAs configuration if provided
+        if code_signing_configmap_refs is not None or code_signing_secret_refs is not None:
+            existing_endpoint["properties"]["codeSigningCas"] = self._process_code_signing_cas(
                 code_signing_configmap_refs=code_signing_configmap_refs,
                 code_signing_secret_refs=code_signing_secret_refs,
             )
-            if code_signing_cas:
-                existing_endpoint["properties"]["codeSigningCas"] = code_signing_cas
 
         with console.status("Working..."):
             poller = self.registry_endpoints.begin_create_or_update(

--- a/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
@@ -6,6 +6,7 @@
 
 import pytest
 
+from azext_edge.edge.providers.orchestration.common import TrustedSigningKeyType
 from azext_edge.tests.generators import generate_random_string
 from azext_edge.tests.helpers import run
 from azext_edge.tests.settings import EnvironmentVariables
@@ -415,20 +416,25 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         raise
 
 
-def test_registry_endpoint_trusted_signing_key(registry_endpoint_test_setup, tracked_resources):
-    """Test complete lifecycle of registry endpoint with trusted signing settings."""
+def test_registry_endpoint_code_signing_cas(registry_endpoint_test_setup, tracked_resources):
+    """Test complete lifecycle of registry endpoint with code signing CAs."""
     resource_group = registry_endpoint_test_setup["resourceGroup"]
     instance_name = registry_endpoint_test_setup["instanceName"]
     registry_endpoint_name = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
     host = "trustregistry.azurecr.io"
-    trust_configmap = "my-trust-configmap"
+
+    # Define test values
+    configmap1 = "configmap1"
+    configmap2 = "configmap2"
+    secret1 = "secret1"
+    secret2 = "secret2"
 
     try:
-        # CREATE - with trusted signing configmap
+        # CREATE - with one configmap
         registry_endpoint = run(
             f"az iot ops registry add -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
-            f"--host {host} --trust-config-map-ref {trust_configmap}"
+            f"--host {host} --cs-config-map-refs {configmap1}"
         )
         tracked_resources.append(registry_endpoint["id"])
 
@@ -441,30 +447,18 @@ def test_registry_endpoint_trusted_signing_key(registry_endpoint_test_setup, tra
             auth_method="SystemAssignedManagedIdentity",
         )
 
-        # Verify trust settings
-        trust_settings = registry_endpoint["properties"].get("trustSettings")
-        assert trust_settings is not None
-        trusted_signing_keys = trust_settings.get("trustedSigningKeys")
-        assert trusted_signing_keys is not None
-        assert trusted_signing_keys.get("configMapRef") == trust_configmap
-        assert trusted_signing_keys.get("type") == "ConfigMap"
+        # Verify single configmap type
+        code_signing_cas = registry_endpoint["properties"].get("codeSigningCas")
+        assert code_signing_cas is not None
+        assert len(code_signing_cas) == 1
+        assert code_signing_cas[0]["type"] == TrustedSigningKeyType.CONFIGMAP.value
+        assert code_signing_cas[0]["configMapRef"] == configmap1
 
-        # UPDATE - test mutual exclusivity
-        with pytest.raises(Exception) as exc_info:
-            run(
-                f"az iot ops registry update -n {registry_endpoint_name} "
-                f"-g {resource_group} --instance {instance_name} "
-                f"--host {host} --trust-config-map-ref my-configmap --trust-secret-ref my-secret"
-            )
-        # The CLI should fail with the mutual exclusivity error
-        assert exc_info.value.error_msg is not None
-
-        # UPDATE - switch to signing secret instead of configmap
-        trust_secret = "my-trust-secret"
+        # UPDATE - two configmaps and one secret ref
         updated_endpoint = run(
             f"az iot ops registry update -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
-            f"--trust-secret-ref {trust_secret}"
+            f"--cs-config-map-refs {configmap1} {configmap2} --cs-secret-refs {secret1}"
         )
 
         assert_registry_endpoint(
@@ -476,15 +470,47 @@ def test_registry_endpoint_trusted_signing_key(registry_endpoint_test_setup, tra
             auth_method="SystemAssignedManagedIdentity",
         )
 
-        # Verify trust settings were updated
-        trust_settings = updated_endpoint["properties"].get("trustSettings")
-        assert trust_settings is not None
-        trusted_signing_keys = trust_settings.get("trustedSigningKeys")
-        assert trusted_signing_keys is not None
-        assert trusted_signing_keys.get("secretRef") == trust_secret
-        assert trusted_signing_keys.get("type") == "Secret"
-        # Ensure configMapRef is no longer present
-        assert "configMapRef" not in trusted_signing_keys
+        code_signing_cas = updated_endpoint["properties"].get("codeSigningCas")
+        assert code_signing_cas is not None
+        assert len(code_signing_cas) == 3
+
+        configmap_refs = [ca for ca in code_signing_cas if ca["type"] == TrustedSigningKeyType.CONFIGMAP.value]
+        secret_refs = [ca for ca in code_signing_cas if ca["type"] == TrustedSigningKeyType.SECRET.value]
+
+        assert len(configmap_refs) == 2
+        assert len(secret_refs) == 1
+        assert any(ca["configMapRef"] == configmap1 for ca in configmap_refs)
+        assert any(ca["configMapRef"] == configmap2 for ca in configmap_refs)
+        assert secret_refs[0]["secretRef"] == secret1
+
+        # UPDATE - remove configmaps, add second secret ref
+        updated_endpoint = run(
+            f"az iot ops registry update -n {registry_endpoint_name} "
+            f"-g {resource_group} --instance {instance_name} "
+            f"--cs-secret-refs {secret1} {secret2}"
+        )
+
+        code_signing_cas = updated_endpoint["properties"].get("codeSigningCas")
+        assert len(code_signing_cas) == 2
+
+        configmap_refs = [ca for ca in code_signing_cas if ca["type"] == TrustedSigningKeyType.CONFIGMAP.value]
+        secret_refs = [ca for ca in code_signing_cas if ca["type"] == TrustedSigningKeyType.SECRET.value]
+
+        assert len(configmap_refs) == 0
+        assert len(secret_refs) == 2
+        assert any(ca["secretRef"] == secret1 for ca in secret_refs)
+        assert any(ca["secretRef"] == secret2 for ca in secret_refs)
+
+        # UPDATE - remove all code signing CAs
+        updated_endpoint = run(
+            f"az iot ops registry update -n {registry_endpoint_name} "
+            f"-g {resource_group} --instance {instance_name} "
+            f"--cs-config-map-refs --cs-secret-refs"
+        )
+
+        # Verify code signing CAs are cleared
+        code_signing_cas = updated_endpoint["properties"].get("codeSigningCas")
+        assert code_signing_cas is None or len(code_signing_cas) == 0
 
         # REMOVE
         run(
@@ -505,25 +531,6 @@ def test_registry_endpoint_trusted_signing_key(registry_endpoint_test_setup, tra
             except Exception:
                 pass
         raise
-
-
-def test_registry_endpoint_trusted_signing_mutual_exclusivity(registry_endpoint_test_setup, tracked_resources):
-    """Test that specifying both configmap and secret raises an error."""
-    resource_group = registry_endpoint_test_setup["resourceGroup"]
-    instance_name = registry_endpoint_test_setup["instanceName"]
-    registry_endpoint_name = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
-    host = "trustregistry.azurecr.io"
-
-    # Test mutual exclusivity on add
-    with pytest.raises(Exception) as exc_info:
-        run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
-            f"-g {resource_group} --instance {instance_name} "
-            f"--host {host} --trust-config-map-ref my-configmap --trust-secret-ref my-secret"
-        )
-
-    # The CLI should fail with the mutual exclusivity error
-    assert exc_info.value.error_msg is not None
 
 
 def assert_registry_endpoint(endpoint: dict, **expected):

--- a/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_unit.py
@@ -857,62 +857,81 @@ def test_registry_endpoint_update_host_and_auth(mocked_cmd, mocked_responses: re
     assert len(mocked_responses.calls) == 2  # GET + PUT
 
 
-class TestRegistryEndpointsTrustedSigningKey:
-    """Test class for RegistryEndpoints trusted signing key functionality."""
+class TestRegistryEndpointsCodeSigningCas:
+    """Test class for RegistryEndpoints code signing CAs functionality."""
 
-    def test_process_trusted_signing_key_none(self, mocked_cmd):
-        """Test _process_trusted_signing_key returns None when no parameters provided."""
+    def test_process_code_signing_cas_none(self, mocked_cmd):
+        """Test _process_code_signing_cas returns None when no parameters provided."""
         registry_endpoints = RegistryEndpoints(cmd=mocked_cmd)
 
-        result = registry_endpoints._process_trusted_signing_key()
+        result = registry_endpoints._process_code_signing_cas()
         assert result is None
 
-    def test_process_trusted_signing_key_configmap(self, mocked_cmd):
-        """Test _process_trusted_signing_key with configmap reference."""
+    def test_process_code_signing_cas_configmap_refs(self, mocked_cmd):
+        """Test _process_code_signing_cas with configmap references."""
         registry_endpoints = RegistryEndpoints(cmd=mocked_cmd)
 
-        result = registry_endpoints._process_trusted_signing_key(trusted_signing_configmap_key="my-configmap")
+        result = registry_endpoints._process_code_signing_cas(code_signing_configmap_refs=["configmap1", "configmap2"])
 
-        expected = {
-            "trustedSigningKeys": {
-                "configMapRef": "my-configmap",
+        expected = [
+            {
                 "type": "ConfigMap",
+                "configMapRef": "configmap1",
+            },
+            {
+                "type": "ConfigMap",
+                "configMapRef": "configmap2",
             }
-        }
+        ]
         assert result == expected
 
-    def test_process_trusted_signing_key_secret(self, mocked_cmd):
-        """Test _process_trusted_signing_key with secret reference."""
+    def test_process_code_signing_cas_secret_refs(self, mocked_cmd):
+        """Test _process_code_signing_cas with secret references."""
         registry_endpoints = RegistryEndpoints(cmd=mocked_cmd)
 
-        result = registry_endpoints._process_trusted_signing_key(trusted_signing_secret_key="my-secret")
+        result = registry_endpoints._process_code_signing_cas(code_signing_secret_refs=["secret1", "secret2"])
 
-        expected = {
-            "trustedSigningKeys": {
-                "secretRef": "my-secret",
+        expected = [
+            {
                 "type": "Secret",
+                "secretRef": "secret1",
+            },
+            {
+                "type": "Secret",
+                "secretRef": "secret2",
             }
-        }
+        ]
         assert result == expected
 
-    def test_process_trusted_signing_key_mutually_exclusive(self, mocked_cmd):
-        """Test _process_trusted_signing_key raises error when both configmap and secret provided."""
+    def test_process_code_signing_cas_mixed_refs(self, mocked_cmd):
+        """Test _process_code_signing_cas with both configmap and secret references."""
         registry_endpoints = RegistryEndpoints(cmd=mocked_cmd)
 
-        with pytest.raises(MutuallyExclusiveArgumentError):
-            registry_endpoints._process_trusted_signing_key(
-                trusted_signing_configmap_key="my-configmap",
-                trusted_signing_secret_key="my-secret",
-            )
+        result = registry_endpoints._process_code_signing_cas(
+            code_signing_configmap_refs=["configmap1"],
+            code_signing_secret_refs=["secret1"],
+        )
+
+        expected = [
+            {
+                "type": "ConfigMap",
+                "configMapRef": "configmap1",
+            },
+            {
+                "type": "Secret",
+                "secretRef": "secret1",
+            },
+        ]
+        assert result == expected
 
 
-def test_registry_endpoint_add_with_trust_configmap(mocked_cmd, mocked_responses: responses):
-    """Test adding a registry endpoint with trusted signing configmap."""
+def test_registry_endpoint_add_with_code_signing_configmap(mocked_cmd, mocked_responses: responses):
+    """Test adding a registry endpoint with code signing ConfigMap CAs."""
     registry_endpoint_name = generate_random_string()
     instance_name = generate_random_string()
     resource_group_name = generate_random_string()
     host = "myregistry.azurecr.io"
-    trust_configmap = "my-trust-configmap"
+    code_signing_configmaps = ["configmap1", "configmap2"]
 
     # Mock the instance record for extended location retrieval
     mock_instance_record = get_mock_instance_record(
@@ -932,19 +951,23 @@ def test_registry_endpoint_add_with_trust_configmap(mocked_cmd, mocked_responses
         content_type="application/json",
     )
 
-    # Create expected record with trust settings
+    # Create expected record with code signing CAs
     mock_registry_record = get_mock_registry_endpoint_record(
         registry_endpoint_name=registry_endpoint_name,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         host=host,
     )
-    mock_registry_record["properties"]["trustSettings"] = {
-        "trustedSigningKeys": {
-            "configMapRef": trust_configmap,
+    mock_registry_record["properties"]["codeSigningCas"] = [
+        {
             "type": "ConfigMap",
+            "configMapRef": "configmap1",
+        },
+        {
+            "type": "ConfigMap",
+            "configMapRef": "configmap2",
         }
-    }
+    ]
 
     mocked_responses.add(
         method=responses.PUT,
@@ -964,26 +987,29 @@ def test_registry_endpoint_add_with_trust_configmap(mocked_cmd, mocked_responses
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,
         host=host,
-        trusted_signing_configmap_key=trust_configmap,
+        code_signing_configmap_refs=code_signing_configmaps,
         wait_sec=0,
     )
 
     assert result == mock_registry_record
     assert len(mocked_responses.calls) == 2  # GET instance + PUT registry
 
-    # Verify trust settings in the result
-    trust_settings = result["properties"]["trustSettings"]
-    assert trust_settings["trustedSigningKeys"]["configMapRef"] == trust_configmap
-    assert trust_settings["trustedSigningKeys"]["type"] == "ConfigMap"
+    # Verify code signing CAs in the result
+    cas = result["properties"]["codeSigningCas"]
+    assert len(cas) == 2
+    assert cas[0]["configMapRef"] == "configmap1"
+    assert cas[0]["type"] == "ConfigMap"
+    assert cas[1]["configMapRef"] == "configmap2"
+    assert cas[1]["type"] == "ConfigMap"
 
 
-def test_registry_endpoint_add_with_trust_secret(mocked_cmd, mocked_responses: responses):
-    """Test adding a registry endpoint with trusted signing secret."""
+def test_registry_endpoint_add_with_code_signing_secret(mocked_cmd, mocked_responses: responses):
+    """Test adding a registry endpoint with code signing Secret CAs."""
     registry_endpoint_name = generate_random_string()
     instance_name = generate_random_string()
     resource_group_name = generate_random_string()
     host = "myregistry.azurecr.io"
-    trust_secret = "my-trust-secret"
+    code_signing_secrets = ["secret1"]
 
     # Mock the instance record for extended location retrieval
     mock_instance_record = get_mock_instance_record(
@@ -1003,19 +1029,19 @@ def test_registry_endpoint_add_with_trust_secret(mocked_cmd, mocked_responses: r
         content_type="application/json",
     )
 
-    # Create expected record with trust settings
+    # Create expected record with code signing CAs
     mock_registry_record = get_mock_registry_endpoint_record(
         registry_endpoint_name=registry_endpoint_name,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         host=host,
     )
-    mock_registry_record["properties"]["trustSettings"] = {
-        "trustedSigningKeys": {
-            "secretRef": trust_secret,
+    mock_registry_record["properties"]["codeSigningCas"] = [
+        {
             "type": "Secret",
+            "secretRef": "secret1",
         }
-    }
+    ]
 
     mocked_responses.add(
         method=responses.PUT,
@@ -1035,25 +1061,26 @@ def test_registry_endpoint_add_with_trust_secret(mocked_cmd, mocked_responses: r
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,
         host=host,
-        trusted_signing_secret_key=trust_secret,
+        code_signing_secret_refs=code_signing_secrets,
         wait_sec=0,
     )
 
     assert result == mock_registry_record
     assert len(mocked_responses.calls) == 2  # GET instance + PUT registry
 
-    # Verify trust settings in the result
-    trust_settings = result["properties"]["trustSettings"]
-    assert trust_settings["trustedSigningKeys"]["secretRef"] == trust_secret
-    assert trust_settings["trustedSigningKeys"]["type"] == "Secret"
+    # Verify code signing CAs in the result
+    cas = result["properties"]["codeSigningCas"]
+    assert len(cas) == 1
+    assert cas[0]["secretRef"] == "secret1"
+    assert cas[0]["type"] == "Secret"
 
 
-def test_registry_endpoint_update_with_trust_configmap(mocked_cmd, mocked_responses: responses):
-    """Test updating a registry endpoint with trusted signing configmap."""
+def test_registry_endpoint_update_with_code_signing_configmap(mocked_cmd, mocked_responses: responses):
+    """Test updating a registry endpoint with code signing ConfigMap CAs."""
     registry_endpoint_name = generate_random_string()
     instance_name = generate_random_string()
     resource_group_name = generate_random_string()
-    trust_configmap = "my-trust-configmap"
+    code_signing_configmaps = ["configmap1"]
 
     # Mock existing registry endpoint
     existing_record = get_mock_registry_endpoint_record(
@@ -1075,14 +1102,14 @@ def test_registry_endpoint_update_with_trust_configmap(mocked_cmd, mocked_respon
         content_type="application/json",
     )
 
-    # Create updated record with trust settings
+    # Create updated record with code signing CAs
     updated_record = existing_record.copy()
-    updated_record["properties"]["trustSettings"] = {
-        "trustedSigningKeys": {
-            "configMapRef": trust_configmap,
+    updated_record["properties"]["codeSigningCas"] = [
+        {
             "type": "ConfigMap",
+            "configMapRef": "configmap1",
         }
-    }
+    ]
 
     # Mock the PUT call to update endpoint
     mocked_responses.add(
@@ -1102,25 +1129,26 @@ def test_registry_endpoint_update_with_trust_configmap(mocked_cmd, mocked_respon
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,
-        trusted_signing_configmap_key=trust_configmap,
+        code_signing_configmap_refs=code_signing_configmaps,
         wait_sec=0,
     )
 
     assert result == updated_record
     assert len(mocked_responses.calls) == 2  # GET + PUT
 
-    # Verify trust settings in the result
-    trust_settings = result["properties"]["trustSettings"]
-    assert trust_settings["trustedSigningKeys"]["configMapRef"] == trust_configmap
-    assert trust_settings["trustedSigningKeys"]["type"] == "ConfigMap"
+    # Verify code signing CAs in the result
+    cas = result["properties"]["codeSigningCas"]
+    assert len(cas) == 1
+    assert cas[0]["configMapRef"] == "configmap1"
+    assert cas[0]["type"] == "ConfigMap"
 
 
-def test_registry_endpoint_update_with_trust_secret(mocked_cmd, mocked_responses: responses):
-    """Test updating a registry endpoint with trusted signing secret."""
+def test_registry_endpoint_update_with_code_signing_secret(mocked_cmd, mocked_responses: responses):
+    """Test updating a registry endpoint with code signing Secret CAs."""
     registry_endpoint_name = generate_random_string()
     instance_name = generate_random_string()
     resource_group_name = generate_random_string()
-    trust_secret = "my-trust-secret"
+    code_signing_secrets = ["secret1"]
 
     # Mock existing registry endpoint
     existing_record = get_mock_registry_endpoint_record(
@@ -1142,14 +1170,14 @@ def test_registry_endpoint_update_with_trust_secret(mocked_cmd, mocked_responses
         content_type="application/json",
     )
 
-    # Create updated record with trust settings
+    # Create updated record with code signing CAs
     updated_record = existing_record.copy()
-    updated_record["properties"]["trustSettings"] = {
-        "trustedSigningKeys": {
-            "secretRef": trust_secret,
+    updated_record["properties"]["codeSigningCas"] = [
+        {
             "type": "Secret",
+            "secretRef": "secret1",
         }
-    }
+    ]
 
     # Mock the PUT call to update endpoint
     mocked_responses.add(
@@ -1169,14 +1197,15 @@ def test_registry_endpoint_update_with_trust_secret(mocked_cmd, mocked_responses
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,
-        trusted_signing_secret_key=trust_secret,
+        code_signing_secret_refs=code_signing_secrets,
         wait_sec=0,
     )
 
     assert result == updated_record
     assert len(mocked_responses.calls) == 2  # GET + PUT
 
-    # Verify trust settings in the result
-    trust_settings = result["properties"]["trustSettings"]
-    assert trust_settings["trustedSigningKeys"]["secretRef"] == trust_secret
-    assert trust_settings["trustedSigningKeys"]["type"] == "Secret"
+    # Verify code signing CAs in the result
+    cas = result["properties"]["codeSigningCas"]
+    assert len(cas) == 1
+    assert cas[0]["secretRef"] == "secret1"
+    assert cas[0]["type"] == "Secret"


### PR DESCRIPTION
Updates registry endpoint add/update commands to replace `--trust-config-map-ref` and `--trust-secret-ref` with `--cs-config-map-refs` and `--cs-secret-refs`

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
