### PR TITLE
feat: add expiration date support for OPC UA certificates in Key Vault

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -2299,6 +2299,10 @@ def load_iotops_help():
           text: >
             az iot ops connector opcua trust add --instance instance --resource-group instanceresourcegroup
             --certificate-file "certificate.der" --overwrite-secret
+        - name: Add a trusted certificate with a custom expiration date for the Key Vault secret.
+          text: >
+            az iot ops connector opcua trust add --instance instance --resource-group instanceresourcegroup
+            --certificate-file "certificate.der" --expiration-date "2026-12-31T23:59:59Z"
     """
 
     helps[

--- a/azext_edge/edge/commands_connector.py
+++ b/azext_edge/edge/commands_connector.py
@@ -20,6 +20,7 @@ def add_connector_opcua_trust(
     file: str,
     overwrite_secret: bool = False,
     secret_name: Optional[str] = None,
+    expiration_date: Optional[str] = None,
 ) -> dict:
     return OpcUACerts(
         cmd,
@@ -29,6 +30,7 @@ def add_connector_opcua_trust(
         file=file,
         secret_name=secret_name,
         overwrite_secret=overwrite_secret,
+        expiration_date=expiration_date,
     )
 
 

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1689,6 +1689,13 @@ def load_iotops_arguments(self, _):
             help="Secret name in the Key Vault. If not provided, the "
             "certificate file name will be used to generate the secret name.",
         )
+        context.argument(
+            "expiration_date",
+            options_list=["--expiration-date", "--ed"],
+            help="Expiration date for the Key Vault secret in ISO 8601 format (e.g., 2025-12-31T23:59:59Z). "
+            "If not provided, the certificate's expiration date will be used. "
+            "If the certificate expiration cannot be determined, defaults to 180 days from the current date.",
+        )
 
     with self.argument_context("iot ops connector opcua issuer") as context:
         context.argument(

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -42,6 +42,7 @@ SERVICE_ACCOUNT_NAME = "aio-ssc-sa"
 KEYVAULT_URL = "https://{keyvaultName}.vault.azure.net/"
 SECRET_DELETE_MAX_RETRIES = 10
 SECRET_DELETE_RETRY_INTERVAL = 2
+DEFAULT_SECRET_EXPIRATION_DAYS = 180  # Default to 180 days for governance policy compliance
 
 
 class OpcUACerts(Queryable):
@@ -73,6 +74,7 @@ class OpcUACerts(Queryable):
         file: str,
         overwrite_secret: bool = False,
         secret_name: Optional[str] = None,
+        expiration_date: Optional[str] = None,
     ) -> dict:
         default_spc = self.instances.get_default_spc(
             instance_name=self.instance_name,
@@ -107,7 +109,11 @@ class OpcUACerts(Queryable):
             return
 
         self._upload_to_key_vault(
-            keyvault_name=spc_keyvault_name, secret_name=secret_name, file_path=file, cert_extension=cert_extension
+            keyvault_name=spc_keyvault_name,
+            secret_name=secret_name,
+            file_path=file,
+            cert_extension=cert_extension,
+            expiration_date=expiration_date,
         )
 
         self._add_secrets_to_spc(
@@ -207,7 +213,10 @@ class OpcUACerts(Queryable):
             return
 
         self._upload_to_key_vault(
-            keyvault_name=spc_keyvault_name, secret_name=secret_name, file_path=file, cert_extension=cert_extension
+            keyvault_name=spc_keyvault_name,
+            secret_name=secret_name,
+            file_path=file,
+            cert_extension=cert_extension,
         )
 
         self._add_secrets_to_spc(
@@ -295,7 +304,10 @@ class OpcUACerts(Queryable):
                 return
 
             self._upload_to_key_vault(
-                keyvault_name=spc_keyvault_name, secret_name=secret_name, file_path=file, cert_extension=cert_extension
+                keyvault_name=spc_keyvault_name,
+                secret_name=secret_name,
+                file_path=file,
+                cert_extension=cert_extension,
             )
             secrets_to_add.append((secret_name, file_name))
 
@@ -528,9 +540,129 @@ class OpcUACerts(Queryable):
 
         return new_secret_name
 
-    def _upload_to_key_vault(self, keyvault_name: str, secret_name: str, file_path: str, cert_extension: str):
+    def _calculate_secret_expiration(
+        self,
+        file_path: str,
+        cert_extension: str,
+        expiration_date: Optional[str] = None,
+    ) -> datetime:
+        """
+        Calculate the appropriate expiration date for a Key Vault secret.
+
+        Priority order:
+        1. If expiration_date is provided by user, use that
+        2. For certificate files (.der, .crt), extract the certificate's expiration date
+        3. Default to 180 days from now
+
+        Args:
+            file_path: Path to the certificate/key file
+            cert_extension: File extension indicating the file type
+            expiration_date: Optional expiration date string in ISO 8601 format (user-provided)
+
+        Returns:
+            datetime: UTC-aware datetime for secret expiration
+        """
+        from datetime import timedelta
+        from dateutil import parser as date_parser
+
+        # Priority 1: User-provided expiration date
+        if expiration_date is not None:
+            try:
+                user_expiration = date_parser.isoparse(expiration_date)
+                # Ensure it's UTC-aware
+                if user_expiration.tzinfo is None:
+                    user_expiration = user_expiration.replace(tzinfo=timezone.utc)
+
+                # Validate it's in the future
+                if user_expiration <= datetime.now(timezone.utc):
+                    raise InvalidArgumentValueError(
+                        f"Expiration date must be in the future. Provided: {expiration_date}"
+                    )
+
+                logger.info(
+                    f"Using user-provided expiration date: {user_expiration.strftime('%Y-%m-%d %H:%M:%S UTC')} "
+                    f"for Key Vault secret."
+                )
+                return user_expiration
+            except (ValueError, TypeError) as e:
+                raise InvalidArgumentValueError(
+                    f"Invalid expiration date format. Expected ISO 8601 format (e.g., 2025-12-31T23:59:59Z). "
+                    f"Provided: {expiration_date}. Error: {str(e)}"
+                )
+
+        # Priority 2: For certificate files, try to extract the certificate's actual expiration date
+        if cert_extension in {X509FileExtension.DER.value, X509FileExtension.CRT.value}:
+            try:
+                cert_data = read_file_content(file_path=file_path, read_as_binary=True)
+                expected_format = (
+                    X509FileExtension.PEM.name if cert_extension == X509FileExtension.CRT.value
+                    else X509FileExtension.DER.name
+                )
+                certs = decode_x509_files(cert_data, expected_format, cert_extension)
+
+                if certs:
+                    cert = certs[0]
+                    # Handle both old and new cryptography library versions
+                    try:
+                        expiry_date = cert.not_valid_after_utc
+                    except AttributeError:
+                        # Fallback for older cryptography versions (< 41.0)
+                        expiry_date = cert.not_valid_after
+                        # Convert to UTC-aware datetime if it's naive
+                        if expiry_date.tzinfo is None:
+                            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+
+                    logger.info(
+                        f"Using certificate expiration date: {expiry_date.strftime('%Y-%m-%d %H:%M:%S UTC')} "
+                        f"for Key Vault secret."
+                    )
+                    return expiry_date
+            except Exception as e:
+                # If certificate parsing fails, log warning and fall through to default
+                logger.warning(
+                    f"Could not extract expiration from certificate: {str(e)}. "
+                    f"Using default expiration of {DEFAULT_SECRET_EXPIRATION_DAYS} days."
+                )
+
+        # Priority 3: Default to 180 days from now for:
+        # - Private keys (.pem)
+        # - Certificate Revocation Lists (.crl)
+        # - Any files where certificate parsing failed
+        default_expiration = datetime.now(timezone.utc) + timedelta(days=DEFAULT_SECRET_EXPIRATION_DAYS)
+        logger.info(
+            f"Using default expiration date: {default_expiration.strftime('%Y-%m-%d %H:%M:%S UTC')} "
+            f"({DEFAULT_SECRET_EXPIRATION_DAYS} days) for Key Vault secret."
+        )
+        return default_expiration
+
+    def _upload_to_key_vault(
+        self,
+        keyvault_name: str,
+        secret_name: str,
+        file_path: str,
+        cert_extension: str,
+        expiration_date: Optional[str] = None,
+    ):
+        """
+        Upload a certificate or key file to Azure Key Vault as a secret with expiration date.
+
+        This method ensures Key Vault governance policy compliance by setting an expiration
+        date on the secret (required by many enterprise policies).
+
+        Args:
+            keyvault_name: Name of the Azure Key Vault
+            secret_name: Name for the secret in Key Vault
+            file_path: Path to the certificate/key file
+            cert_extension: File extension indicating the file type
+            expiration_date: Optional expiration date string in ISO 8601 format (user-provided via CLI)
+
+        Returns:
+            The Key Vault secret response
+        """
         with console.status(f"Uploading certificate to keyvault as secret {secret_name}..."):
             content = read_file_content(file_path=file_path, read_as_binary=True).hex()
+
+            # Determine content type based on file extension
             if cert_extension == X509FileExtension.CRL.value:
                 content_type = "application/pkix-crl"
             elif cert_extension == X509FileExtension.DER.value:
@@ -538,11 +670,26 @@ class OpcUACerts(Queryable):
             else:
                 content_type = "application/x-pem-file"
 
+            # Calculate expiration date for Key Vault compliance
+            # Priority: user-provided > certificate expiration > 180-day default
+            calculated_expiration = self._calculate_secret_expiration(file_path, cert_extension, expiration_date)
+
+            # Build parameters with compliance attributes
+            # Note: Key Vault API expects expiration in attributes.exp (Unix timestamp format)
             parameters = {
                 "value": content,
                 "contentType": content_type,
                 "tags": {"file-encoding": "hex"},
+                "attributes": {
+                    "exp": int(calculated_expiration.timestamp()),  # Required by Key Vault governance policies
+                },
             }
+
+            logger.info(
+                f"Creating Key Vault secret '{secret_name}' with expiration: "
+                f"{calculated_expiration.strftime('%Y-%m-%d %H:%M:%S UTC')}"
+            )
+
             return self.keyvault_client.set_secret(
                 vault_base_url=KEYVAULT_URL.format(keyvaultName=keyvault_name),
                 secret_name=secret_name,
@@ -896,7 +1043,16 @@ class OpcUACerts(Queryable):
         # check for certificate expiry
         if not cert_extension == X509FileExtension.CRL.value:
             # check if the certificate is expired
-            expiry_date = cert.not_valid_after_utc
+            # Handle both old and new cryptography library versions
+            try:
+                expiry_date = cert.not_valid_after_utc
+            except AttributeError:
+                # Fallback for older cryptography versions (< 41.0)
+                expiry_date = cert.not_valid_after
+                # Convert to UTC-aware datetime if it's naive
+                if expiry_date.tzinfo is None:
+                    expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+
             if expiry_date < datetime.now(timezone.utc):
                 raise InvalidArgumentValueError(
                     f"Certificate in file '{file_name}' is expired. Please provide a valid certificate."

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -508,6 +508,28 @@ class OpcUACerts(Queryable):
         cl_resources = self.resource_map.connected_cluster.get_aio_resources(custom_location_id=custom_location["id"])
         return cl_resources
 
+    def _extract_cert_expiration(self, cert: x509.Certificate) -> datetime:
+        """
+        Extract the expiration date from a certificate, handling both old and new cryptography library versions.
+
+        Args:
+            cert: The certificate object
+
+        Returns:
+            datetime: UTC-aware datetime of the certificate's expiration
+        """
+        # Handle both old and new cryptography library versions
+        try:
+            expiry_date = cert.not_valid_after_utc
+        except AttributeError:
+            # Fallback for older cryptography versions (< 41.0)
+            expiry_date = cert.not_valid_after
+            # Convert to UTC-aware datetime if it's naive
+            if expiry_date.tzinfo is None:
+                expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+
+        return expiry_date
+
     def _check_secret_name(
         self,
         secret_names: List[str],
@@ -602,15 +624,7 @@ class OpcUACerts(Queryable):
 
                 if certs:
                     cert = certs[0]
-                    # Handle both old and new cryptography library versions
-                    try:
-                        expiry_date = cert.not_valid_after_utc
-                    except AttributeError:
-                        # Fallback for older cryptography versions (< 41.0)
-                        expiry_date = cert.not_valid_after
-                        # Convert to UTC-aware datetime if it's naive
-                        if expiry_date.tzinfo is None:
-                            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+                    expiry_date = self._extract_cert_expiration(cert)
 
                     logger.info(
                         f"Using certificate expiration date: {expiry_date.strftime('%Y-%m-%d %H:%M:%S UTC')} "
@@ -1043,15 +1057,7 @@ class OpcUACerts(Queryable):
         # check for certificate expiry
         if not cert_extension == X509FileExtension.CRL.value:
             # check if the certificate is expired
-            # Handle both old and new cryptography library versions
-            try:
-                expiry_date = cert.not_valid_after_utc
-            except AttributeError:
-                # Fallback for older cryptography versions (< 41.0)
-                expiry_date = cert.not_valid_after
-                # Convert to UTC-aware datetime if it's naive
-                if expiry_date.tzinfo is None:
-                    expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+            expiry_date = self._extract_cert_expiration(cert)
 
             if expiry_date < datetime.now(timezone.utc):
                 raise InvalidArgumentValueError(

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/int/test_opcua_certs_trust_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/int/test_opcua_certs_trust_int.py
@@ -136,3 +136,115 @@ def test_opcua_cert_trust(cluster_connection, opcua_certs_trust_test_setup, trac
     )
     # clean up the cert file created
     cert_file.unlink(missing_ok=True)
+
+
+@pytest.mark.require_wlif_setup
+def test_opcua_cert_trust_with_user_expiration(
+    cluster_connection, opcua_certs_trust_test_setup, tracked_files: List[str]
+):
+    """Test adding certificate with user-provided expiration date."""
+    from datetime import datetime, timezone, timedelta
+
+    resource_group = opcua_certs_trust_test_setup["resourceGroup"]
+    instance_name = opcua_certs_trust_test_setup["instanceName"]
+    kv_id = opcua_certs_trust_test_setup["keyvaultId"]
+    kv_name = kv_id.rsplit("/", maxsplit=1)[-1]
+
+    # Generate certificate
+    cert_file = generate_self_signed_der_cert()
+
+    # Set expiration date to 2 years from now
+    expiration_date = (datetime.now(timezone.utc) + timedelta(days=730)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Add cert with expiration date
+    run(f"az iot ops connector opcua trust add --instance {instance_name} \
+        -g {resource_group} --certificate-file {cert_file} --expiration-date {expiration_date} --overwrite-secret")
+
+    # Get secret name
+    from pathlib import Path
+    p = Path(cert_file)
+    file_name_info = (p.stem, p.suffix)
+    cert_extension = file_name_info[1].replace(".", "")
+    secret_name = f"{file_name_info[0]}-{cert_extension}"
+
+    # Verify secret exists with expiration date
+    secret = run(f"az keyvault secret show --vault-name {kv_name} -n {secret_name}")
+    assert "attributes" in secret, "Secret should have attributes"
+    assert "expires" in secret["attributes"], "Secret attributes should have expires field"
+    assert secret["attributes"]["expires"] is not None, "Expiration date should be set"
+
+    # Verify the expiration date matches what we provided (allowing for timezone differences)
+    from dateutil import parser as date_parser
+    expected_expiration = date_parser.isoparse(expiration_date)
+    if expected_expiration.tzinfo is None:
+        expected_expiration = expected_expiration.replace(tzinfo=timezone.utc)
+    actual_expiration = date_parser.isoparse(secret["attributes"]["expires"])
+
+    # Allow 1 second difference due to rounding
+    time_diff = abs((actual_expiration - expected_expiration).total_seconds())
+    assert time_diff < 2, f"Expiration date should match. Expected: {expected_expiration}, Got: {actual_expiration}"
+
+    logger.info(f"✅ User-provided expiration test passed. Expiration: {actual_expiration}")
+
+    # Cleanup
+    run(f"az iot ops connector opcua trust remove --instance {instance_name} -g {resource_group} \
+        --certificate-names {cert_file.name} -y --include-secrets")
+    cert_file.unlink(missing_ok=True)
+
+
+@pytest.mark.require_wlif_setup
+def test_opcua_cert_trust_with_cert_expiration(
+    cluster_connection, opcua_certs_trust_test_setup, tracked_files: List[str]
+):
+    """Test adding certificate without user expiration - should extract from certificate."""
+    resource_group = opcua_certs_trust_test_setup["resourceGroup"]
+    instance_name = opcua_certs_trust_test_setup["instanceName"]
+    kv_id = opcua_certs_trust_test_setup["keyvaultId"]
+    kv_name = kv_id.rsplit("/", maxsplit=1)[-1]
+
+    # Generate certificate (will have its own expiration date)
+    cert_file = generate_self_signed_der_cert()
+
+    # Get the certificate's expiration date
+    cert_info = run(f"openssl x509 -inform DER -in {cert_file} -noout -enddate")
+    # Parse the openssl output: "notAfter=Nov  6 00:34:25 2026 GMT"
+    import re
+    from datetime import datetime, timezone
+    match = re.search(r"notAfter=(.+)", cert_info)
+    assert match, "Could not parse certificate expiration"
+    cert_expiration_str = match.group(1).strip()
+    # Parse the date (format: "Nov  6 00:34:25 2026 GMT")
+    cert_expiration = datetime.strptime(cert_expiration_str, "%b %d %H:%M:%S %Y %Z")
+    cert_expiration = cert_expiration.replace(tzinfo=timezone.utc)
+
+    # Add cert WITHOUT expiration date parameter
+    run(f"az iot ops connector opcua trust add --instance {instance_name} \
+        -g {resource_group} --certificate-file {cert_file} --overwrite-secret")
+
+    # Get secret name
+    from pathlib import Path
+    p = Path(cert_file)
+    file_name_info = (p.stem, p.suffix)
+    cert_extension = file_name_info[1].replace(".", "")
+    secret_name = f"{file_name_info[0]}-{cert_extension}"
+
+    # Verify secret exists with expiration date
+    secret = run(f"az keyvault secret show --vault-name {kv_name} -n {secret_name}")
+    assert "attributes" in secret, "Secret should have attributes"
+    assert "expires" in secret["attributes"], "Secret attributes should have expires field"
+    assert secret["attributes"]["expires"] is not None, "Expiration date should be set"
+
+    # Verify the expiration date matches the certificate's expiration
+    from dateutil import parser as date_parser
+    actual_expiration = date_parser.isoparse(secret["attributes"]["expires"])
+
+    # Allow 2 seconds difference due to rounding and parsing
+    time_diff = abs((actual_expiration - cert_expiration).total_seconds())
+    assert time_diff < 2, f"Expiration should match certificate. Expected: {cert_expiration}, Got: {actual_expiration}"
+
+    logger.info(f"✅ Certificate expiration extraction test passed. Expiration: {actual_expiration}")
+
+    # Cleanup
+    run(f"az iot ops connector opcua trust remove --instance {instance_name} -g {resource_group} \
+        --certificate-names {cert_file.name} -y --include-secrets")
+    cert_file.unlink(missing_ok=True)

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
@@ -817,3 +817,42 @@ def test_trust_show_error(
             resource_group=rg_name,
         )
     assert e.value.args[0] == expected_error
+
+
+def test_trust_add_accepts_expiration_parameter(mocker):
+    """Test that the trust add command accepts and passes through the expiration_date parameter."""
+    from azext_edge.edge.commands_connector import add_connector_opcua_trust
+
+    # Mock the OpcUACerts class
+    mock_opcua_certs = mocker.patch('azext_edge.edge.commands_connector.OpcUACerts')
+    mock_instance = mock_opcua_certs.return_value
+    mock_instance.trust_add.return_value = {"status": "success"}
+
+    # Test with expiration_date parameter
+    expiration_date = "2026-12-31T23:59:59Z"
+    add_connector_opcua_trust(
+        cmd=mocker.MagicMock(),
+        instance_name="test-instance",
+        resource_group="test-rg",
+        file="/fake/cert.der",
+        expiration_date=expiration_date,
+    )
+
+    # Verify trust_add was called with expiration_date
+    mock_instance.trust_add.assert_called_once()
+    call_kwargs = mock_instance.trust_add.call_args[1]
+    assert 'expiration_date' in call_kwargs, "expiration_date parameter should be passed to trust_add"
+    assert call_kwargs['expiration_date'] == expiration_date, "expiration_date value should match"
+
+    # Test without expiration_date parameter (should default to None)
+    mock_instance.trust_add.reset_mock()
+    add_connector_opcua_trust(
+        cmd=mocker.MagicMock(),
+        instance_name="test-instance",
+        resource_group="test-rg",
+        file="/fake/cert.der",
+    )
+
+    call_kwargs = mock_instance.trust_add.call_args[1]
+    assert 'expiration_date' in call_kwargs, "expiration_date parameter should be passed to trust_add"
+    assert call_kwargs['expiration_date'] is None, "expiration_date should be None when not provided"


### PR DESCRIPTION
## Summary
Adds expiration date functionality for OPC UA certificates stored in Azure Key Vault to comply with enterprise governance policies.

## Changes
- Implements 3-tier priority for certificate expiration: user-provided date → certificate extraction → 180-day default
- Adds `--expiration-date` CLI parameter with ISO 8601 format validation
- Includes comprehensive test coverage (1 unit test, 2 integration tests)
- Compatible with both old and new cryptography library versions

Integration Test link: https://github.com/ketkimnaik/azure-iot-ops-cli-extension/actions/runs/19153750646/job/54749847773

<img width="1367" height="206" alt="image" src="https://github.com/user-attachments/assets/1e7a39a2-831c-470d-8d97-51b6de01c3b3" />
