### PR TITLE
feat!: registry endpoint management command updates and preview flag removal

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -754,41 +754,40 @@ def load_iotops_help():
     """
 
     helps[
-        "iot ops registry add"
+        "iot ops registry create"
     ] = """
         type: command
-        short-summary: Add a container registry endpoint to an instance.
+        short-summary: Create a container registry endpoint for an instance.
         long-summary: |
-          Only Azure Container Registry (ACR) endpoints are supported.
           By default, the registry endpoint will use System Assigned Managed Identity authentication.
           Use the --no-auth flag to explicitly configure anonymous authentication.
 
         examples:
-        - name: Add a registry endpoint with default System Assigned Managed Identity authentication.
+        - name: Create a registry endpoint with default System Assigned Managed Identity authentication.
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
-        - name: Add a registry endpoint with explicit anonymous authentication.
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+        - name: Create a registry endpoint with explicit anonymous authentication.
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup --no-auth
-        - name: Add a registry endpoint with system-assigned managed identity and optional audience configuration
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup --no-auth
+        - name: Create a registry endpoint with system-assigned managed identity and optional audience configuration
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --auth-type SystemAssignedManagedIdentity --aud myaudience
-        - name: Add a registry endpoint with kubernetes secret reference authentication
+        - name: Create a registry endpoint with kubernetes secret reference authentication
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --auth-type ArtifactPullSecret --secret-ref mysecret
-        - name: Add a registry endpoint with user-assigned managed identity configuration
+        - name: Create a registry endpoint with user-assigned managed identity configuration
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --auth-type UserAssignedManagedIdentity --scope myscope --cid myclientid --tid mytenantid
-        - name: Add a registry endpoint with a code signing CA secret reference
+        - name: Create a registry endpoint with a code signing CA secret reference
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --cs-secret-refs mysecret
-        - name: Add a registry endpoint with multiple code signing CA secret and configmap references
+        - name: Create a registry endpoint with multiple code signing CA secret and configmap references
           text: >
-            az iot ops registry add -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
+            az iot ops registry create -n myregistry --host myregistry.azurecr.io -i myinstance -g myresourcegroup
             --cs-config-map-refs configmap1 configmap2 --cs-secret-refs secret1 secret2
     """
 
@@ -837,15 +836,15 @@ def load_iotops_help():
     """
 
     helps[
-        "iot ops registry remove"
+        "iot ops registry delete"
     ] = """
         type: command
-        short-summary: Remove a container registry endpoint.
+        short-summary: Delete a container registry endpoint.
 
         examples:
-        - name: Remove a registry endpoint.
+        - name: Delete a registry endpoint.
           text: >
-            az iot ops registry remove -n myregistry -i myinstance -g myresourcegroup
+            az iot ops registry delete -n myregistry -i myinstance -g myresourcegroup
     """
 
     helps[

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -184,9 +184,9 @@ def load_iotops_commands(self, _):
         command_type=registry_endpoint_resource_ops,
     ) as cmd_group:
         cmd_group.command("list", "list_registry_endpoints")
-        cmd_group.command("add", "create_registry_endpoint")
+        cmd_group.command("create", "create_registry_endpoint")
         cmd_group.command("update", "update_registry_endpoint")
-        cmd_group.command("remove", "delete_registry_endpoint")
+        cmd_group.command("delete", "delete_registry_endpoint")
         cmd_group.show_command("show", "show_registry_endpoint")
 
     with self.command_group(

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -182,7 +182,6 @@ def load_iotops_commands(self, _):
     with self.command_group(
         "iot ops registry",
         command_type=registry_endpoint_resource_ops,
-        is_preview=True,
     ) as cmd_group:
         cmd_group.command("list", "list_registry_endpoints")
         cmd_group.command("add", "create_registry_endpoint")

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -185,9 +185,9 @@ def load_iotops_commands(self, _):
         is_preview=True,
     ) as cmd_group:
         cmd_group.command("list", "list_registry_endpoints")
-        cmd_group.command("add", "add_registry_endpoint")
+        cmd_group.command("add", "create_registry_endpoint")
         cmd_group.command("update", "update_registry_endpoint")
-        cmd_group.command("remove", "remove_registry_endpoint")
+        cmd_group.command("remove", "delete_registry_endpoint")
         cmd_group.show_command("show", "show_registry_endpoint")
 
     with self.command_group(

--- a/azext_edge/edge/commands_registry_endpoints.py
+++ b/azext_edge/edge/commands_registry_endpoints.py
@@ -13,7 +13,7 @@ from typing import Iterable, Optional
 from .providers.orchestration.resources import RegistryEndpoints
 
 
-def add_registry_endpoint(
+def create_registry_endpoint(
     cmd,
     instance_name: str,
     resource_group_name: str,
@@ -30,8 +30,8 @@ def add_registry_endpoint(
     code_signing_secret_refs: Optional[list] = None,
     **kwargs,
 ) -> dict:
-    """Add a registry endpoint to an IoT Operations instance."""
-    return RegistryEndpoints(cmd).add(
+    """Create a registry endpoint for an IoT Operations instance."""
+    return RegistryEndpoints(cmd).create(
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,
@@ -102,7 +102,7 @@ def list_registry_endpoints(cmd, instance_name: str, resource_group_name: str) -
     )
 
 
-def remove_registry_endpoint(
+def delete_registry_endpoint(
     cmd,
     registry_endpoint_name: str,
     instance_name: str,
@@ -110,8 +110,8 @@ def remove_registry_endpoint(
     confirm_yes: Optional[bool] = None,
     **kwargs,
 ) -> None:
-    """Remove a registry endpoint from an IoT Operations instance."""
-    return RegistryEndpoints(cmd).remove(
+    """Delete a registry endpoint from an IoT Operations instance."""
+    return RegistryEndpoints(cmd).delete(
         instance_name=instance_name,
         resource_group_name=resource_group_name,
         registry_endpoint_name=registry_endpoint_name,

--- a/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
+++ b/azext_edge/edge/providers/orchestration/resources/registryendpoints.py
@@ -183,7 +183,7 @@ class RegistryEndpoints(Queryable):
 
         return cas
 
-    def add(
+    def create(
         self,
         instance_name: str,
         resource_group_name: str,
@@ -201,7 +201,7 @@ class RegistryEndpoints(Queryable):
         **kwargs,
     ) -> dict:
         """
-        Add a registry endpoint to an IoT Operations instance.
+        Create a registry endpoint for an IoT Operations Instance.
 
         :param instance_name: Name of the IoT Operations instance.
         :param resource_group_name: Name of the resource group.
@@ -223,7 +223,7 @@ class RegistryEndpoints(Queryable):
         status_text = kwargs.pop("status_text", "Working...")
         no_status = kwargs.pop("no_status", False)
         headers = kwargs.pop("headers", None)
-        operation_kwargs = {"headers": headers or {"CommandName": "iot ops registry add"}}
+        operation_kwargs = {"headers": headers or {"CommandName": "iot ops registry create"}}
 
         # Process authentication configuration
         auth_config = self._process_registry_endpoint_authentication(
@@ -347,7 +347,7 @@ class RegistryEndpoints(Queryable):
             )
             return wait_for_terminal_state(poller, **kwargs)
 
-    def remove(
+    def delete(
         self,
         instance_name: str,
         resource_group_name: str,
@@ -356,7 +356,7 @@ class RegistryEndpoints(Queryable):
         **kwargs,
     ) -> None:
         """
-        Remove a registry endpoint from an IoT Operations instance.
+        Delete a registry endpoint from an IoT Operations instance.
 
         :param instance_name: Name of the IoT Operations instance.
         :param resource_group_name: Name of the resource group.
@@ -368,14 +368,14 @@ class RegistryEndpoints(Queryable):
         if should_bail:
             return
 
-        with console.status(f"Removing registry endpoint '{registry_endpoint_name}'..."):
+        with console.status(f"Deleting registry endpoint '{registry_endpoint_name}'..."):
             poller = self.registry_endpoints.begin_delete(
                 resource_group_name=resource_group_name,
                 instance_name=instance_name,
                 registry_endpoint_name=registry_endpoint_name,
             )
             wait_for_terminal_state(poller, **kwargs)
-        logger.info(f"Registry endpoint '{registry_endpoint_name}' removed successfully.")
+        logger.info(f"Registry endpoint '{registry_endpoint_name}' deleted successfully.")
 
     def _identify_authentication_method(
         self,

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -297,7 +297,7 @@ class UpgradeManager:
         )
 
     def _create_default_registry_endpoint(self, headers: dict) -> dict:
-        return self.registry_endpoints.add(
+        return self.registry_endpoints.create(
             instance_name=self.instance_name,
             resource_group_name=self.resource_group_name,
             registry_endpoint_name="default",

--- a/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
@@ -42,7 +42,7 @@ def test_registry_endpoint_lifecycle_anonymous(registry_endpoint_test_setup, tra
     try:
         # CREATE - SAMI authentication (default)
         registry_endpoint = run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
+            f"az iot ops registry create -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host {host}"
         )
@@ -93,7 +93,7 @@ def test_registry_endpoint_lifecycle_anonymous(registry_endpoint_test_setup, tra
 
         # REMOVE
         run(
-            f"az iot ops registry remove -n {registry_endpoint_name} "
+            f"az iot ops registry delete -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} -y"
         )
         tracked_resources.remove(registry_endpoint["id"])
@@ -108,7 +108,7 @@ def test_registry_endpoint_lifecycle_anonymous(registry_endpoint_test_setup, tra
         if registry_endpoint.get("id") in tracked_resources:
             try:
                 run(
-                    f"az iot ops registry remove -n {registry_endpoint_name} "
+                    f"az iot ops registry delete -n {registry_endpoint_name} "
                     f"-g {resource_group} --instance {instance_name} -y"
                 )
                 tracked_resources.remove(registry_endpoint["id"])
@@ -128,7 +128,7 @@ def test_registry_endpoint_artifact_pull_secret(registry_endpoint_test_setup, tr
     try:
         # CREATE - ArtifactPullSecret authentication
         registry_endpoint = run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
+            f"az iot ops registry create -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host {host} --secret-ref {secret_ref}"
         )
@@ -158,7 +158,7 @@ def test_registry_endpoint_artifact_pull_secret(registry_endpoint_test_setup, tr
 
         # REMOVE
         run(
-            f"az iot ops registry remove -n {registry_endpoint_name} "
+            f"az iot ops registry delete -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} -y"
         )
         tracked_resources.remove(registry_endpoint["id"])
@@ -168,7 +168,7 @@ def test_registry_endpoint_artifact_pull_secret(registry_endpoint_test_setup, tr
         if registry_endpoint.get("id") in tracked_resources:
             try:
                 run(
-                    f"az iot ops registry remove -n {registry_endpoint_name} "
+                    f"az iot ops registry delete -n {registry_endpoint_name} "
                     f"-g {resource_group} --instance {instance_name} -y"
                 )
                 tracked_resources.remove(registry_endpoint["id"])
@@ -188,7 +188,7 @@ def test_registry_endpoint_system_assigned_auth(registry_endpoint_test_setup, tr
     try:
         # CREATE - SystemAssigned authentication with audience
         registry_endpoint = run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
+            f"az iot ops registry create -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host {host} --auth-type SystemAssignedManagedIdentity --audience {audience}"
         )
@@ -218,7 +218,7 @@ def test_registry_endpoint_system_assigned_auth(registry_endpoint_test_setup, tr
 
         # REMOVE
         run(
-            f"az iot ops registry remove -n {registry_endpoint_name} "
+            f"az iot ops registry delete -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} -y"
         )
         tracked_resources.remove(registry_endpoint["id"])
@@ -228,7 +228,7 @@ def test_registry_endpoint_system_assigned_auth(registry_endpoint_test_setup, tr
         if registry_endpoint.get("id") in tracked_resources:
             try:
                 run(
-                    f"az iot ops registry remove -n {registry_endpoint_name} "
+                    f"az iot ops registry delete -n {registry_endpoint_name} "
                     f"-g {resource_group} --instance {instance_name} -y"
                 )
                 tracked_resources.remove(registry_endpoint["id"])
@@ -250,7 +250,7 @@ def test_registry_endpoint_user_assigned_auth(registry_endpoint_test_setup, trac
     try:
         # CREATE - UserAssigned authentication with full parameters
         registry_endpoint = run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
+            f"az iot ops registry create -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host {host} --auth-type UserAssignedManagedIdentity "
             f"--client-id {client_id} --tenant-id {tenant_id} --scope {scope}"
@@ -281,7 +281,7 @@ def test_registry_endpoint_user_assigned_auth(registry_endpoint_test_setup, trac
 
         # REMOVE
         run(
-            f"az iot ops registry remove -n {registry_endpoint_name} "
+            f"az iot ops registry delete -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} -y"
         )
         tracked_resources.remove(registry_endpoint["id"])
@@ -291,7 +291,7 @@ def test_registry_endpoint_user_assigned_auth(registry_endpoint_test_setup, trac
         if registry_endpoint.get("id") in tracked_resources:
             try:
                 run(
-                    f"az iot ops registry remove -n {registry_endpoint_name} "
+                    f"az iot ops registry delete -n {registry_endpoint_name} "
                     f"-g {resource_group} --instance {instance_name} -y"
                 )
                 tracked_resources.remove(registry_endpoint["id"])
@@ -335,7 +335,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         # Auto-detect ArtifactPullSecret (secret_ref provided)
         name1 = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
         endpoint1 = run(
-            f"az iot ops registry add -n {name1} "
+            f"az iot ops registry create -n {name1} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host registry1.azurecr.io --secret-ref my-secret"
         )
@@ -352,7 +352,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         # Auto-detect SystemAssigned (no auth parameters provided)
         name2 = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
         endpoint2 = run(
-            f"az iot ops registry add -n {name2} "
+            f"az iot ops registry create -n {name2} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host registry2.azurecr.io"
         )
@@ -369,7 +369,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         # Auto-detect UserAssigned (client-id and tenant-id provided)
         name3 = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
         endpoint3 = run(
-            f"az iot ops registry add -n {name3} "
+            f"az iot ops registry create -n {name3} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host registry3.azurecr.io --client-id my-client --tenant-id my-tenant"
         )
@@ -386,7 +386,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         # Auto-detect Anonymous --no-auth
         name4 = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
         endpoint4 = run(
-            f"az iot ops registry add -n {name4} "
+            f"az iot ops registry create -n {name4} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host registry4.azurecr.io --no-auth"
         )
@@ -402,7 +402,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
 
         # Cleanup all endpoints
         for ep_id, ep_name in endpoints_to_cleanup:
-            run(f"az iot ops registry remove -n {ep_name} " f"-g {resource_group} --instance {instance_name} -y")
+            run(f"az iot ops registry delete -n {ep_name} " f"-g {resource_group} --instance {instance_name} -y")
             tracked_resources.append(ep_id)  # Add to tracked for safety
             tracked_resources.remove(ep_id)  # Remove after successful deletion
 
@@ -410,7 +410,7 @@ def test_registry_endpoint_authentication_auto_detection(registry_endpoint_test_
         # Cleanup in case of failure
         for ep_id, ep_name in endpoints_to_cleanup:
             try:
-                run(f"az iot ops registry remove -n {ep_name} " f"-g {resource_group} --instance {instance_name} -y")
+                run(f"az iot ops registry delete -n {ep_name} " f"-g {resource_group} --instance {instance_name} -y")
             except Exception:
                 pass  # Best effort cleanup
         raise
@@ -432,7 +432,7 @@ def test_registry_endpoint_code_signing_cas(registry_endpoint_test_setup, tracke
     try:
         # CREATE - with one configmap
         registry_endpoint = run(
-            f"az iot ops registry add -n {registry_endpoint_name} "
+            f"az iot ops registry create -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} "
             f"--host {host} --cs-config-map-refs {configmap1}"
         )
@@ -514,7 +514,7 @@ def test_registry_endpoint_code_signing_cas(registry_endpoint_test_setup, tracke
 
         # REMOVE
         run(
-            f"az iot ops registry remove -n {registry_endpoint_name} "
+            f"az iot ops registry delete -n {registry_endpoint_name} "
             f"-g {resource_group} --instance {instance_name} -y"
         )
         tracked_resources.remove(registry_endpoint["id"])
@@ -524,7 +524,7 @@ def test_registry_endpoint_code_signing_cas(registry_endpoint_test_setup, tracke
         if registry_endpoint.get("id") in tracked_resources:
             try:
                 run(
-                    f"az iot ops registry remove -n {registry_endpoint_name} "
+                    f"az iot ops registry delete -n {registry_endpoint_name} "
                     f"-g {resource_group} --instance {instance_name} -y"
                 )
                 tracked_resources.remove(registry_endpoint["id"])

--- a/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_unit.py
@@ -11,9 +11,9 @@ import responses
 from azure.cli.core.azclierror import MutuallyExclusiveArgumentError, RequiredArgumentMissingError
 
 from azext_edge.edge.commands_registry_endpoints import (
-    add_registry_endpoint,
+    create_registry_endpoint,
     list_registry_endpoints,
-    remove_registry_endpoint,
+    delete_registry_endpoint,
     show_registry_endpoint,
     update_registry_endpoint,
 )
@@ -142,7 +142,7 @@ def test_registry_endpoint_remove(mocked_cmd, mocked_responses: responses):
         status=204,
     )
 
-    remove_registry_endpoint(
+    delete_registry_endpoint(
         cmd=mocked_cmd,
         registry_endpoint_name=registry_endpoint_name,
         instance_name=instance_name,
@@ -532,7 +532,7 @@ def test_registry_endpoint_add_anonymous(mocked_cmd, mocked_responses: responses
         content_type="application/json",
     )
 
-    result = add_registry_endpoint(
+    result = create_registry_endpoint(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
@@ -618,7 +618,7 @@ def test_registry_endpoint_add_with_auth(
         content_type="application/json",
     )
 
-    result = add_registry_endpoint(
+    result = create_registry_endpoint(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
@@ -981,7 +981,7 @@ def test_registry_endpoint_add_with_code_signing_configmap(mocked_cmd, mocked_re
         content_type="application/json",
     )
 
-    result = add_registry_endpoint(
+    result = create_registry_endpoint(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,
@@ -1055,7 +1055,7 @@ def test_registry_endpoint_add_with_code_signing_secret(mocked_cmd, mocked_respo
         content_type="application/json",
     )
 
-    result = add_registry_endpoint(
+    result = create_registry_endpoint(
         cmd=mocked_cmd,
         instance_name=instance_name,
         resource_group_name=resource_group_name,


### PR DESCRIPTION
Removes the `preview` flag for the `iot ops registry` command group, and makes the following command renames:
* `iot ops registry add` → `iot ops registry create`
* `iot ops registry remove` → `iot ops registry delete`

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
