### PR TITLE
feat!: rsync enable -> enable-rsync. Remove rule provisioning.

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.0.0b4.dev9"
+VERSION = "2.0.0b4.dev10"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -32,7 +32,7 @@ from .providers.support_bundle import (
 )
 
 # cause help barfs on anything not indented correctly
-DEVICEREGISTRY_API_STR_FOR_HELP = COMPAT_DEVICEREGISTRY_APIS.as_str().strip().replace('\n', '\n            - ')
+DEVICEREGISTRY_API_STR_FOR_HELP = COMPAT_DEVICEREGISTRY_APIS.as_str().strip().replace("\n", "\n            - ")
 
 
 def load_iotops_help():
@@ -2652,61 +2652,22 @@ def load_iotops_help():
     """
 
     helps[
-        "iot ops rsync"
-    ] = """
-        type: group
-        short-summary: Resource sync rules management.
-    """
-
-    helps[
-        "iot ops rsync enable"
+        "iot ops enable-rsync"
     ] = """
         type: command
-        short-summary: Enable edge to cloud hydration by creating resource sync rules for the instance.
+        short-summary: Enable edge to cloud hydration.
         long-summary: |
-          This operation will create two resource sync rules. One for IoT Operations and one for
-          Device Registry. It will then apply a role assignment between the K8 Bridge service
-          principal and the IoT Operations instance custom location.
+          This operation will lookup the K8 Bridge service principal then assign
+          it to the scope of the IoT Operations instance custom location with the built-in
+          role of Azure Kubernetes Service Arc Contributor by default.
 
         examples:
         - name: Enable resource sync for the instance.
           text: >
-            az iot ops rsync enable -n myinstance -g myresourcegroup
-        - name: Enable resource sync for the instance but skip the role assignment step.
-          text: >
-            az iot ops rsync enable -n myinstance -g myresourcegroup --skip-ra
+            az iot ops enable-rsync -n myinstance -g myresourcegroup
         - name: Enable resource sync for the instance and explictly provide the K8 Bridge principal OID.
           text: >
-            az iot ops rsync enable -n myinstance -g myresourcegroup --k8-bridge-sp-oid $TENANT_K8_BRIDGE_SP_OID
-        - name: Enable resource sync for the instance with some customization.
-          text: >
-            az iot ops rsync enable -n myinstance -g myresourcegroup
-            --rule-adr-name myadrsync --rule-ops-name myopsync
-            --rule-adr-pri 100 --rule-ops-pri 200
-    """
-
-    helps[
-        "iot ops rsync list"
-    ] = """
-        type: command
-        short-summary: List resource sync rules associated with the instance.
-
-        examples:
-        - name: List resource sync rules associated with the instance.
-          text: >
-            az iot ops rsync list -n myinstance -g myresourcegroup
-    """
-
-    helps[
-        "iot ops rsync disable"
-    ] = """
-        type: command
-        short-summary: Disable edge to cloud hydration by deleting instance associated resource sync rules.
-
-        examples:
-        - name: Disable resource sync for the target instance.
-          text: >
-            az iot ops rsync disable -n myinstance -g myresourcegroup
+            az iot ops enable-rsync -n myinstance -g myresourcegroup --k8-bridge-sp-oid $TENANT_K8_BRIDGE_SP_OID
     """
 
     helps[

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -39,16 +39,8 @@ def load_iotops_commands(self, _):
         cmd_group.command("delete", "delete")
         cmd_group.command("clone", "clone_instance", is_preview=True)
         cmd_group.command("get-versions", "get_versions", is_experimental=True)
-        cmd_group.command("migrate-assets", "migrate_assets", is_preview=True)
-
-    with self.command_group(
-        "iot ops rsync",
-        command_type=edge_resource_ops,
-        is_preview=True,
-    ) as cmd_group:
-        cmd_group.command("enable", "enable_rsync")
-        cmd_group.command("disable", "disable_rsync")
-        cmd_group.command("list", "list_rsync")
+        cmd_group.command("migrate-assets", "migrate_assets")
+        cmd_group.command("enable-rsync", "enable_rsync")
 
     with self.command_group(
         "iot ops identity",

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -415,47 +415,17 @@ def enable_rsync(
     cmd,
     instance_name: str,
     resource_group_name: str,
-    skip_role_assignments: Optional[bool] = None,
     custom_role_id: Optional[str] = None,
     k8_bridge_sp_oid: Optional[str] = None,
-    rule_ops_name: Optional[str] = None,
-    rule_adr_name: Optional[str] = None,
-    rule_ops_pri: Optional[int] = None,
-    rule_adr_pri: Optional[int] = None,
-    tags: Optional[dict] = None,
     **kwargs,
 ):
     from .providers.orchestration.resources import SyncRules
 
     return SyncRules(cmd=cmd, resource_group_name=resource_group_name, instance_name=instance_name).enable(
-        skip_role_assignments=skip_role_assignments,
         custom_role_id=custom_role_id,
         k8_bridge_sp_oid=k8_bridge_sp_oid,
-        rule_ops_name=rule_ops_name,
-        rule_adr_name=rule_adr_name,
-        rule_ops_pri=rule_ops_pri,
-        rule_adr_pri=rule_adr_pri,
-        tags=tags,
         **kwargs,
     )
-
-
-def disable_rsync(cmd, instance_name: str, resource_group_name: str, confirm_yes: Optional[bool] = None):
-    from .providers.orchestration.resources import SyncRules
-
-    return SyncRules(cmd=cmd, resource_group_name=resource_group_name, instance_name=instance_name).disable(
-        confirm_yes=confirm_yes
-    )
-
-
-def list_rsync(
-    cmd,
-    instance_name: str,
-    resource_group_name: str,
-) -> List[dict]:
-    from .providers.orchestration.resources import SyncRules
-
-    return SyncRules(cmd=cmd, resource_group_name=resource_group_name, instance_name=instance_name).list()
 
 
 def get_versions():

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1810,38 +1810,7 @@ def load_iotops_arguments(self, _):
             arg_group="Cluster Target",
         )
 
-    with self.argument_context("iot ops rsync") as context:
-        context.argument(
-            "instance_name",
-            options_list=["--instance", "-i", "-n"],
-            help="IoT Operations instance name.",
-        )
-        context.argument(
-            "rule_ops_name",
-            options_list=["--rule-ops-name"],
-            help="The desired name of the resource sync rule to create for IoT Operations.",
-            arg_group="Custom Rule",
-        )
-        context.argument(
-            "rule_adr_name",
-            options_list=["--rule-adr-name"],
-            help="The desired name of the resource sync rule to create for Device Registry.",
-            arg_group="Custom Rule",
-        )
-        context.argument(
-            "rule_ops_pri",
-            type=int,
-            options_list=["--rule-ops-pri"],
-            help="The desired priority of the resource sync rule to create for IoT Operations.",
-            arg_group="Custom Rule",
-        )
-        context.argument(
-            "rule_adr_pri",
-            type=int,
-            options_list=["--rule-adr-pri"],
-            help="The desired priority of the resource sync rule to create for Device Registry.",
-            arg_group="Custom Rule",
-        )
+    with self.argument_context("iot ops enable-rsync") as context:
         context.argument(
             "k8_bridge_sp_oid",
             options_list=["--k8-bridge-sp-oid"],

--- a/azext_edge/edge/providers/orchestration/resources/sync_rules.py
+++ b/azext_edge/edge/providers/orchestration/resources/sync_rules.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import TYPE_CHECKING, List, NamedTuple, Optional
+from typing import Optional
 
 from azure.cli.core.azclierror import (
     AzureResponseError,
@@ -12,10 +12,9 @@ from azure.cli.core.azclierror import (
 from knack.log import get_logger
 from rich.console import Console
 
-from ....util.az_client import get_extloc_mgmt_client, wait_for_terminal_states
-from ....util.common import should_continue_prompt
-from ....util.id_tools import parse_resource_id
+from ....util.az_client import get_extloc_mgmt_client
 from ....util.queryable import Queryable
+from ..common import KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID
 from ..permissions import (
     ROLE_DEF_FORMAT_STR,
     PermissionManager,
@@ -23,12 +22,6 @@ from ..permissions import (
     get_ra_user_error_msg,
 )
 from . import Instances
-from ..common import KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID
-
-if TYPE_CHECKING:
-    from ....vendor.clients.extendedlocmgmt.operations import (
-        ResourceSyncRulesOperations,
-    )
 
 K8_BRIDGE_APP_ID = "319f651f-7ddb-4fc6-9857-7aef9250bd05"
 ADR_PROVIDER = "Microsoft.DeviceRegistry"
@@ -36,33 +29,6 @@ OPS_PROVIDER = "Microsoft.IoTOperations"
 
 logger = get_logger(__name__)
 console = Console()
-
-
-class SyncRuleAttr(NamedTuple):
-    provider: str
-    priority: int
-    name: str
-
-
-def get_sync_rule_attrs(
-    custom_location_name: str,
-    rule_ops_name: Optional[str] = None,
-    rule_adr_name: Optional[str] = None,
-    rule_ops_pri: Optional[int] = None,
-    rule_adr_pri: Optional[int] = None,
-) -> List[SyncRuleAttr]:
-    return [
-        SyncRuleAttr(
-            provider=OPS_PROVIDER,
-            priority=rule_ops_pri or 400,
-            name=rule_ops_name or f"{custom_location_name}-aio-sync",
-        ),
-        SyncRuleAttr(
-            provider=ADR_PROVIDER,
-            priority=rule_adr_pri or 200,
-            name=rule_adr_name or f"{custom_location_name}-adr-sync",
-        ),
-    ]
 
 
 class SyncRules(Queryable):
@@ -75,128 +41,56 @@ class SyncRules(Queryable):
             self.instances.show(name=self.instance_name, resource_group_name=self.resource_group_name)
         )
         self.extloc_mgmt_client = get_extloc_mgmt_client(self.default_subscription_id)
-        self.ops: "ResourceSyncRulesOperations" = self.extloc_mgmt_client.resource_sync_rules
-
-    def _get_enable_params(
-        self, provider_name: str, priority: Optional[int] = None, tags: Optional[dict] = None
-    ) -> dict:
-        parsed_cl_id = parse_resource_id(self.custom_location["id"])
-        rg_id = "/subscriptions/{}/resourceGroups/{}".format(
-            parsed_cl_id["subscription"], parsed_cl_id["resource_group"]
-        )
-        properties = {
-            "targetResourceGroup": rg_id,
-        }
-        parameters = {
-            "location": self.custom_location["location"],
-        }
-        if priority:
-            properties["priority"] = priority
-        if tags:
-            parameters["tags"] = tags
-
-        properties["selector"] = {
-            "matchExpressions": [
-                {
-                    "key": "management.azure.com/provider-name",
-                    "operator": "In",
-                    "values": [provider_name, provider_name.lower()],
-                }
-            ]
-        }
-        parameters["properties"] = properties
-        return parameters
 
     def enable(
         self,
-        skip_role_assignments: Optional[bool] = None,
         custom_role_id: Optional[str] = None,
         k8_bridge_sp_oid: Optional[str] = None,
-        rule_ops_name: Optional[str] = None,
-        rule_adr_name: Optional[str] = None,
-        rule_ops_pri: Optional[int] = None,
-        rule_adr_pri: Optional[int] = None,
-        tags: Optional[dict] = None,
         **kwargs,
-    ) -> List[dict]:
+    ) -> Optional[dict]:
         with console.status("Working...") as c:
-            pollers = []
-            sync_rule_attrs = get_sync_rule_attrs(
-                custom_location_name=self.custom_location["name"],
-                rule_ops_name=rule_ops_name,
-                rule_adr_name=rule_adr_name,
-                rule_ops_pri=rule_ops_pri,
-                rule_adr_pri=rule_adr_pri,
+            target_role_def = custom_role_id or ROLE_DEF_FORMAT_STR.format(
+                subscription_id=self.default_subscription_id, role_id=KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID
             )
-            for rule_attrs in sync_rule_attrs:
-                poller = self.ops.begin_create_or_update(
-                    resource_group_name=self.resource_group_name,
-                    resource_name=self.custom_location["name"],
-                    child_resource_name=rule_attrs.name,
-                    parameters=self._get_enable_params(
-                        provider_name=rule_attrs.provider,
-                        priority=rule_attrs.priority,
-                        tags=tags,
-                    ),
+            k8_bridge_sp_oid = k8_bridge_sp_oid or self.get_sp_id(K8_BRIDGE_APP_ID)
+            if not k8_bridge_sp_oid:
+                c.stop()
+                logger.warning(
+                    "Unable to query K8 Bridge service principal and OID not provided via parameter. "
+                    "Role assignment can not be made."
                 )
-                pollers.append(poller)
-            wait_for_terminal_states(*pollers, **kwargs)
-            result = [p.result() for p in pollers]
+                return
 
-            if not skip_role_assignments:
-                target_role_def = custom_role_id or ROLE_DEF_FORMAT_STR.format(
-                    subscription_id=self.default_subscription_id, role_id=KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID
+            permission_manager = PermissionManager(self.default_subscription_id)
+            try:
+                result = permission_manager.apply_role_assignment(
+                    scope=self.custom_location["id"],
+                    principal_id=k8_bridge_sp_oid,
+                    role_def_id=target_role_def,
+                    principal_type=PrincipalType.SERVICE_PRINCIPAL.value,
+                    **kwargs,
                 )
-                k8_bridge_sp_oid = k8_bridge_sp_oid or self.get_sp_id(K8_BRIDGE_APP_ID)
-                if not k8_bridge_sp_oid:
-                    c.stop()
-                    logger.warning(
-                        "Unable to query K8 Bridge service principal and OID not provided via parameter. "
-                        "Skipping role assignment."
-                    )
-                    return result
 
-                permission_manager = PermissionManager(self.default_subscription_id)
-                try:
-                    permission_manager.apply_role_assignment(
+                if result is None:
+                    console.print(":exclamation: Role assignment already exists for K8 Bridge service principal.")
+                    action_msg = "already exists"
+                else:
+                    action_msg = "successfully created"
+
+                logger.info(
+                    "Role assignment %s for K8 Bridge service principal on custom location '%s'.",
+                    action_msg,
+                    self.custom_location["name"],
+                )
+                return result
+            except Exception as e:
+                c.stop()
+                raise AzureResponseError(
+                    get_ra_user_error_msg(
+                        error_str=str(e),
+                        sp_name="K8 Bridge",
+                        sp_id=K8_BRIDGE_APP_ID,
+                        expected_role="Azure Kubernetes Service Arc Contributor Role",
                         scope=self.custom_location["id"],
-                        principal_id=k8_bridge_sp_oid,
-                        role_def_id=target_role_def,
-                        principal_type=PrincipalType.SERVICE_PRINCIPAL.value,
                     )
-                except Exception as e:
-                    c.stop()
-                    raise AzureResponseError(
-                        get_ra_user_error_msg(
-                            error_str=str(e),
-                            sp_name="K8 Bridge",
-                            sp_id=K8_BRIDGE_APP_ID,
-                            expected_role="Azure Kubernetes Service Arc Contributor Role",
-                            scope=self.custom_location["id"],
-                        )
-                    )
-
-            return result
-
-    def disable(self, confirm_yes: Optional[bool] = None) -> None:
-        if not should_continue_prompt(confirm_yes=confirm_yes):
-            return
-
-        sync_rules = list(self.list())
-        if not sync_rules:
-            logger.warning(f"No resource sync rules found for instance '{self.instance_name}'.")
-            return
-
-        with console.status("Working..."):
-            for rule in sync_rules:
-                self.ops.delete(
-                    resource_group_name=self.resource_group_name,
-                    resource_name=self.custom_location["name"],
-                    child_resource_name=rule["name"],
                 )
-
-    def list(self) -> List[dict]:
-        return self.ops.list_by_custom_location_id(
-            resource_group_name=self.resource_group_name,
-            resource_name=self.custom_location["name"],
-        )

--- a/azext_edge/tests/edge/orchestration/resources/test_sync_rules_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_sync_rules_unit.py
@@ -4,87 +4,22 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-
-import re
 import json
-from typing import Optional, Dict
+import re
 from unittest.mock import Mock
 
 import pytest
 import responses
+from azure.cli.core.azclierror import AzureResponseError
 
-from azext_edge.edge.providers.orchestration.resources.sync_rules import (
-    K8_BRIDGE_APP_ID,
-    KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID,
-    ADR_PROVIDER,
-    OPS_PROVIDER,
-)
-from azext_edge.edge.commands_edge import enable_rsync, list_rsync, disable_rsync
+from azext_edge.edge.commands_edge import enable_rsync
+from azext_edge.edge.providers.orchestration.resources.sync_rules import K8_BRIDGE_APP_ID
+from azext_edge.edge.providers.orchestration.common import KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID
 
-from ....generators import generate_random_string, generate_uuid, generate_role_def_id
-from .conftest import (
-    ZEROED_SUBSCRIPTION,
-    append_role_assignment_endpoint,
-    get_base_endpoint,
-    get_mock_resource,
-)
-from .test_custom_locations_unit import (
-    get_custom_location_endpoint,
-    get_mock_custom_location_record,
-)
+from ....generators import generate_random_string, generate_role_def_id, generate_uuid
+from .conftest import ZEROED_SUBSCRIPTION, append_role_assignment_endpoint
+from .test_custom_locations_unit import get_custom_location_endpoint, get_mock_custom_location_record
 from .test_instances_unit import get_instance_endpoint, get_mock_instance_record
-
-RESOURCE_SYNC_RP = "Microsoft.ExtendedLocation"
-RESOURCE_SYNC_API_VERSION = "2021-08-31-preview"
-
-EXPECTED_SELECTORS = {
-    ADR_PROVIDER: {
-        "matchExpressions": [
-            {
-                "key": "management.azure.com/provider-name",
-                "operator": "In",
-                "values": [ADR_PROVIDER, ADR_PROVIDER.lower()],
-            }
-        ]
-    },
-    OPS_PROVIDER: {
-        "matchExpressions": [
-            {
-                "key": "management.azure.com/provider-name",
-                "operator": "In",
-                "values": [OPS_PROVIDER, OPS_PROVIDER.lower()],
-            }
-        ]
-    },
-}
-
-
-def get_sync_rule_endpoint(resource_group_name: str, cl_name: str, rule_name: Optional[str] = None) -> str:
-    resource_path = f"/customLocations/{cl_name}/resourceSyncRules"
-    if rule_name:
-        resource_path += f"/{rule_name}"
-    return get_base_endpoint(
-        resource_group_name=resource_group_name,
-        resource_path=resource_path,
-        resource_provider=RESOURCE_SYNC_RP,
-        api_version=RESOURCE_SYNC_API_VERSION,
-    )
-
-
-def get_mock_sync_rule_record(name: str, resource_group_name: str, provider: str, priority: int = 400) -> dict:
-    resource = get_mock_resource(
-        name=name,
-        properties={
-            "priority": priority,
-            "provisioningState": "Succeeded",
-            "selector": EXPECTED_SELECTORS[provider],
-            "targetResourceGroup": f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{resource_group_name}",
-        },
-        resource_group_name=resource_group_name,
-        qualified_type=f"{RESOURCE_SYNC_RP}/customLocations/resourceSyncRules",
-    )
-
-    return resource
 
 
 def get_sp_fetch_endpoint() -> str:
@@ -97,337 +32,255 @@ def mocked_logger(mocker):
 
 
 @pytest.fixture
-def mocked_logger_queryable(mocker):
-    yield mocker.patch("azext_edge.edge.util.queryable.logger", autospec=True)
+def setup_base_mocks(mocked_responses):
+    def _setup(instance_name: str, resource_group_name: str, cl_name: str):
+        instance_endpoint = get_instance_endpoint(resource_group_name=resource_group_name, instance_name=instance_name)
+        mocked_responses.add(
+            method=responses.GET,
+            url=instance_endpoint,
+            json=get_mock_instance_record(
+                name=instance_name,
+                resource_group_name=resource_group_name,
+                cl_name=cl_name,
+            ),
+            status=200,
+        )
+
+        cl_endpoint = get_custom_location_endpoint(
+            resource_group_name=resource_group_name, custom_location_name=cl_name
+        )
+        cl_payload = get_mock_custom_location_record(name=cl_name, resource_group_name=resource_group_name)
+        mocked_responses.add(
+            method=responses.GET,
+            url=cl_endpoint,
+            json=cl_payload,
+            status=200,
+        )
+        return cl_endpoint, cl_payload
+
+    return _setup
 
 
 @pytest.mark.parametrize(
-    "role_assignment_scenario",
-    [{}, {"sp_lookup_code": 401}, {"k8_bridge_sp_oid": generate_uuid()}, {"skip_role_assignments": True}],
+    "sp_scenario",
+    [
+        {"sp_lookup_code": 200, "expect_ra": True},
+        {"sp_lookup_code": 401, "expect_ra": False},
+        {"sp_lookup_code": 404, "expect_ra": False},
+        {"k8_bridge_sp_oid": generate_uuid(), "expect_ra": True},
+    ],
 )
-@pytest.mark.parametrize(
-    "tags",
-    [None, {generate_random_string(): generate_random_string(), generate_random_string(): generate_random_string()}],
-)
-@pytest.mark.parametrize(
-    "custom_role_id",
-    [None, generate_uuid()],
-)
-@pytest.mark.parametrize(
-    "rule_name_map",
-    [{}, {"adr": generate_random_string(), "ops": generate_random_string()}],
-)
-@pytest.mark.parametrize(
-    "rule_pri_map",
-    [{}, {"adr": 123, "ops": 456}],
-)
+@pytest.mark.parametrize("use_custom_role", [False, True])
 def test_sync_rules_enable(
     mocked_cmd,
     mocked_logger: Mock,
-    mocked_logger_queryable: Mock,
     mocked_responses: responses,
-    tags: Optional[dict],
-    role_assignment_scenario: dict,
-    custom_role_id: Optional[str],
-    rule_name_map: Dict[str, str],
-    rule_pri_map: Dict[str, int],
+    setup_base_mocks,
+    sp_scenario: dict,
+    use_custom_role: bool,
 ):
-    cl_name = generate_random_string()
+    """Test sync rules enablement across SP lookup and role assignment scenarios."""
+    instance_name = generate_random_string()
     resource_group_name = generate_random_string()
-    default_k8_bridge_sp_oid = generate_uuid()
+    cl_name = generate_random_string()
 
-    skip_role_assignments = role_assignment_scenario.get("skip_role_assignments")
-    user_k8_bridge_sp_oid = role_assignment_scenario.get("k8_bridge_sp_oid")
-    sp_lookup_code = role_assignment_scenario.get("sp_lookup_code", 200)
+    default_k8_bridge_sp_oid = generate_uuid()
+    user_k8_bridge_sp_oid = sp_scenario.get("k8_bridge_sp_oid")
+    sp_lookup_code = sp_scenario.get("sp_lookup_code", 200)
+    expect_ra = sp_scenario.get("expect_ra", True)
     target_k8_bridge_sp_oid = user_k8_bridge_sp_oid or default_k8_bridge_sp_oid
 
-    rule_adr_pri = rule_pri_map.get("adr", 200)
-    rule_ops_pri = rule_pri_map.get("ops", 400)
-    rule_adr_name = rule_name_map.get("adr")
-    rule_ops_name = rule_name_map.get("ops")
-
-    # Instance fetch mock
-    instance_name = generate_random_string()
-    instance_endpoint = get_instance_endpoint(resource_group_name=resource_group_name, instance_name=instance_name)
-    instance_record = get_mock_instance_record(
-        name=instance_name,
-        resource_group_name=resource_group_name,
-        cl_name=cl_name,
-    )
-    mocked_responses.add(
-        method=responses.GET,
-        url=instance_endpoint,
-        json=instance_record,
-        status=200,
-        content_type="application/json",
+    custom_role_id = (
+        generate_role_def_id(role_id=generate_uuid(), subscription_id=ZEROED_SUBSCRIPTION) if use_custom_role else None
     )
 
-    # Custom location fetch mock
-    cl_endpoint = get_custom_location_endpoint(resource_group_name=resource_group_name, custom_location_name=cl_name)
-    cl_payload = get_mock_custom_location_record(name=cl_name, resource_group_name=resource_group_name)
-    mocked_responses.add(
-        method=responses.GET,
-        url=cl_endpoint,
-        json=cl_payload,
-        status=200,
-        content_type="application/json",
-    )
+    cl_endpoint, cl_payload = setup_base_mocks(instance_name, resource_group_name, cl_name)
 
-    # Role assignment fetch mock
-    if not skip_role_assignments:
-        fails_sp_lookup = sp_lookup_code != 200
-        if not user_k8_bridge_sp_oid:
-            # Fetch SP OID if not provided
-            sp_get = mocked_responses.add(
-                method=responses.GET,
-                url=get_sp_fetch_endpoint(),
-                json={"id": default_k8_bridge_sp_oid, "appId": K8_BRIDGE_APP_ID},
-                status=sp_lookup_code,
-                content_type="application/json",
-            )
-        if not fails_sp_lookup:
-            ra_get_endpoint = append_role_assignment_endpoint(
-                resource_endpoint=cl_endpoint, filter_query=f"principalId eq '{target_k8_bridge_sp_oid}'"
-            )
-            ra_get = mocked_responses.add(
-                method=responses.GET,
-                url=ra_get_endpoint,
-                json={"value": []},
-                status=200,
-                content_type="application/json",
-            )
-            ra_put_endpoint = append_role_assignment_endpoint(resource_endpoint=cl_endpoint, ra_name=".*")
-            ra_put = mocked_responses.add(
-                method=responses.PUT,
-                url=re.compile(ra_put_endpoint),
-                json={},
-                status=200,
-                content_type="application/json",
-            )
+    if not user_k8_bridge_sp_oid:
+        sp_get = mocked_responses.add(
+            method=responses.GET,
+            url=get_sp_fetch_endpoint(),
+            json={"id": default_k8_bridge_sp_oid, "appId": K8_BRIDGE_APP_ID} if sp_lookup_code == 200 else {},
+            status=sp_lookup_code,
+        )
 
-    expected_rule_adr_name = rule_adr_name or f"{cl_name}-adr-sync"
-    expected_rule_ops_name = rule_ops_name or f"{cl_name}-aio-sync"
-    adr_rule_payload = get_mock_sync_rule_record(
-        name=expected_rule_adr_name, resource_group_name=resource_group_name, provider=ADR_PROVIDER
-    )
-    ops_rule_payload = get_mock_sync_rule_record(
-        name=expected_rule_ops_name, resource_group_name=resource_group_name, provider=OPS_PROVIDER
-    )
-    sync_rule_adr_put = mocked_responses.add(
-        method=responses.PUT,
-        url=get_sync_rule_endpoint(
-            resource_group_name=resource_group_name, cl_name=cl_name, rule_name=expected_rule_adr_name
-        ),
-        json=adr_rule_payload,
-        status=200,
-        content_type="application/json",
-    )
-    sync_rule_ops_put = mocked_responses.add(
-        method=responses.PUT,
-        url=get_sync_rule_endpoint(
-            resource_group_name=resource_group_name, cl_name=cl_name, rule_name=expected_rule_ops_name
-        ),
-        json=ops_rule_payload,
-        status=200,
-        content_type="application/json",
-    )
+    if expect_ra:
+        expected_role_def_id = custom_role_id or generate_role_def_id(
+            role_id=KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID, subscription_id=ZEROED_SUBSCRIPTION
+        )
+
+        ra_get_endpoint = append_role_assignment_endpoint(
+            resource_endpoint=cl_endpoint, filter_query=f"principalId eq '{target_k8_bridge_sp_oid}'"
+        )
+        ra_get = mocked_responses.add(
+            method=responses.GET,
+            url=ra_get_endpoint,
+            json={"value": []},
+            status=200,
+        )
+
+        ra_put_endpoint = append_role_assignment_endpoint(cl_endpoint, ".*")
+        ra_put = mocked_responses.add(
+            method=responses.PUT,
+            url=re.compile(ra_put_endpoint),
+            json={
+                "id": generate_uuid(),
+                "properties": {"principalId": target_k8_bridge_sp_oid, "roleDefinitionId": expected_role_def_id},
+            },
+            status=200,
+        )
 
     result = enable_rsync(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
-        skip_role_assignments=skip_role_assignments,
         custom_role_id=custom_role_id,
         k8_bridge_sp_oid=user_k8_bridge_sp_oid,
-        rule_adr_name=rule_adr_name,
-        rule_ops_name=rule_ops_name,
-        rule_adr_pri=rule_adr_pri,
-        rule_ops_pri=rule_ops_pri,
-        tags=tags,
-        wait_sec=0.1,
     )
-    assert result == [ops_rule_payload, adr_rule_payload]
 
-    if not skip_role_assignments:
-        assert_ra_flow = True
-        if not user_k8_bridge_sp_oid:
-            assert sp_get.call_count == 1
-            mocked_logger_queryable.debug.call_args_list[0].assert_called_once_with(
-                "Using aud: https://graph.microsoft.com"
-            )
-            if sp_lookup_code != 200:
-                mocked_logger.warning.assert_called_once_with(
-                    "Unable to query K8 Bridge service principal and OID not provided via parameter. "
-                    "Skipping role assignment."
-                )
-                assert_ra_flow = False
-        if assert_ra_flow:
-            assert ra_get.call_count == 1
-            assert ra_put.call_count == 1
-            ra_put_json = json.loads(ra_put.calls[0].request.body)
-            expected_role_def_id = custom_role_id or generate_role_def_id(
-                role_id=KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID, subscription_id=ZEROED_SUBSCRIPTION
-            )
-            assert ra_put_json["properties"]["roleDefinitionId"] == expected_role_def_id
-            assert ra_put_json["properties"]["principalId"] == target_k8_bridge_sp_oid
-            assert ra_put_json["properties"]["principalType"] == "ServicePrincipal"
+    if not user_k8_bridge_sp_oid:
+        assert sp_get.call_count == 1
+        if sp_lookup_code != 200:
+            mocked_logger.warning.assert_called_once()
+            assert result is None
+            return
 
-    sync_rule_adr_put.call_count == 1
-    sync_rule_adr_put_json = json.loads(sync_rule_adr_put.calls[0].request.body)
-    assert sync_rule_adr_put_json["properties"]["targetResourceGroup"] == (
-        f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{resource_group_name}"
-    )
-    assert sync_rule_adr_put_json["properties"]["priority"] == rule_adr_pri
-    assert sync_rule_adr_put_json["properties"]["selector"] == EXPECTED_SELECTORS[ADR_PROVIDER]
-
-    sync_rule_ops_put.call_count == 1
-    sync_rule_ops_put_json = json.loads(sync_rule_ops_put.calls[0].request.body)
-    assert sync_rule_ops_put_json["properties"]["targetResourceGroup"] == (
-        f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{resource_group_name}"
-    )
-    assert sync_rule_ops_put_json["properties"]["priority"] == rule_ops_pri
-    assert sync_rule_ops_put_json["properties"]["selector"] == EXPECTED_SELECTORS[OPS_PROVIDER]
-    if tags:
-        assert sync_rule_ops_put_json["tags"] == tags
-        assert sync_rule_adr_put_json["tags"] == tags
+    if expect_ra:
+        assert ra_get.call_count == 1
+        assert ra_put.call_count == 1
+        ra_put_json = json.loads(ra_put.calls[0].request.body)
+        assert ra_put_json["properties"]["roleDefinitionId"] == expected_role_def_id
+        assert ra_put_json["properties"]["principalId"] == target_k8_bridge_sp_oid
+        assert ra_put_json["properties"]["principalType"] == "ServicePrincipal"
+        assert result is not None
+        mocked_logger.info.assert_called_with(
+            "Role assignment %s for K8 Bridge service principal on custom location '%s'.",
+            "successfully created",
+            cl_payload["name"],
+        )
 
 
-@pytest.mark.parametrize(
-    "rules_count",
-    [0, 2],
-)
-def test_sync_rules_list(mocked_cmd, mocked_responses: responses, rules_count: int):
-    cl_name = generate_random_string()
-    resource_group_name = generate_random_string()
-
-    # Instance fetch mock
+@pytest.mark.parametrize("existing_ra", [False, True])
+def test_sync_rules_enable_existing_assignment(
+    mocked_cmd,
+    mocked_logger: Mock,
+    mocked_responses: responses,
+    setup_base_mocks,
+    existing_ra: bool,
+):
+    """Test sync rules enablement behavior with existing role assignments."""
     instance_name = generate_random_string()
-    instance_endpoint = get_instance_endpoint(resource_group_name=resource_group_name, instance_name=instance_name)
-    instance_record = get_mock_instance_record(
-        name=instance_name,
-        resource_group_name=resource_group_name,
-        cl_name=cl_name,
-    )
-    mocked_responses.add(
-        method=responses.GET,
-        url=instance_endpoint,
-        json=instance_record,
-        status=200,
-        content_type="application/json",
-    )
-
-    # Custom location fetch mock
-    cl_endpoint = get_custom_location_endpoint(resource_group_name=resource_group_name, custom_location_name=cl_name)
-    cl_payload = get_mock_custom_location_record(name=cl_name, resource_group_name=resource_group_name)
-    mocked_responses.add(
-        method=responses.GET,
-        url=cl_endpoint,
-        json=cl_payload,
-        status=200,
-        content_type="application/json",
-    )
-
-    rules_payload = []
-    for _ in range(rules_count):
-        rules_payload.append(
-            get_mock_sync_rule_record(
-                name=generate_random_string(),
-                resource_group_name=resource_group_name,
-                provider=ADR_PROVIDER if _ % 2 == 0 else OPS_PROVIDER,
-            )
-        )
-    mocked_responses.add(
-        method=responses.GET,
-        url=get_sync_rule_endpoint(resource_group_name=resource_group_name, cl_name=cl_name),
-        json={"value": rules_payload},
-        status=200,
-        content_type="application/json",
-    )
-    result = list(
-        list_rsync(
-            cmd=mocked_cmd,
-            instance_name=instance_name,
-            resource_group_name=resource_group_name,
-        )
-    )
-    assert result == rules_payload
-
-
-@pytest.mark.parametrize(
-    "rules_count",
-    [0, 2],
-)
-def test_sync_rules_disable(mocked_cmd, mocked_logger: Mock, mocked_responses: responses, rules_count: int):
-    cl_name = generate_random_string()
     resource_group_name = generate_random_string()
+    cl_name = generate_random_string()
+    k8_bridge_sp_oid = generate_uuid()
 
-    # Instance fetch mock
-    instance_name = generate_random_string()
-    instance_endpoint = get_instance_endpoint(resource_group_name=resource_group_name, instance_name=instance_name)
-    instance_record = get_mock_instance_record(
-        name=instance_name,
-        resource_group_name=resource_group_name,
-        cl_name=cl_name,
+    cl_endpoint, cl_payload = setup_base_mocks(instance_name, resource_group_name, cl_name)
+
+    expected_role_def_id = generate_role_def_id(
+        role_id=KUBERNETES_ARC_CONTRIBUTOR_ROLE_ID, subscription_id=ZEROED_SUBSCRIPTION
     )
-    mocked_responses.add(
+
+    ra_get_endpoint = append_role_assignment_endpoint(
+        resource_endpoint=cl_endpoint, filter_query=f"principalId eq '{k8_bridge_sp_oid}'"
+    )
+    ra_get = mocked_responses.add(
         method=responses.GET,
-        url=instance_endpoint,
-        json=instance_record,
-        status=200,
-        content_type="application/json",
-    )
-
-    # Custom location fetch mock
-    cl_endpoint = get_custom_location_endpoint(resource_group_name=resource_group_name, custom_location_name=cl_name)
-    cl_payload = get_mock_custom_location_record(name=cl_name, resource_group_name=resource_group_name)
-    mocked_responses.add(
-        method=responses.GET,
-        url=cl_endpoint,
-        json=cl_payload,
-        status=200,
-        content_type="application/json",
-    )
-
-    rules_payload = []
-    for i in range(rules_count):
-        rules_payload.append(
-            get_mock_sync_rule_record(
-                name=generate_random_string(),
-                resource_group_name=resource_group_name,
-                provider=ADR_PROVIDER if i % 2 == 0 else OPS_PROVIDER,
+        url=ra_get_endpoint,
+        json={
+            "value": (
+                [
+                    {
+                        "id": generate_uuid(),
+                        "properties": {
+                            "principalId": k8_bridge_sp_oid,
+                            "roleDefinitionId": expected_role_def_id,
+                        },
+                    }
+                ]
+                if existing_ra
+                else []
             )
-        )
-    mocked_responses.add(
-        method=responses.GET,
-        url=get_sync_rule_endpoint(resource_group_name=resource_group_name, cl_name=cl_name),
-        json={"value": rules_payload},
+        },
         status=200,
-        content_type="application/json",
     )
 
-    sync_rule_deletes = []
-    for rule in rules_payload:
-        sync_rule_deletes.append(
-            mocked_responses.add(
-                method=responses.DELETE,
-                url=get_sync_rule_endpoint(
-                    resource_group_name=resource_group_name, cl_name=cl_name, rule_name=rule["name"]
-                ),
-                status=200,
-            )
+    if not existing_ra:
+        ra_put_endpoint = append_role_assignment_endpoint(cl_endpoint, ".*")
+        ra_put = mocked_responses.add(
+            method=responses.PUT,
+            url=re.compile(ra_put_endpoint),
+            json={
+                "id": generate_uuid(),
+                "properties": {"principalId": k8_bridge_sp_oid, "roleDefinitionId": expected_role_def_id},
+            },
+            status=200,
         )
 
-    disable_rsync(
+    result = enable_rsync(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
-        confirm_yes=True,
+        k8_bridge_sp_oid=k8_bridge_sp_oid,
     )
-    rules_payload_len = len(rules_payload)
-    if not rules_payload_len:
-        mocked_logger.warning.assert_called_once_with(f"No resource sync rules found for instance '{instance_name}'.")
 
-    for i in range(rules_payload_len):
-        rule = rules_payload[i]
-        sync_rule_delete = sync_rule_deletes[i]
-        assert sync_rule_delete.call_count == 1
+    assert ra_get.call_count == 1
+
+    if existing_ra:
+        assert result is None
+        mocked_logger.info.assert_called_with(
+            "Role assignment %s for K8 Bridge service principal on custom location '%s'.",
+            "already exists",
+            cl_payload["name"],
+        )
+    else:
+        assert ra_put.call_count == 1
+        assert result is not None
+        mocked_logger.info.assert_called_with(
+            "Role assignment %s for K8 Bridge service principal on custom location '%s'.",
+            "successfully created",
+            cl_payload["name"],
+        )
+
+
+def test_sync_rules_enable_role_assignment_error(
+    mocked_cmd,
+    mocked_responses: responses,
+    setup_base_mocks,
+):
+    """Test sync rules enablement when role assignment creation fails."""
+    instance_name = generate_random_string()
+    resource_group_name = generate_random_string()
+    cl_name = generate_random_string()
+    k8_bridge_sp_oid = generate_uuid()
+
+    cl_endpoint, cl_payload = setup_base_mocks(instance_name, resource_group_name, cl_name)
+
+    mocked_responses.add(
+        method=responses.GET,
+        url=append_role_assignment_endpoint(
+            resource_endpoint=cl_endpoint, filter_query=f"principalId eq '{k8_bridge_sp_oid}'"
+        ),
+        json={"value": []},
+        status=200,
+    )
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=re.compile(append_role_assignment_endpoint(cl_endpoint, ".*")),
+        json={"error": {"message": "Forbidden"}},
+        status=403,
+    )
+
+    with pytest.raises(AzureResponseError) as exc_info:
+        enable_rsync(
+            cmd=mocked_cmd,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            k8_bridge_sp_oid=k8_bridge_sp_oid,
+        )
+
+    error_msg = str(exc_info.value)
+    assert all(
+        text in error_msg
+        for text in ["K8 Bridge", K8_BRIDGE_APP_ID, "Azure Kubernetes Service Arc Contributor Role", cl_payload["id"]]
+    )


### PR DESCRIPTION
* Remove `rsync` command group in favor of single verb-compound noun style command.
* `enable-rsync` looks up the k8 bridge service principal and applies a role assignment (default arc contributor) between the sp and instance custom location.
* Update tests.
* Remove preview from `migrate-assets` and `enable-rsync`.