### PR TITLE
ci: update test runner images

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -91,7 +91,7 @@ env:
 jobs:
   setup:
     name: "Check Inputs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # Run on dispatch, or ensure scheduled runs only on dev branch
     if: github.event_name != 'schedule' || (github.repository == 'azure/azure-iot-ops-cli-extension' && github.ref == 'refs/heads/dev')
     outputs:
@@ -111,7 +111,7 @@ jobs:
           echo "INIT_ARG=${{ env.RUNTIME_INIT_ARGS }}" >> $GITHUB_OUTPUT
   unit-test:
     name: "Run linter and unit tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout Source"
         uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
           - feature: trustbundle
             runtime-args: true
     name: "Run cluster integration tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Determine Init Args"
         id: "init"
@@ -481,7 +481,7 @@ jobs:
     name: "Combine coverage reports"
     if: ${{ always() }}
     needs: [unit-test, int-test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout source"
         uses: actions/checkout@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
-          - windows-2022
-          - macos-13
+          - ubuntu-24.04
+          - windows-2025
+          - macos-15
         py:
           - "3.13"
           - "3.12"
@@ -48,7 +48,7 @@ jobs:
       - name: Run test suite
         run: tox r --skip-pkg-install
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.py == '3.13' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.py == '3.13' }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Bumps test runner images to more modern versions

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
