### PR TITLE
feat(adr): Add export/import commands for namespace asset datasets and datapoints

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -314,6 +314,8 @@ def load_iotops_commands(self, _):
             cmd_group.command("remove", "remove_namespace_asset_dataset")
             cmd_group.show_command("show", "show_namespace_asset_dataset")
             cmd_group.command("update", f"update_namespace_{asset_type}_asset_dataset")
+            cmd_group.command("export", "export_namespace_asset_datasets")
+            cmd_group.command("import", "import_namespace_asset_datasets")
 
     # dataset point
     for asset_type in ["custom", "opcua"]:
@@ -324,6 +326,8 @@ def load_iotops_commands(self, _):
             cmd_group.command("add", f"add_namespace_{asset_type}_asset_dataset_point")
             cmd_group.command("list", "list_namespace_asset_dataset_points")
             cmd_group.command("remove", "remove_namespace_asset_dataset_point")
+            cmd_group.command("export", "export_namespace_asset_dataset_points")
+            cmd_group.command("import", "import_namespace_asset_dataset_points")
 
     # event group
     for asset_type in ["custom", "opcua", "onvif"]:

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -1409,6 +1409,78 @@ def remove_namespace_asset_dataset_point(
     )
 
 
+def export_namespace_asset_dataset_points(
+    cmd,
+    asset_name: str,
+    dataset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    format: str = "json",
+    output_dir: str = ".",
+) -> dict:
+    return NamespaceAssets(cmd).export_dataset_datapoints(
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format=format,
+        output_dir=output_dir,
+    )
+
+
+def import_namespace_asset_dataset_points(
+    cmd,
+    asset_name: str,
+    dataset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    input_file: str,
+    **kwargs
+) -> list:
+    return NamespaceAssets(cmd).import_dataset_datapoints(
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        **kwargs
+    )
+
+
+def export_namespace_asset_datasets(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    format: str = "json",
+    output_dir: str = ".",
+) -> dict:
+    return NamespaceAssets(cmd).export_datasets(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format=format,
+        output_dir=output_dir,
+    )
+
+
+def import_namespace_asset_datasets(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    input_file: str,
+    **kwargs
+) -> list:
+    return NamespaceAssets(cmd).import_datasets(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        **kwargs
+    )
+
+
 # ASSET EVENT GROUP COMMANDS
 def add_namespace_custom_asset_event_group(
     cmd,

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1833,3 +1833,43 @@ def load_iotops_arguments(self, _):
             "This is useful if the logged-in principal does not have permission to query apps from MS Graph.",
             arg_group="Role Assignment",
         )
+
+    with self.argument_context("iot ops ns asset datapoint export") as context:
+        context.argument(
+            "format",
+            options_list=["--format"],
+            arg_type=get_enum_type(["json", "csv", "yaml"]),
+            help="Output file format. Default is json.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir"],
+            help="Output directory for the exported file. Default is current directory.",
+        )
+
+    with self.argument_context("iot ops ns asset datapoint import") as context:
+        context.argument(
+            "input_file",
+            options_list=["--input-file"],
+            help="Path to the file containing datapoints to import.",
+        )
+
+    with self.argument_context("iot ops ns asset dataset export") as context:
+        context.argument(
+            "format",
+            options_list=["--format"],
+            arg_type=get_enum_type(["json", "yaml"]),
+            help="Output file format. Default is json.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir"],
+            help="Output directory for the exported file. Default is current directory.",
+        )
+
+    with self.argument_context("iot ops ns asset dataset import") as context:
+        context.argument(
+            "input_file",
+            options_list=["--input-file"],
+            help="Path to the file containing datasets to import.",
+        )

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -1137,6 +1137,78 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset custom datapoint export"
+    ] = """
+        type: command
+        short-summary: Export datapoints from a custom asset dataset to a file.
+
+        examples:
+        - name: Export datapoints to JSON
+          text: >
+            az iot ops ns asset custom datapoint export --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --dataset myDataset
+
+        - name: Export datapoints to CSV
+          text: >
+            az iot ops ns asset custom datapoint export --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --dataset myDataset --format csv
+
+        - name: Export to a specific directory
+          text: >
+            az iot ops ns asset custom datapoint export --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --dataset myDataset --output-dir ./backups
+    """
+
+    helps[
+        "iot ops ns asset custom datapoint import"
+    ] = """
+        type: command
+        short-summary: Import datapoints into a custom asset dataset from a file.
+
+        examples:
+        - name: Import datapoints from JSON file
+          text: >
+            az iot ops ns asset custom datapoint import --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --dataset myDataset --input-file datapoints.json
+
+        - name: Import datapoints from CSV file
+          text: >
+            az iot ops ns asset custom datapoint import --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --dataset myDataset --input-file datapoints.csv
+    """
+
+    helps[
+        "iot ops ns asset custom dataset export"
+    ] = """
+        type: command
+        short-summary: Export datasets from a custom asset to a file.
+
+        examples:
+        - name: Export datasets to JSON
+          text: >
+            az iot ops ns asset custom dataset export --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup
+
+        - name: Export datasets to YAML
+          text: >
+            az iot ops ns asset custom dataset export --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --format yaml
+    """
+
+    helps[
+        "iot ops ns asset custom dataset import"
+    ] = """
+        type: command
+        short-summary: Import datasets into a custom asset from a file.
+
+        examples:
+        - name: Import datasets from JSON file
+          text: >
+            az iot ops ns asset custom dataset import --asset mycustomasset --instance myInstance
+            -g myInstanceResourceGroup --input-file datasets.json
+    """
+
+    helps[
         "iot ops ns asset custom event-group"
     ] = """
         type: group
@@ -2248,6 +2320,78 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset opcua datapoint export"
+    ] = """
+        type: command
+        short-summary: Export datapoints from an OPC UA asset dataset to a file.
+
+        examples:
+        - name: Export datapoints to JSON
+          text: >
+            az iot ops ns asset opcua datapoint export --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --dataset temperatureData
+
+        - name: Export datapoints to CSV
+          text: >
+            az iot ops ns asset opcua datapoint export --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --dataset temperatureData --format csv
+
+        - name: Export to a specific directory
+          text: >
+            az iot ops ns asset opcua datapoint export --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --dataset temperatureData --output-dir ./backups
+    """
+
+    helps[
+        "iot ops ns asset opcua datapoint import"
+    ] = """
+        type: command
+        short-summary: Import datapoints into an OPC UA asset dataset from a file.
+
+        examples:
+        - name: Import datapoints from JSON file
+          text: >
+            az iot ops ns asset opcua datapoint import --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --dataset temperatureData --input-file datapoints.json
+
+        - name: Import datapoints from CSV file
+          text: >
+            az iot ops ns asset opcua datapoint import --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --dataset temperatureData --input-file datapoints.csv
+    """
+
+    helps[
+        "iot ops ns asset opcua dataset export"
+    ] = """
+        type: command
+        short-summary: Export datasets from an OPC UA asset to a file.
+
+        examples:
+        - name: Export datasets to JSON
+          text: >
+            az iot ops ns asset opcua dataset export --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup
+
+        - name: Export datasets to YAML
+          text: >
+            az iot ops ns asset opcua dataset export --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --format yaml
+    """
+
+    helps[
+        "iot ops ns asset opcua dataset import"
+    ] = """
+        type: command
+        short-summary: Import datasets into an OPC UA asset from a file.
+
+        examples:
+        - name: Import datasets from JSON file
+          text: >
+            az iot ops ns asset opcua dataset import --asset myopcuaasset --instance myInstance
+            -g myInstanceResourceGroup --input-file datasets.json
+    """
+
+    helps[
         "iot ops ns asset opcua event-group"
     ] = """
         type: group
@@ -2660,6 +2804,37 @@ def load_iotops_adr_help():
           text: >
             az iot ops ns asset rest dataset remove --asset myrestasset --instance myInstance
             -g myInstanceResourceGroup --name temperatureData
+    """
+
+    helps[
+        "iot ops ns asset rest dataset export"
+    ] = """
+        type: command
+        short-summary: Export datasets from a REST asset to a file.
+
+        examples:
+        - name: Export datasets to JSON
+          text: >
+            az iot ops ns asset rest dataset export --asset myrestasset --instance myInstance
+            -g myInstanceResourceGroup
+
+        - name: Export datasets to YAML
+          text: >
+            az iot ops ns asset rest dataset export --asset myrestasset --instance myInstance
+            -g myInstanceResourceGroup --format yaml
+    """
+
+    helps[
+        "iot ops ns asset rest dataset import"
+    ] = """
+        type: command
+        short-summary: Import datasets into a REST asset from a file.
+
+        examples:
+        - name: Import datasets from JSON file
+          text: >
+            az iot ops ns asset rest dataset import --asset myrestasset --instance myInstance
+            -g myInstanceResourceGroup --input-file datasets.json
     """
 
     helps[

--- a/azext_edge/edge/providers/adr/assets.py
+++ b/azext_edge/edge/providers/adr/assets.py
@@ -358,6 +358,17 @@ class Assets(Queryable):
             queue_size=queue_size,
             sampling_interval=sampling_interval,
         )
+        
+        # Validate datapoint configuration against connector metadata
+        logger.info(f"Validating data point '{data_point_name}' against connector metadata...")
+        try:
+            from .validator import ConnectorMetadataValidator
+            validator = ConnectorMetadataValidator.from_asset(self.cmd, asset)
+            validator.validate_datapoint(sub_point)
+            logger.info(f"Data point '{data_point_name}' validation passed.")
+        except Exception as e:
+            logger.warning(f"Data point validation failed or skipped: {e}")
+        
         dataset["dataPoints"].append(sub_point)
 
         # note that update does not return the properties
@@ -426,12 +437,35 @@ class Assets(Queryable):
         )
         # should get the direct object so this should be enough
         dataset = get_default_dataset(asset, dataset_name, create_if_none=True)
-        dataset["dataPoints"] = _process_asset_sub_points_file_path(
+        new_data_points = _process_asset_sub_points_file_path(
             file_path=file_path,
             original_items=dataset.get("dataPoints", []),
             point_key="name",
             replace=replace
         )
+        
+        # Validate all data points against connector metadata
+        logger.info(f"Validating {len(new_data_points)} data points against connector metadata...")
+        try:
+            from .validator import ConnectorMetadataValidator
+            validator = ConnectorMetadataValidator.from_asset(self.cmd, asset)
+            validation_errors = []
+            for idx, point in enumerate(new_data_points):
+                try:
+                    validator.validate_datapoint(point)
+                    logger.debug(f"Data point {idx + 1}/{len(new_data_points)} ('{point.get('name', 'unnamed')}') validation passed.")
+                except Exception as e:
+                    validation_errors.append(f"Data point '{point.get('name', 'unnamed')}': {e}")
+                    logger.warning(f"Data point '{point.get('name', 'unnamed')}' validation failed: {e}")
+            
+            if validation_errors:
+                logger.warning(f"{len(validation_errors)} data point(s) failed validation. Errors:\n" + "\n".join(validation_errors))
+            else:
+                logger.info(f"All {len(new_data_points)} data points validated successfully.")
+        except Exception as e:
+            logger.warning(f"Data point validation failed or skipped: {e}")
+        
+        dataset["dataPoints"] = new_data_points
 
         # note that update does not return the properties
         with console.status(f"Updating {asset_name}..."):
@@ -587,12 +621,35 @@ class Assets(Queryable):
             resource_group_name=resource_group_name,
             check_cluster=True
         )
-        asset["properties"]["events"] = _process_asset_sub_points_file_path(
+        new_events = _process_asset_sub_points_file_path(
             file_path=file_path,
             original_items=asset["properties"].get("events", []),
             point_key="name",
             replace=replace
         )
+        
+        # Validate all events against connector metadata
+        logger.info(f"Validating {len(new_events)} events against connector metadata...")
+        try:
+            from .validator import ConnectorMetadataValidator
+            validator = ConnectorMetadataValidator.from_asset(self.cmd, asset)
+            validation_errors = []
+            for idx, event in enumerate(new_events):
+                try:
+                    validator.validate_event(event)
+                    logger.debug(f"Event {idx + 1}/{len(new_events)} ('{event.get('name', 'unnamed')}') validation passed.")
+                except Exception as e:
+                    validation_errors.append(f"Event '{event.get('name', 'unnamed')}': {e}")
+                    logger.warning(f"Event '{event.get('name', 'unnamed')}' validation failed: {e}")
+            
+            if validation_errors:
+                logger.warning(f"{len(validation_errors)} event(s) failed validation. Errors:\n" + "\n".join(validation_errors))
+            else:
+                logger.info(f"All {len(new_events)} events validated successfully.")
+        except Exception as e:
+            logger.warning(f"Event validation failed or skipped: {e}")
+        
+        asset["properties"]["events"] = new_events
 
         # note that update does not return the properties
         with console.status(f"Updating {asset_name}..."):

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -711,7 +711,7 @@ class NamespaceAssets(Queryable):
     ):
         """Export datapoints from a dataset to a file."""
         from ...util import dump_content_to_file
-        
+
         asset = self.show(
             asset_name=asset_name,
             instance_name=instance_name,
@@ -719,7 +719,7 @@ class NamespaceAssets(Queryable):
         )
         dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
         datapoints = dataset.get("dataPoints", [])
-        
+
         fieldnames = None
         if format == "csv":
             # Convert to CSV format
@@ -733,7 +733,7 @@ class NamespaceAssets(Queryable):
                 default_configuration=default_configuration,
                 portal_friendly=True
             )
-        
+
         file_path = dump_content_to_file(
             content=datapoints,
             file_name=f"{asset_name}_datapoint_{dataset_name}",
@@ -761,9 +761,9 @@ class NamespaceAssets(Queryable):
             check_cluster=True
         )
         namespace = parse_resource_id(asset["id"])
-        
+
         dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
-        
+
         # Process file and merge with existing datapoints
         from .assets import _process_asset_sub_points_file_path
         dataset["dataPoints"] = _process_asset_sub_points_file_path(
@@ -776,13 +776,13 @@ class NamespaceAssets(Queryable):
         # Remove observabilityMode if present (not supported in ADR)
         for point in dataset["dataPoints"]:
             point.pop("observabilityMode", None)
-        
+
         update_payload = {
             "properties": {
                 "datasets": asset["properties"]["datasets"]
             }
         }
-        
+
         with console.status(f"Updating asset {asset_name}..."):
             poller = self.ops.begin_update(
                 resource_group_name=namespace["resource_group"],
@@ -808,21 +808,21 @@ class NamespaceAssets(Queryable):
     ):
         """Export all datasets from an asset to a file."""
         from ...util import dump_content_to_file
-        
+
         asset = self.show(
             asset_name=asset_name,
             instance_name=instance_name,
             resource_group=instance_resource_group
         )
         datasets = asset["properties"].get("datasets", [])
-        
+
         # Remove dataPoints from each dataset for cleaner export
         datasets_export = []
         for dataset in datasets:
             dataset_copy = dataset.copy()
             dataset_copy.pop("dataPoints", None)
             datasets_export.append(dataset_copy)
-        
+
         file_path = dump_content_to_file(
             content=datasets_export,
             file_name=f"{asset_name}_dataset",
@@ -843,7 +843,7 @@ class NamespaceAssets(Queryable):
     ):
         """Import datasets into an asset from a file."""
         from ...util import deserialize_file_content
-        
+
         asset = self.show(
             asset_name=asset_name,
             instance_name=instance_name,
@@ -851,14 +851,14 @@ class NamespaceAssets(Queryable):
             check_cluster=True
         )
         namespace = parse_resource_id(asset["id"])
-        
+
         # Deserialize file
         file_datasets = list(deserialize_file_content(file_path=input_file))
-        
+
         # Get existing datasets
         existing_datasets = asset["properties"].get("datasets", [])
         existing_datasets_dict = {ds["name"]: ds for ds in existing_datasets}
-        
+
         # Merge: skip duplicates by default
         for file_dataset in file_datasets:
             dataset_name = file_dataset.get("name")
@@ -871,13 +871,13 @@ class NamespaceAssets(Queryable):
                 if "dataPoints" not in file_dataset:
                     file_dataset["dataPoints"] = []
                 existing_datasets_dict[dataset_name] = file_dataset
-        
+
         update_payload = {
             "properties": {
                 "datasets": list(existing_datasets_dict.values())
             }
         }
-        
+
         with console.status(f"Updating asset {asset_name}..."):
             poller = self.ops.begin_update(
                 resource_group_name=namespace["resource_group"],

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -772,6 +772,10 @@ class NamespaceAssets(Queryable):
             point_key="name",
             replace=False  # Default: skip duplicates
         )
+
+        # Remove observabilityMode if present (not supported in ADR)
+        for point in dataset["dataPoints"]:
+            point.pop("observabilityMode", None)
         
         update_payload = {
             "properties": {

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -700,6 +700,195 @@ class NamespaceAssets(Queryable):
             )
             return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
 
+    def export_dataset_datapoints(
+        self,
+        asset_name: str,
+        dataset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        format: str = "json",
+        output_dir: str = ".",
+    ):
+        """Export datapoints from a dataset to a file."""
+        from ...util import dump_content_to_file
+        
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group
+        )
+        dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
+        datapoints = dataset.get("dataPoints", [])
+        
+        fieldnames = None
+        if format == "csv":
+            # Convert to CSV format
+            default_configuration = dataset.get("datasetConfiguration", "{}")
+            if default_configuration == "{}":
+                default_configuration = asset["properties"].get("defaultDatasetsConfiguration", "{}")
+            from .assets import _convert_sub_points_to_csv
+            fieldnames = _convert_sub_points_to_csv(
+                sub_points=datapoints,
+                sub_point_type="dataPoints",
+                default_configuration=default_configuration,
+                portal_friendly=True
+            )
+        
+        file_path = dump_content_to_file(
+            content=datapoints,
+            file_name=f"{asset_name}_datapoint_{dataset_name}",
+            extension=format,
+            fieldnames=fieldnames,
+            output_dir=output_dir,
+            replace=False
+        )
+        return {"file_path": file_path}
+
+    def import_dataset_datapoints(
+        self,
+        asset_name: str,
+        dataset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        input_file: str,
+        **kwargs
+    ):
+        """Import datapoints into a dataset from a file."""
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+            check_cluster=True
+        )
+        namespace = parse_resource_id(asset["id"])
+        
+        dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
+        
+        # Process file and merge with existing datapoints
+        from .assets import _process_asset_sub_points_file_path
+        dataset["dataPoints"] = _process_asset_sub_points_file_path(
+            file_path=input_file,
+            original_items=dataset.get("dataPoints", []),
+            point_key="name",
+            replace=False  # Default: skip duplicates
+        )
+        
+        update_payload = {
+            "properties": {
+                "datasets": asset["properties"]["datasets"]
+            }
+        }
+        
+        with console.status(f"Updating asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
+
+    def export_datasets(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        format: str = "json",
+        output_dir: str = ".",
+    ):
+        """Export all datasets from an asset to a file."""
+        from ...util import dump_content_to_file
+        
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group
+        )
+        datasets = asset["properties"].get("datasets", [])
+        
+        # Remove dataPoints from each dataset for cleaner export
+        datasets_export = []
+        for dataset in datasets:
+            dataset_copy = dataset.copy()
+            dataset_copy.pop("dataPoints", None)
+            datasets_export.append(dataset_copy)
+        
+        file_path = dump_content_to_file(
+            content=datasets_export,
+            file_name=f"{asset_name}_dataset",
+            extension=format,
+            fieldnames=None,
+            output_dir=output_dir,
+            replace=False
+        )
+        return {"file_path": file_path}
+
+    def import_datasets(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        input_file: str,
+        **kwargs
+    ):
+        """Import datasets into an asset from a file."""
+        from ...util import deserialize_file_content
+        
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+            check_cluster=True
+        )
+        namespace = parse_resource_id(asset["id"])
+        
+        # Deserialize file
+        file_datasets = list(deserialize_file_content(file_path=input_file))
+        
+        # Get existing datasets
+        existing_datasets = asset["properties"].get("datasets", [])
+        existing_datasets_dict = {ds["name"]: ds for ds in existing_datasets}
+        
+        # Merge: skip duplicates by default
+        for file_dataset in file_datasets:
+            dataset_name = file_dataset.get("name")
+            if dataset_name in existing_datasets_dict:
+                logger.warning(
+                    f"Dataset '{dataset_name}' already exists in asset '{asset_name}' and will be ignored."
+                )
+            else:
+                # Initialize dataPoints as empty array if not present
+                if "dataPoints" not in file_dataset:
+                    file_dataset["dataPoints"] = []
+                existing_datasets_dict[dataset_name] = file_dataset
+        
+        update_payload = {
+            "properties": {
+                "datasets": list(existing_datasets_dict.values())
+            }
+        }
+        
+        with console.status(f"Updating asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return asset["properties"].get("datasets", [])
+
     # EVENT GROUPS - allowed for opcua, and custom assets
     def add_event_group(
         self,

--- a/azext_edge/edge/providers/adr/validator.py
+++ b/azext_edge/edge/providers/adr/validator.py
@@ -1,0 +1,461 @@
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import json
+import requests
+from typing import Any, Dict, Optional, TYPE_CHECKING
+from knack.log import get_logger
+from azure.cli.core.azclierror import ValidationError
+from ...util.az_client import get_iotops_mgmt_client
+
+if TYPE_CHECKING:
+    from ...vendor.clients.iotopsmgmt.operations import AkriConnectorTemplateOperations
+
+logger = get_logger(__name__)
+
+class ConnectorMetadataValidator:
+    """
+    Validates Asset sub-resources (datasets, events, etc.) against schemas defined
+    in the associated Connector Template's metadata (stored as OCI artifacts).
+    """
+
+    _METADATA_CACHE = {}
+
+    def __init__(self, cmd, resource_group_name: str, instance_name: str, 
+                 endpoint_type: str, endpoint_version: Optional[str] = None):
+        """
+        Args:
+            cmd: The Azure CLI command context
+            resource_group_name: Resource group containing the IoT Operations instance
+            instance_name: Name of the IoT Operations instance
+            endpoint_type: The endpoint type (e.g., "Microsoft.Http", "Microsoft.Onvif")
+            endpoint_version: Optional version of the endpoint (e.g., "1.0")
+        """
+        self.cmd = cmd
+        self.resource_group_name = resource_group_name
+        self.instance_name = instance_name
+        self.endpoint_type = endpoint_type
+        self.endpoint_version = endpoint_version
+        self.metadata = self._get_metadata()
+
+    @classmethod
+    def from_asset(cls, cmd, asset: Dict[str, Any]):
+        """
+        Factory method to create validator from an asset by looking up its device and endpoint.
+        
+        Args:
+            cmd: The Azure CLI command context
+            asset: The asset resource dictionary
+            
+        Returns:
+            ConnectorMetadataValidator instance
+        """
+        # Extract resource group and instance from asset's extended location or ID
+        from ...util.az_client import parse_resource_id
+        asset_id_str = asset.get("id", "")
+        if not asset_id_str:
+            raise ValidationError("Asset does not have an ID.")
+        
+        asset_id = parse_resource_id(asset_id_str)
+        if not asset_id:
+            raise ValidationError(f"Invalid asset ID: {asset_id_str}")
+            
+        resource_group_name = asset_id.resource_group_name
+        
+        # Get the namespace from asset
+        adr_namespace = asset.get("adrNamespace") or asset.get("properties", {}).get("adrNamespace")
+        if not adr_namespace:
+            raise ValidationError("Asset does not have adrNamespace specified.")
+        
+        namespace_id = parse_resource_id(adr_namespace)
+        if not namespace_id:
+            raise ValidationError(f"Invalid namespace ID: {adr_namespace}")
+        
+        # Get device reference
+        device_ref = asset.get("deviceRef") or asset.get("properties", {}).get("deviceRef", {})
+        device_name = device_ref.get("deviceName")
+        endpoint_name = device_ref.get("endpointName")
+        
+        if not device_name or not endpoint_name:
+            raise ValidationError(
+                "Asset must reference a device and endpoint via deviceRef.deviceName and deviceRef.endpointName"
+            )
+        
+        # Fetch the device to get endpoint type/version
+        from ...vendor.clients.iotopsmgmt import MicrosoftIoTOperationsManagementService
+        iotops_client: MicrosoftIoTOperationsManagementService = get_iotops_mgmt_client(
+            cmd.cli_ctx.cloud.endpoints.resource_manager,
+            namespace_id.subscription_id,
+        )
+        
+        device = iotops_client.device.get(
+            resource_group_name=namespace_id.resource_group_name,
+            namespace_name=namespace_id.resource_name,
+            device_name=device_name
+        )
+        
+        # Get endpoint from device
+        endpoints_inbound = device.get("properties", {}).get("endpoints", {}).get("inbound", {})
+        endpoint = endpoints_inbound.get(endpoint_name)
+        
+        if not endpoint:
+            raise ValidationError(f"Device '{device_name}' does not have inbound endpoint '{endpoint_name}'.")
+        
+        endpoint_type = endpoint.get("endpointType")
+        endpoint_version = endpoint.get("version")  # May be None
+        
+        if not endpoint_type:
+            raise ValidationError(f"Endpoint '{endpoint_name}' does not have endpointType specified.")
+        
+        # Extract instance name from namespace
+        # Namespace format: aio-adr-ns-{instance_name_hash}
+        instance_name = namespace_id.resource_name.replace("-ns-", "-").rsplit("-", 1)[0]  # Heuristic
+        
+        return cls(
+            cmd=cmd,
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            endpoint_type=endpoint_type,
+            endpoint_version=endpoint_version
+        )
+
+    def _get_metadata(self) -> Dict[str, Any]:
+        """
+        Retrieves the metadata JSON for the connector by:
+        1. Finding the matching Connector Template based on endpoint type/version
+        2. Extracting the connectorMetadataRef (OCI URI)
+        3. Fetching the OCI artifact containing the JSON metadata
+        4. Caching the result for future use
+        
+        Returns:
+            Dict containing the connector metadata JSON
+        """
+        # Check cache first
+        cache_key = f"{self.endpoint_type}:{self.endpoint_version or 'none'}"
+        if cache_key in self._METADATA_CACHE:
+            logger.debug(f"Using cached metadata for {cache_key}")
+            return self._METADATA_CACHE[cache_key]
+        
+        try:
+            # Step 1: Get IoT Operations management client
+            from ...vendor.clients.iotopsmgmt import MicrosoftIoTOperationsManagementService
+            from ...util.az_client import parse_resource_id
+            
+            logger.debug(f"Creating IoT Operations management client")
+            iotops_client: MicrosoftIoTOperationsManagementService = get_iotops_mgmt_client(
+                self.cmd.cli_ctx.cloud.endpoints.resource_manager,
+                self.cmd.cli_ctx.data.get('subscription_id'),
+            )
+            
+            # Step 2: List all connector templates in the instance
+            logger.debug(f"Listing connector templates for instance '{self.instance_name}' in resource group '{self.resource_group_name}'")
+            connector_templates = list(iotops_client.akri_connector_template.list_by_instance_resource(
+                resource_group_name=self.resource_group_name,
+                instance_name=self.instance_name
+            ))
+            
+            logger.debug(f"Found {len(connector_templates)} connector templates")
+            
+            # Step 3: Find matching connector template
+            matched_template = None
+            for template in connector_templates:
+                template_name = template.get("name")
+                device_endpoint_types = template.get("properties", {}).get("deviceInboundEndpointTypes", [])
+                logger.debug(f"Checking template '{template_name}' with {len(device_endpoint_types)} endpoint types")
+                
+                for endpoint_type_info in device_endpoint_types:
+                    et = endpoint_type_info.get("endpointType")
+                    ev = endpoint_type_info.get("version")
+                    logger.debug(f"  Endpoint: type='{et}', version='{ev}'")
+                    
+                    # Match endpoint type
+                    if et != self.endpoint_type:
+                        logger.debug(f"    Type mismatch: '{et}' != '{self.endpoint_type}'")
+                        continue
+                    
+                    # Match version (if both specified, they must match; if either is None, match)
+                    if self.endpoint_version and ev and self.endpoint_version != ev:
+                        logger.debug(f"    Version mismatch: '{self.endpoint_version}' != '{ev}'")
+                        continue
+                    
+                    logger.info(f"Matched connector template '{template_name}' for endpoint type '{self.endpoint_type}' version '{self.endpoint_version or ev}'")
+                    matched_template = template
+                    break
+                
+                if matched_template:
+                    break
+            
+            if not matched_template:
+                logger.warning(
+                    f"No connector template found for endpoint type '{self.endpoint_type}' "
+                    f"version '{self.endpoint_version}'. Validation will be skipped."
+                )
+                return {}
+            
+            # Step 4: Extract connectorMetadataRef
+            connector_metadata_ref = matched_template.get("properties", {}).get("connectorMetadataRef")
+            logger.debug(f"Connector metadata reference: {connector_metadata_ref}")
+            
+            if not connector_metadata_ref:
+                logger.warning(
+                    f"Connector template '{matched_template.get('name')}' does not have connectorMetadataRef. "
+                    "Validation will be skipped."
+                )
+                return {}
+            
+            logger.info(f"Fetching connector metadata from OCI: {connector_metadata_ref}")
+            
+            # Step 5: Fetch OCI artifact
+            metadata = self.fetch_oci_artifact(connector_metadata_ref)
+            
+            # Step 6: Cache the result
+            self._METADATA_CACHE[cache_key] = metadata
+            
+            return metadata
+            
+        except Exception as e:
+            logger.warning(f"Failed to fetch connector metadata: {e}. Validation will be skipped.")
+            return {}
+
+    @staticmethod
+    def fetch_oci_artifact(image_ref: str) -> Dict[str, Any]:
+        """
+        Fetches a JSON artifact from an OCI registry without requiring the 'oras' CLI.
+        
+        Args:
+            image_ref: The OCI image reference (e.g., mcr.microsoft.com/repo:tag)
+        
+        Returns:
+            The parsed JSON content of the artifact.
+        """
+        logger.info(f"Fetching OCI artifact: {image_ref}")
+        # 1. Parse the reference
+        # Format: registry/repo:tag
+        if "/" not in image_ref:
+            raise ValidationError(f"Invalid OCI reference: {image_ref}")
+        
+        registry, remainder = image_ref.split("/", 1)
+        if ":" in remainder:
+            repository, tag = remainder.split(":", 1)
+        else:
+            repository = remainder
+            tag = "latest"
+        
+        logger.debug(f"Parsed OCI reference - Registry: {registry}, Repository: {repository}, Tag: {tag}")
+
+        # Handle mcr.microsoft.com specific logic if needed, or generic OCI
+        # MCR redirects to data endpoints, so standard requests usually work if we follow redirects.
+        
+        base_url = f"https://{registry}/v2/{repository}"
+        headers = {
+            "Accept": "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json"
+        }
+
+        # 2. Get Manifest
+        manifest_url = f"{base_url}/manifests/{tag}"
+        logger.debug(f"Fetching manifest from {manifest_url}")
+        
+        # Note: For private registries, we'd need authentication (Bearer token).
+        # MCR public images usually allow anonymous pull but might require a token handshake.
+        # For simplicity in this draft, we'll assume public access or implement a basic token flow.
+        
+        token = ConnectorMetadataValidator._get_auth_token(registry, repository)
+        if token:
+            logger.debug(f"Using Bearer token for authentication (token length: {len(token)})")
+            headers["Authorization"] = f"Bearer {token}"
+        else:
+            logger.debug("No authentication token obtained, attempting anonymous access")
+
+        logger.debug(f"Fetching manifest with headers: {list(headers.keys())}")
+        response = requests.get(manifest_url, headers=headers)
+        logger.debug(f"Manifest fetch response: HTTP {response.status_code}")
+        if response.status_code != 200:
+            raise ValidationError(f"Failed to fetch manifest for {image_ref}: {response.status_code} {response.text}")
+        
+        manifest = response.json()
+        
+        # 3. Find the config layer or the specific JSON layer
+        # We look for a layer with a specific media type or just the first application/json layer
+        target_digest = None
+        
+        # Common media types for OCI artifacts containing config
+        target_media_types = [
+            "application/vnd.microsoft.akri-connector.v1+json", # Example custom type
+            "application/json",
+            "application/octet-stream" # Sometimes used for generic blobs
+        ]
+
+        layers = manifest.get("layers", [])
+        # Also check config blob if it's not a standard image
+        config = manifest.get("config", {})
+        
+        # Strategy: Look for the specific artifact layer
+        for layer in layers:
+            if layer.get("mediaType") in target_media_types or layer.get("annotations", {}).get("org.opencontainers.image.title") == "connector-metadata.json":
+                target_digest = layer["digest"]
+                break
+        
+        if not target_digest:
+             # Fallback: try the config blob if it's small and json
+             if config.get("mediaType") in target_media_types:
+                 target_digest = config["digest"]
+
+        if not target_digest:
+            raise ValidationError(f"Could not find suitable JSON layer in {image_ref}")
+
+        # 4. Fetch the Blob
+        blob_url = f"{base_url}/blobs/{target_digest}"
+        logger.debug(f"Fetching blob from {blob_url}")
+        
+        blob_response = requests.get(blob_url, headers=headers)
+        if blob_response.status_code != 200:
+            raise ValidationError(f"Failed to fetch blob {target_digest}: {blob_response.status_code}")
+
+        try:
+            return blob_response.json()
+        except json.JSONDecodeError:
+            raise ValidationError(f"Artifact at {image_ref} is not valid JSON.")
+
+    @staticmethod
+    def _get_auth_token(registry: str, repository: str) -> Optional[str]:
+        """
+        Helper to get an anonymous auth token for the registry if required (common for MCR/Docker Hub).
+        
+        This implements the Docker Registry v2 authentication flow:
+        1. Attempt unauthenticated access to /v2/ endpoint
+        2. If 401 with WWW-Authenticate header is returned, parse the authentication challenge
+        3. Request a token from the auth realm with the required service and scope
+        4. Return the token for use in subsequent requests
+        
+        For public registries like MCR, this allows anonymous pull access without credentials.
+        """
+        auth_url = f"https://{registry}/v2/"
+        logger.debug(f"Attempting to obtain auth token for registry: {registry}, repository: {repository}")
+        try:
+            # Ping v2 endpoint to get Www-Authenticate header
+            logger.debug(f"Pinging registry v2 endpoint: {auth_url}")
+            resp = requests.get(auth_url)
+            logger.debug(f"Registry v2 response: HTTP {resp.status_code}")
+            
+            if resp.status_code == 401 and "Www-Authenticate" in resp.headers:
+                auth_header = resp.headers["Www-Authenticate"]
+                logger.debug(f"Received WWW-Authenticate header: {auth_header}")
+                
+                # Format: Bearer realm="...",service="...",scope="..."
+                # Simple parser
+                parts = {}
+                for part in auth_header.replace("Bearer ", "").split(","):
+                    if "=" in part:
+                        k, v = part.split("=", 1)
+                        parts[k.strip()] = v.strip().strip('"')
+                
+                logger.debug(f"Parsed auth challenge: realm={parts.get('realm')}, service={parts.get('service')}")
+                
+                if "realm" in parts:
+                    token_params = {"service": parts.get("service")}
+                    if "scope" not in parts:
+                        token_params["scope"] = f"repository:{repository}:pull"
+                    else:
+                        token_params["scope"] = parts.get("scope")
+                    
+                    logger.debug(f"Requesting token from {parts['realm']} with params: {token_params}")
+                    token_resp = requests.get(parts["realm"], params=token_params)
+                    logger.debug(f"Token response: HTTP {token_resp.status_code}")
+                    
+                    if token_resp.status_code == 200:
+                        token = token_resp.json().get("token")
+                        logger.info(f"Successfully obtained anonymous auth token (length: {len(token) if token else 0})")
+                        return token
+                    else:
+                        logger.warning(f"Token request failed: {token_resp.status_code} {token_resp.text}")
+            else:
+                logger.debug(f"No authentication required (HTTP {resp.status_code})")
+        except Exception as e:
+            logger.warning(f"Failed to obtain auth token: {e}")
+        return None
+
+    def validate_dataset(self, dataset_config: Dict[str, Any]):
+        logger.debug(f"Validating dataset configuration: {dataset_config}")
+        schema = self._get_schema("datasetConfigurationSchema")
+        if schema:
+            logger.debug(f"Found dataset schema, performing validation")
+            self._validate(dataset_config, schema, "Dataset")
+        else:
+            logger.warning(f"No dataset schema found for endpoint type '{self.endpoint_type}' - skipping validation")
+
+    def validate_datapoint(self, datapoint_config: Dict[str, Any]):
+        logger.debug(f"Validating datapoint configuration: {datapoint_config}")
+        schema = self._get_schema("dataPointConfigurationSchema")
+        if schema:
+            logger.debug(f"Found datapoint schema, performing validation")
+            self._validate(datapoint_config, schema, "Datapoint")
+        else:
+            logger.warning(f"No datapoint schema found for endpoint type '{self.endpoint_type}' - skipping validation")
+
+    def validate_event(self, event_config: Dict[str, Any]):
+        logger.debug(f"Validating event configuration: {event_config}")
+        schema = self._get_schema("eventConfigurationSchema")
+        if schema:
+            logger.debug(f"Found event schema, performing validation")
+            self._validate(event_config, schema, "Event")
+        else:
+            logger.warning(f"No event schema found for endpoint type '{self.endpoint_type}' - skipping validation")
+
+    def _get_schema(self, schema_key: str) -> Optional[Dict[str, Any]]:
+        """
+        Extracts the specific schema from the metadata based on the endpoint type and version.
+        """
+        logger.debug(f"Looking for schema '{schema_key}' in metadata for endpoint type '{self.endpoint_type}'")
+        inbound_endpoints = self.metadata.get("inboundEndpoints", [])
+        logger.debug(f"Found {len(inbound_endpoints)} inbound endpoints in metadata")
+        
+        for idx, endpoint in enumerate(inbound_endpoints):
+            endpoint_type = endpoint.get("endpointType")
+            logger.debug(f"Checking endpoint {idx}: type='{endpoint_type}'")
+            
+            if endpoint_type == self.endpoint_type:
+                logger.debug(f"Matched endpoint type '{self.endpoint_type}', extracting schema for '{schema_key}'")
+                # Version check if needed, for now assume type is unique or we take the first match
+                # if self.endpoint_version and endpoint.get("version") != self.endpoint_version:
+                #     continue
+                
+                # Navigate the structure based on the key
+                schema = None
+                if schema_key == "datasetConfigurationSchema":
+                    schema = endpoint.get("datasets", {}).get("datasetConfigurationSchema")
+                elif schema_key == "dataPointConfigurationSchema":
+                    schema = endpoint.get("datasets", {}).get("dataPointConfigurationSchema")
+                elif schema_key == "eventConfigurationSchema":
+                    schema = endpoint.get("eventGroups", {}).get("events", {}).get("eventConfigurationSchema")
+                elif schema_key == "eventGroupConfigurationSchema":
+                    schema = endpoint.get("eventGroups", {}).get("eventGroupConfigurationSchema")
+                elif schema_key == "additionalConfigurationSchema":
+                    schema = endpoint.get("additionalConfigurationSchema")
+                elif schema_key == "actionConfigurationSchema":
+                    schema = endpoint.get("managementGroups", {}).get("managementGroupActions", {}).get("actionConfigurationSchema")
+                elif schema_key == "managementGroupConfigurationSchema":
+                    schema = endpoint.get("managementGroups", {}).get("managementGroupConfigurationSchema")
+                
+                if schema:
+                    logger.debug(f"Found schema for '{schema_key}'")
+                    return schema
+                else:
+                    logger.warning(f"Schema key '{schema_key}' not found in endpoint structure")
+                    return None
+        
+        logger.warning(f"No endpoint found matching type '{self.endpoint_type}'")
+        return None
+
+    def _validate(self, instance: Dict[str, Any], schema: Dict[str, Any], resource_name: str):
+        logger.debug(f"Validating {resource_name} against schema")
+        try:
+            from jsonschema import validate
+            validate(instance=instance, schema=schema)
+            logger.info(f"{resource_name} configuration is valid")
+        except ImportError:
+            logger.warning("jsonschema library not found. Skipping validation.")
+        except Exception as e:
+            logger.error(f"{resource_name} validation failed: {str(e)}")
+            raise ValidationError(f"{resource_name} configuration is invalid: {str(e)}")

--- a/azext_edge/tests/edge/adr/test_assets_import_export_validation_int.py
+++ b/azext_edge/tests/edge/adr/test_assets_import_export_validation_int.py
@@ -1,0 +1,925 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""
+Integration tests for asset dataset/datapoint/event import/export with validation.
+Tests the complete flow: File → Import → Validate → Azure Resource
+"""
+
+import pytest
+import json
+import tempfile
+import os
+from unittest.mock import patch, Mock
+from azext_edge.edge.providers.adr.assets import Assets
+from azext_edge.edge.commands_assets import (
+    import_asset_data_points,
+    export_asset_data_points,
+    import_asset_events,
+    export_asset_events
+)
+
+pytestmark = pytest.mark.integration
+
+
+# Sample metadata for REST HTTP connector
+REST_HTTP_METADATA = {
+    "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+    "name": "Azure IoT Operations connector for REST/HTTP",
+    "version": "1.0.5",
+    "inboundEndpoints": [
+        {
+            "endpointType": "Microsoft.Http",
+            "version": "1.0",
+            "datasets": {
+                "datasetConfigurationSchema": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "title": "REST Dataset Config Schema",
+                    "type": "object",
+                    "properties": {
+                        "samplingIntervalInMilliseconds": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                        },
+                        "transform": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["samplingIntervalInMilliseconds"]
+                },
+                "dataPointConfigurationSchema": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "title": "REST Datapoint Config Schema",
+                    "type": "object",
+                    "properties": {
+                        "method": {
+                            "type": "string",
+                            "enum": ["GET", "POST", "PUT", "DELETE"]
+                        },
+                        "headers": {
+                            "type": "object"
+                        }
+                    },
+                    "required": ["method"]
+                }
+            }
+        }
+    ]
+}
+
+# Sample metadata for ONVIF connector
+ONVIF_METADATA = {
+    "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+    "name": "Azure IoT Operations connector for ONVIF",
+    "version": "1.2.37",
+    "inboundEndpoints": [
+        {
+            "endpointType": "Microsoft.Onvif",
+            "eventGroups": {
+                "events": {
+                    "eventConfigurationSchema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                        "properties": {
+                            "filter": {
+                                "type": "string"
+                            },
+                            "priority": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 10
+                            }
+                        },
+                        "required": ["filter"]
+                    }
+                }
+            }
+        }
+    ]
+}
+
+
+class TestAssetDataPointImportWithValidation:
+    """Test import_asset_data_points with validation."""
+
+    def _create_mock_cmd(self):
+        """Helper to create a mock cmd object."""
+        cmd = Mock()
+        cmd.cli_ctx = Mock()
+        cmd.cli_ctx.cloud = Mock()
+        cmd.cli_ctx.cloud.endpoints = Mock()
+        cmd.cli_ctx.cloud.endpoints.resource_manager = "https://management.azure.com"
+        cmd.cli_ctx.data = {"subscription_id": "eab4c10d-b020-4cb2-8959-d53cf2df388d"}
+        return cmd
+
+    def _create_mock_asset(self, endpoint_type="Microsoft.Http"):
+        """Helper to create a mock asset with all required fields for validation."""
+        return {
+            "id": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.DeviceRegistry/assets/test-asset",
+            "name": "test-asset",
+            "type": "Microsoft.DeviceRegistry/assets",
+            "extendedLocation": {
+                "type": "CustomLocation",
+                "name": "/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.extendedlocation/customlocations/test-cl"
+            },
+            "properties": {
+                "assetEndpointProfileRef": "test-endpoint-profile",
+                "adrNamespace": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.IoTOperations/instances/test-instance/namespaces/aio-adr-ns-test-instance",
+                "deviceRef": {
+                    "deviceName": "test-device",
+                    "endpointName": "test-endpoint"
+                },
+                "datasets": [
+                    {
+                        "name": "default",
+                        "dataPoints": []
+                    }
+                ]
+            }
+        }
+
+    def _create_mock_endpoint_profile(self, endpoint_type="Microsoft.Http"):
+        """Helper to create a mock endpoint profile."""
+        return {
+            "name": "test-endpoint-profile",
+            "properties": {
+                "targetAddress": "http://example.com",
+                "endpointType": endpoint_type,
+                "endpointProfileType": "http",
+                "configuration": "{}"
+            }
+        }
+
+    def _create_mock_connector_template(self, endpoint_type="Microsoft.Http", version="1.0"):
+        """Helper to create a mock connector template."""
+        return {
+            "name": f"{endpoint_type.lower()}-connector-template",
+            "properties": {
+                "deviceInboundEndpointTypes": [
+                    {
+                        "endpointType": endpoint_type,
+                        "version": version
+                    }
+                ],
+                "connectorMetadataRef": f"mcr.microsoft.com/azureiotoperations/akri-connectors/{endpoint_type.lower()}-metadata:1.0.0"
+            }
+        }
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_datapoints_json_with_valid_data(self, mock_fetch_oci, mock_get_client):
+        """Test importing valid datapoints from JSON file with validation."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        # Mock updated asset response
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["datasets"][0]["dataPoints"] = [
+            {
+                "name": "temperature",
+                "dataSource": "http://sensor/temp",
+                "dataPointConfiguration": json.dumps({"method": "GET", "headers": {"Accept": "application/json"}})
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock device.get() to return device with endpoint info
+        mock_device = {
+            "name": "test-device",
+            "properties": {
+                "endpoints": {
+                    "inbound": {
+                        "test-endpoint": {
+                            "endpointType": "Microsoft.Http",
+                            "version": "1.0"
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.device = Mock()
+        mock_client.device.get = Mock(return_value=mock_device)
+        
+        # Mock connector template list
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = REST_HTTP_METADATA
+        
+        # Create temporary JSON file with valid datapoints
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "temperature",
+                    "dataSource": "http://sensor/temp",
+                    "dataPointConfiguration": json.dumps({"method": "GET", "headers": {"Accept": "application/json"}})
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            # Execute import
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                assets_provider = Assets(cmd)
+                with patch.object(assets_provider, 'ops', mock_ops):
+                    result = assets_provider.import_dataset_data_points(
+                        asset_name="test-asset",
+                        dataset_name="default",
+                        file_path=temp_file,
+                        resource_group_name="test-rg",
+                        replace=False,
+                        wait_sec=0
+                    )
+            
+            # Verify result
+            assert len(result) == 1
+            assert result[0]["name"] == "temperature"
+            
+            # Verify validation was called
+            mock_get_client.assert_called()
+            mock_client.device.get.assert_called_once()
+            mock_fetch_oci.assert_called_once()
+        finally:
+            os.unlink(temp_file)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_datapoints_with_invalid_data_logs_warnings(self, mock_fetch_oci, mock_get_client):
+        """Test importing datapoints with validation errors logs warnings but continues."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        # Mock updated asset - all points get imported even with validation errors
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["datasets"][0]["dataPoints"] = [
+            {
+                "name": "temperature",
+                "dataSource": "http://sensor/temp",
+                "dataPointConfiguration": json.dumps({"method": "GET"})
+            },
+            {
+                "name": "pressure",
+                "dataSource": "http://sensor/pressure",
+                "dataPointConfiguration": json.dumps({"headers": {"Accept": "application/json"}})  # Missing required "method"
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = REST_HTTP_METADATA
+        
+        # Create temporary JSON file with mixed valid/invalid datapoints
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "temperature",
+                    "dataSource": "http://sensor/temp",
+                    "dataPointConfiguration": json.dumps({"method": "GET"})
+                },
+                {
+                    "name": "pressure",
+                    "dataSource": "http://sensor/pressure",
+                    "dataPointConfiguration": json.dumps({"headers": {"Accept": "application/json"}})  # Missing method
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            # Execute import with logging capture
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                with patch('azext_edge.edge.providers.adr.assets.logger') as mock_logger:
+                    assets_provider = Assets(cmd)
+                    with patch.object(assets_provider, 'ops', mock_ops):
+                        result = assets_provider.import_dataset_data_points(
+                            asset_name="test-asset",
+                            dataset_name="default",
+                            file_path=temp_file,
+                            resource_group_name="test-rg",
+                            replace=False,
+                            wait_sec=0
+                        )
+            
+            # Verify result - both points should be imported despite validation error
+            assert len(result) == 2
+            
+            # Verify warning was logged for validation failure
+            # The logger is mocked, so we just verify the function was called
+            assert mock_logger.warning.called, "Expected logger.warning to be called"
+            # Optionally verify call count if needed
+            assert mock_logger.warning.call_count >= 1, "Expected at least one warning call"
+        finally:
+            os.unlink(temp_file)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_datapoints_csv_format(self, mock_fetch_oci, mock_get_client):
+        """Test importing datapoints from CSV file."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["datasets"][0]["dataPoints"] = [
+            {
+                "name": "temperature",
+                "dataSource": "http://sensor/temp",
+                "dataPointConfiguration": json.dumps({"method": "GET"}),
+                "observabilityMode": "Log"
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = REST_HTTP_METADATA
+        
+        # Create temporary CSV file
+        csv_content = """name,dataSource,dataPointConfiguration,observabilityMode
+temperature,http://sensor/temp,"{""method"": ""GET""}",Log
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write(csv_content)
+            temp_file = f.name
+        
+        try:
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                assets_provider = Assets(cmd)
+                with patch.object(assets_provider, 'ops', mock_ops):
+                    result = assets_provider.import_dataset_data_points(
+                        asset_name="test-asset",
+                        dataset_name="default",
+                        file_path=temp_file,
+                        resource_group_name="test-rg",
+                        replace=False,
+                        wait_sec=0
+                    )
+            
+            assert len(result) == 1
+            assert result[0]["name"] == "temperature"
+        finally:
+            os.unlink(temp_file)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_import_datapoints_no_connector_template_skips_validation(self, mock_get_client):
+        """Test that import works when no connector template is found (validation skipped)."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["datasets"][0]["dataPoints"] = [
+            {
+                "name": "sensor1",
+                "dataSource": "http://sensor1"
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock no connector templates found
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(return_value=[])
+        
+        # Create temporary JSON file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "sensor1",
+                    "dataSource": "http://sensor1"
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                with patch('azext_edge.edge.providers.adr.assets.logger') as mock_logger:
+                    assets_provider = Assets(cmd)
+                    with patch.object(assets_provider, 'ops', mock_ops):
+                        result = assets_provider.import_dataset_data_points(
+                            asset_name="test-asset",
+                            dataset_name="default",
+                            file_path=temp_file,
+                            resource_group_name="test-rg",
+                            replace=False,
+                            wait_sec=0
+                        )
+            
+            # Import should succeed
+            assert len(result) == 1
+            
+            # Verify info log about validation
+            info_calls = [call for call in mock_logger.info.call_args_list]
+            assert any('validating' in str(call).lower() for call in info_calls)
+        finally:
+            os.unlink(temp_file)
+
+
+class TestAssetEventImportWithValidation:
+    """Test import_asset_events with validation."""
+
+    def _create_mock_cmd(self):
+        """Helper to create a mock cmd object."""
+        cmd = Mock()
+        cmd.cli_ctx = Mock()
+        cmd.cli_ctx.cloud = Mock()
+        cmd.cli_ctx.cloud.endpoints = Mock()
+        cmd.cli_ctx.cloud.endpoints.resource_manager = "https://management.azure.com"
+        cmd.cli_ctx.data = {"subscription_id": "eab4c10d-b020-4cb2-8959-d53cf2df388d"}
+        return cmd
+
+    def _create_mock_asset(self, endpoint_type="Microsoft.Onvif"):
+        """Helper to create a mock asset for ONVIF."""
+        return {
+            "id": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.DeviceRegistry/assets/test-camera",
+            "name": "test-camera",
+            "type": "Microsoft.DeviceRegistry/assets",
+            "extendedLocation": {
+                "type": "CustomLocation",
+                "name": "/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.extendedlocation/customlocations/test-cl"
+            },
+            "properties": {
+                "assetEndpointProfileRef": "test-onvif-profile",
+                "adrNamespace": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.IoTOperations/instances/test-instance/namespaces/aio-adr-ns-test-instance",
+                "deviceRef": {
+                    "deviceName": "test-device",
+                    "endpointName": "test-endpoint"
+                },
+                "events": []
+            }
+        }
+
+    def _create_mock_connector_template(self, endpoint_type="Microsoft.Onvif"):
+        """Helper to create a mock connector template."""
+        return {
+            "name": f"{endpoint_type.lower()}-connector-template",
+            "properties": {
+                "deviceInboundEndpointTypes": [
+                    {
+                        "endpointType": endpoint_type
+                    }
+                ],
+                "connectorMetadataRef": f"mcr.microsoft.com/azureiotoperations/akri-connectors/{endpoint_type.lower()}-metadata:1.2.37"
+            }
+        }
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_events_json_with_valid_data(self, mock_fetch_oci, mock_get_client):
+        """Test importing valid events from JSON file with validation."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        # Mock updated asset response
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["events"] = [
+            {
+                "name": "motion-detected",
+                "eventNotifier": "ns=2;s=MotionDetector",
+                "eventConfiguration": json.dumps({"filter": "Topic = 'motion'", "priority": 5})
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock device.get() to return device with ONVIF endpoint info
+        mock_device = {
+            "name": "test-device",
+            "properties": {
+                "endpoints": {
+                    "inbound": {
+                        "test-endpoint": {
+                            "endpointType": "Microsoft.Onvif",
+                            "version": None
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.device = Mock()
+        mock_client.device.get = Mock(return_value=mock_device)
+        
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = ONVIF_METADATA
+        
+        # Create temporary JSON file with valid events
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "motion-detected",
+                    "eventNotifier": "ns=2;s=MotionDetector",
+                    "eventConfiguration": json.dumps({"filter": "Topic = 'motion'", "priority": 5})
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            # Execute import
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                assets_provider = Assets(cmd)
+                with patch.object(assets_provider, 'ops', mock_ops):
+                    result = assets_provider.import_events(
+                        asset_name="test-camera",
+                        file_path=temp_file,
+                        resource_group_name="test-rg",
+                        replace=False,
+                        wait_sec=0
+                    )
+            
+            # Verify result
+            assert len(result) == 1
+            assert result[0]["name"] == "motion-detected"
+            
+            # Verify validation was called
+            mock_get_client.assert_called()
+            mock_client.device.get.assert_called_once()
+            mock_fetch_oci.assert_called_once()
+        finally:
+            os.unlink(temp_file)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_events_with_invalid_priority(self, mock_fetch_oci, mock_get_client):
+        """Test importing events with validation errors (priority out of range)."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks
+        mock_asset = self._create_mock_asset()
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        # Events still get imported despite validation errors
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["events"] = [
+            {
+                "name": "tamper-detected",
+                "eventNotifier": "ns=2;s=TamperDetector",
+                "eventConfiguration": json.dumps({"filter": "Topic = 'tamper'", "priority": 99})  # Out of range
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock device.get()
+        mock_device = {
+            "name": "test-device",
+            "properties": {
+                "endpoints": {
+                    "inbound": {
+                        "test-endpoint": {
+                            "endpointType": "Microsoft.Onvif",
+                            "version": None
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.device = Mock()
+        mock_client.device.get = Mock(return_value=mock_device)
+        
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = ONVIF_METADATA
+        
+        # Create temporary JSON file with invalid event
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "tamper-detected",
+                    "eventNotifier": "ns=2;s=TamperDetector",
+                    "eventConfiguration": json.dumps({"filter": "Topic = 'tamper'", "priority": 99})
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                with patch('azext_edge.edge.providers.adr.assets.logger') as mock_logger:
+                    assets_provider = Assets(cmd)
+                    with patch.object(assets_provider, 'ops', mock_ops):
+                        result = assets_provider.import_events(
+                            asset_name="test-camera",
+                            file_path=temp_file,
+                            resource_group_name="test-rg",
+                            replace=False,
+                            wait_sec=0
+                        )
+            
+            # Event should still be imported
+            assert len(result) == 1
+            
+            # Verify warning was logged
+            warning_calls = [call for call in mock_logger.warning.call_args_list if 'validation failed' in str(call).lower()]
+            assert len(warning_calls) > 0
+        finally:
+            os.unlink(temp_file)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_import_events_replace_mode(self, mock_fetch_oci, mock_get_client):
+        """Test importing events with replace=True replaces existing events."""
+        cmd = self._create_mock_cmd()
+        
+        # Setup mocks - asset with existing event
+        mock_asset = self._create_mock_asset()
+        mock_asset["properties"]["events"] = [
+            {
+                "name": "old-event",
+                "eventNotifier": "ns=2;s=OldNotifier",
+                "eventConfiguration": json.dumps({"filter": "old"})
+            }
+        ]
+        mock_ops = Mock()
+        mock_ops.get.return_value = mock_asset
+        
+        # Mock updated asset - only new event
+        updated_asset = mock_asset.copy()
+        updated_asset["properties"]["events"] = [
+            {
+                "name": "new-event",
+                "eventNotifier": "ns=2;s=NewNotifier",
+                "eventConfiguration": json.dumps({"filter": "Topic = 'new'", "priority": 3})
+            }
+        ]
+        mock_poller = Mock()
+        mock_poller.result.return_value = updated_asset
+        mock_ops.begin_create_or_replace.return_value = mock_poller
+        
+        # Mock validator setup
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock device.get()
+        mock_device = {
+            "name": "test-device",
+            "properties": {
+                "endpoints": {
+                    "inbound": {
+                        "test-endpoint": {
+                            "endpointType": "Microsoft.Onvif",
+                            "version": None
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.device = Mock()
+        mock_client.device.get = Mock(return_value=mock_device)
+        
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template()]
+        )
+        mock_fetch_oci.return_value = ONVIF_METADATA
+        
+        # Create temporary JSON file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {
+                    "name": "new-event",
+                    "eventNotifier": "ns=2;s=NewNotifier",
+                    "eventConfiguration": json.dumps({"filter": "Topic = 'new'", "priority": 3})
+                }
+            ], f)
+            temp_file = f.name
+        
+        try:
+            with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                assets_provider = Assets(cmd)
+                with patch.object(assets_provider, 'ops', mock_ops):
+                    result = assets_provider.import_events(
+                        asset_name="test-camera",
+                        file_path=temp_file,
+                        resource_group_name="test-rg",
+                        replace=True,
+                        wait_sec=0
+                    )
+            
+            # Should only have the new event
+            assert len(result) == 1
+            assert result[0]["name"] == "new-event"
+        finally:
+            os.unlink(temp_file)
+
+
+class TestExportWithImportRoundTrip:
+    """Test export → import round-trip to verify file format compatibility."""
+
+    def _create_mock_cmd(self):
+        """Helper to create a mock cmd object."""
+        cmd = Mock()
+        cmd.cli_ctx = Mock()
+        cmd.cli_ctx.cloud = Mock()
+        cmd.cli_ctx.cloud.endpoints = Mock()
+        cmd.cli_ctx.cloud.endpoints.resource_manager = "https://management.azure.com"
+        cmd.cli_ctx.data = {"subscription_id": "eab4c10d-b020-4cb2-8959-d53cf2df388d"}
+        return cmd
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator.fetch_oci_artifact')
+    def test_export_import_datapoints_roundtrip_json(self, mock_fetch_oci, mock_get_client):
+        """Test export → import round-trip for datapoints in JSON format."""
+        cmd = self._create_mock_cmd()
+        
+        # Mock asset with datapoints for export
+        mock_ops = Mock()
+        export_asset = {
+            "id": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.DeviceRegistry/assets/test-asset",
+            "name": "test-asset",
+            "properties": {
+                "assetEndpointProfileRef": "test-profile",
+                "datasets": [
+                    {
+                        "name": "default",
+                        "dataPoints": [
+                            {
+                                "name": "sensor1",
+                                "dataSource": "http://sensor1",
+                                "dataPointConfiguration": json.dumps({"method": "GET"}),
+                                "observabilityMode": "Log"
+                            },
+                            {
+                                "name": "sensor2",
+                                "dataSource": "http://sensor2",
+                                "dataPointConfiguration": json.dumps({"method": "POST", "headers": {"Content-Type": "application/json"}}),
+                                "observabilityMode": "None"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        
+        temp_dir = tempfile.mkdtemp()
+        try:
+            # Export datapoints
+            mock_ops.get.return_value = export_asset
+            
+            # Mock the device registry client to prevent real Azure calls
+            with patch('azext_edge.edge.providers.adr.assets.get_registry_mgmt_client') as mock_get_registry:
+                mock_registry_client = Mock()
+                mock_registry_client.assets = mock_ops
+                mock_get_registry.return_value = mock_registry_client
+                
+                assets_provider = Assets(cmd)
+                export_result = assets_provider.export_dataset_data_points(
+                    asset_name="test-asset",
+                    dataset_name="default",
+                    resource_group_name="test-rg",
+                    extension="json",
+                    output_dir=temp_dir,
+                    replace=True
+                )
+            
+            exported_file = export_result["file_path"]
+            assert os.path.exists(exported_file)
+            
+            # Verify exported content
+            with open(exported_file, 'r') as f:
+                exported_data = json.load(f)
+            assert len(exported_data) == 2
+            assert exported_data[0]["name"] == "sensor1"
+            assert exported_data[1]["name"] == "sensor2"
+            
+            # Now import the exported file
+            import_asset = {
+                "id": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.DeviceRegistry/assets/test-asset-2",
+                "name": "test-asset-2",
+                "properties": {
+                    "assetEndpointProfileRef": "test-profile",
+                    "adrNamespace": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.IoTOperations/instances/test-instance/namespaces/aio-adr-ns-test-instance",
+                    "deviceRef": {
+                        "deviceName": "test-device",
+                        "endpointName": "test-endpoint"
+                    },
+                    "datasets": [{"name": "default", "dataPoints": []}]
+                }
+            }
+            mock_ops.get.return_value = import_asset
+            
+            imported_asset = import_asset.copy()
+            imported_asset["properties"]["datasets"][0]["dataPoints"] = exported_data
+            mock_poller = Mock()
+            mock_poller.result.return_value = imported_asset
+            mock_ops.begin_create_or_replace.return_value = mock_poller
+            
+            # Mock validator
+            mock_client = Mock()
+            mock_get_client.return_value = mock_client
+            
+            # Mock device.get()
+            mock_device = {
+                "name": "test-device",
+                "properties": {
+                    "endpoints": {
+                        "inbound": {
+                            "test-endpoint": {
+                                "endpointType": "Microsoft.Http",
+                                "version": "1.0"
+                            }
+                        }
+                    }
+                }
+            }
+            mock_client.device = Mock()
+            mock_client.device.get = Mock(return_value=mock_device)
+            
+            mock_client.akri_connector_template = Mock()
+            mock_client.akri_connector_template.list_by_instance_resource = Mock(
+                return_value=[{
+                    "name": "http-template",
+                    "properties": {
+                        "deviceInboundEndpointTypes": [{"endpointType": "Microsoft.Http", "version": "1.0"}],
+                        "connectorMetadataRef": "mcr.microsoft.com/test:1.0"
+                    }
+                }]
+            )
+            mock_fetch_oci.return_value = REST_HTTP_METADATA
+            
+            # Create new Assets instance for import with mocked registry client
+            with patch('azext_edge.edge.providers.adr.assets.get_registry_mgmt_client') as mock_get_registry_import:
+                mock_registry_client_import = Mock()
+                mock_registry_client_import.assets = mock_ops
+                mock_get_registry_import.return_value = mock_registry_client_import
+                
+                assets_provider_import = Assets(cmd)
+                
+                with patch('azext_edge.edge.providers.adr.helpers.check_cluster_connectivity'):
+                    import_result = assets_provider_import.import_dataset_data_points(
+                        asset_name="test-asset-2",
+                        dataset_name="default",
+                        file_path=exported_file,
+                        resource_group_name="test-rg",
+                        replace=False,
+                        wait_sec=0
+                    )
+            
+            # Verify imported datapoints match exported ones
+            assert len(import_result) == 2
+            assert import_result[0]["name"] == "sensor1"
+            assert import_result[1]["name"] == "sensor2"
+            
+        finally:
+            # Cleanup
+            import shutil
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/azext_edge/tests/edge/adr/test_assets_validation_unit.py
+++ b/azext_edge/tests/edge/adr/test_assets_validation_unit.py
@@ -1,0 +1,395 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""
+Unit tests for asset validation integration with ConnectorMetadataValidator.
+Tests that validation is properly called during add/import operations.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, call
+from azure.cli.core.azclierror import ValidationError
+from azext_edge.edge.providers.adr.assets import Assets
+
+
+@pytest.fixture
+def mock_asset():
+    """Fixture providing a mock asset record."""
+    return {
+        "id": "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.DeviceRegistry/assets/test-asset",
+        "name": "test-asset",
+        "extendedLocation": {
+            "name": "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/test-instance",
+            "type": "CustomLocation"
+        },
+        "properties": {
+            "assetEndpointProfileRef": "test-aep",
+            "datasets": [
+                {
+                    "name": "default",
+                    "dataPoints": [
+                        {
+                            "name": "existing-point",
+                            "dataSource": "tag1",
+                            "observabilityMode": "None"
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "existing-event",
+                    "eventNotifier": "notifier1",
+                    "observabilityMode": "None"
+                }
+            ]
+        }
+    }
+
+    # ========== add_dataset_data_point Tests ==========
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_add_data_point_with_validation_success(mock_validator_class, mock_console, mock_wait, mocked_cmd, mock_asset):
+    """Test add_dataset_data_point validates successfully."""
+    assets = Assets(mocked_cmd)
+    
+    # Mock show() and ops to prevent Azure calls
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        # Mock validator
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_datapoint.return_value = None  # Success
+        
+        # Mock poller
+        mock_wait.return_value = mock_asset
+        
+        # Call method
+        result = assets.add_dataset_data_point(
+            asset_name="test-asset",
+            dataset_name="default",
+            data_point_name="new-point",
+            data_source="tag2",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify validator was created and called
+        mock_validator_class.from_asset.assert_called_once_with(mocked_cmd, mock_asset)
+        mock_validator.validate_datapoint.assert_called_once()
+        
+        # Verify data point was added
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_add_data_point_validation_fails_but_continues(mock_validator_class, mock_console, mock_wait, mocked_cmd, mock_asset):
+    """Test add_dataset_data_point continues even if validation fails."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        # Mock validator to raise ValidationError
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_datapoint.side_effect = ValidationError("Invalid configuration")
+        
+        mock_wait.return_value = mock_asset
+        
+        # Should not raise, validation is logged as warning
+        result = assets.add_dataset_data_point(
+            asset_name="test-asset",
+            dataset_name="default",
+            data_point_name="new-point",
+            data_source="tag2",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify validator was called
+        mock_validator.validate_datapoint.assert_called_once()
+        
+        # Verify data point was still added despite validation failure
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_add_data_point_validator_import_fails(mock_validator_class, mock_console, mock_wait, mocked_cmd, mock_asset):
+    """Test add_dataset_data_point handles validator import failure gracefully."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        # Mock validator import failure
+        mock_validator_class.from_asset.side_effect = ImportError("Cannot import validator")
+        
+        mock_wait.return_value = mock_asset
+        
+        # Should not raise
+        result = assets.add_dataset_data_point(
+            asset_name="test-asset",
+            dataset_name="default",
+            data_point_name="new-point",
+            data_source="tag2",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify operation completed
+        assert isinstance(result, list)
+
+
+    # ========== import_dataset_data_points Tests ==========
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_data_points_with_validation_all_pass(
+    mock_validator_class, mock_process_file, mock_console, mock_wait, mocked_cmd, mock_asset
+):
+    """Test import_dataset_data_points validates all points successfully."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        # Mock file processing
+        new_points = [
+            {"name": "point1", "dataSource": "tag1"},
+            {"name": "point2", "dataSource": "tag2"},
+            {"name": "point3", "dataSource": "tag3"}
+        ]
+        mock_process_file.return_value = new_points
+        
+        # Mock validator
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_datapoint.return_value = None  # All pass
+        
+        mock_wait.return_value = mock_asset
+        
+        result = assets.import_dataset_data_points(
+            asset_name="test-asset",
+            dataset_name="default",
+            file_path="/path/to/file.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify validator was created
+        mock_validator_class.from_asset.assert_called_once_with(mocked_cmd, mock_asset)
+        
+        # Verify all points were validated
+        assert mock_validator.validate_datapoint.call_count == 3
+        calls = mock_validator.validate_datapoint.call_args_list
+        assert calls[0][0][0] == new_points[0]
+        assert calls[1][0][0] == new_points[1]
+        assert calls[2][0][0] == new_points[2]
+        
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_data_points_with_validation_some_fail(
+    mock_validator_class, mock_process_file, mock_console, mock_wait, mocked_cmd, mock_asset
+):
+    """Test import_dataset_data_points logs errors when some validations fail."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        new_points = [
+            {"name": "valid-point", "dataSource": "tag1"},
+            {"name": "invalid-point", "dataSource": "tag2"}
+        ]
+        mock_process_file.return_value = new_points
+        
+        # Mock validator - first passes, second fails
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_datapoint.side_effect = [
+            None,  # First point passes
+            ValidationError("Invalid configuration")  # Second point fails
+        ]
+        
+        mock_wait.return_value = mock_asset
+        
+        # Should complete despite validation errors
+        result = assets.import_dataset_data_points(
+            asset_name="test-asset",
+            dataset_name="default",
+            file_path="/path/to/file.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify both points were validated
+        assert mock_validator.validate_datapoint.call_count == 2
+        
+        # Import should still proceed
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_data_points_empty_list(
+    mock_validator_class, mock_process_file, mock_console, mock_wait, mocked_cmd, mock_asset
+):
+    """Test import_dataset_data_points handles empty data points list."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        mock_process_file.return_value = []
+        
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        
+        mock_wait.return_value = mock_asset
+        
+        result = assets.import_dataset_data_points(
+            asset_name="test-asset",
+            dataset_name="default",
+            file_path="/path/to/file.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Validator should not be called for empty list
+        mock_validator.validate_datapoint.assert_not_called()
+        assert isinstance(result, list)
+
+
+    # ========== import_events Tests ==========
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_events_with_validation_all_pass(
+    mock_validator_class, mock_process_file, mock_console, mock_wait, mocked_cmd, mock_asset
+):
+    """Test import_events validates all events successfully."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        new_events = [
+            {"name": "event1", "eventNotifier": "notifier1"},
+            {"name": "event2", "eventNotifier": "notifier2"}
+        ]
+        mock_process_file.return_value = new_events
+        
+        # Mock validator
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_event.return_value = None
+        
+        mock_wait.return_value = mock_asset
+        
+        result = assets.import_events(
+            asset_name="test-asset",
+            file_path="/path/to/events.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify validator was created
+        mock_validator_class.from_asset.assert_called_once_with(mocked_cmd, mock_asset)
+        
+        # Verify all events were validated
+        assert mock_validator.validate_event.call_count == 2
+        calls = mock_validator.validate_event.call_args_list
+        assert calls[0][0][0] == new_events[0]
+        assert calls[1][0][0] == new_events[1]
+        
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_events_with_validation_failure(
+    mock_validator_class, mock_process_file, mock_wait, mock_console, mocked_cmd, mock_asset
+):
+    """Test import_events logs errors but continues when validation fails."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        new_events = [
+            {"name": "valid-event", "eventNotifier": "notifier1"},
+            {"name": "invalid-event", "eventNotifier": "notifier2"}
+        ]
+        mock_process_file.return_value = new_events
+        
+        # Mock validator - first passes, second fails
+        mock_validator = Mock()
+        mock_validator_class.from_asset.return_value = mock_validator
+        mock_validator.validate_event.side_effect = [
+            None,
+            ValidationError("Invalid event configuration")
+        ]
+        
+        mock_wait.return_value = mock_asset
+        
+        # Should complete despite validation error
+        result = assets.import_events(
+            asset_name="test-asset",
+            file_path="/path/to/events.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Verify both events were validated
+        assert mock_validator.validate_event.call_count == 2
+        
+        # Import should still proceed
+        assert isinstance(result, list)
+
+
+@patch('azext_edge.edge.providers.adr.assets.wait_for_terminal_state')
+@patch('azext_edge.edge.providers.adr.assets.console')
+@patch('azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path')
+@patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator')
+def test_import_events_validator_creation_fails(
+    mock_validator_class, mock_process_file, mock_console, mock_wait, mocked_cmd, mock_asset
+):
+    """Test import_events handles validator creation failure gracefully."""
+    assets = Assets(mocked_cmd)
+    
+    with patch.object(assets, 'show', return_value=mock_asset), \
+         patch.object(assets, 'ops') as mock_ops:
+        new_events = [{"name": "event1", "eventNotifier": "notifier1"}]
+        mock_process_file.return_value = new_events
+        
+        # Mock validator creation failure
+        mock_validator_class.from_asset.side_effect = Exception("Failed to create validator")
+        
+        mock_wait.return_value = mock_asset
+        
+        # Should not raise, just log warning
+        result = assets.import_events(
+            asset_name="test-asset",
+            file_path="/path/to/events.json",
+            resource_group_name="test-rg",
+            wait_sec=0
+        )
+        
+        # Import should still complete
+        assert isinstance(result, list)

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -700,7 +700,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
 
     # Add multiple datapoints with different properties
     custom_config_path, custom_config = create_config_file(tracked_files)
-    
+
     datapoint_configs = [
         {"name": f"dp1-{generate_random_string(4)}", "source": "sensor/temp", "config": custom_config_path},
         {"name": f"dp2-{generate_random_string(4)}", "source": "sensor/humidity", "config": custom_config_path},
@@ -722,15 +722,15 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
         f"--format json"
     )
-    
+
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
     logger.warning(f"Exported to {exported_file}")
-    
+
     # Verify file exists and contains expected datapoints
     with open(exported_file, 'r') as f:
         exported_data = json.load(f)
-    
+
     assert len(exported_data) == 3
     exported_names = [dp["name"] for dp in exported_data]
     assert all(dp["name"] in exported_names for dp in datapoint_configs)
@@ -764,12 +764,12 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     assert len(imported_datapoints) == 3
     imported_names = [dp["name"] for dp in imported_datapoints]
     assert all(dp["name"] in imported_names for dp in datapoint_configs)
-    
+
     # Verify properties preserved
     for original_dp in datapoint_configs:
         restored_dp = next(dp for dp in imported_datapoints if dp["name"] == original_dp["name"])
         assert restored_dp["dataSource"] == original_dp["source"]
-    
+
     logger.warning("Test completed successfully.")
 
 
@@ -838,7 +838,7 @@ def test_namespace_asset_datapoint_export_import_csv_format(
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
         f"--format csv"
     )
-    
+
     csv_file = export_result["file_path"]
     tracked_files.append(csv_file)
     logger.warning(f"Exported to {csv_file}")
@@ -926,7 +926,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
         f"az iot ops ns asset rest dataset export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --format json"
     )
-    
+
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
     logger.warning(f"Exported to {exported_file}")
@@ -934,7 +934,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     # Verify exported content
     with open(exported_file, 'r') as f:
         exported_datasets = json.load(f)
-    
+
     assert len(exported_datasets) == 3
     # Verify dataPoints arrays removed in export
     for ds in exported_datasets:
@@ -1019,7 +1019,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     # Add initial datapoints
     logger.warning("Adding initial datapoints...")
     custom_config_path, _ = create_config_file(tracked_files)
-    
+
     initial_datapoints = [
         {"name": "dp1", "source": "sensor/temp"},
         {"name": "dp2", "source": "sensor/humidity"},
@@ -1038,7 +1038,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
         f"az iot ops ns asset custom datapoint export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
     )
-    
+
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
     logger.warning(f"Exported to {exported_file}")
@@ -1108,7 +1108,7 @@ def test_namespace_asset_dataset_export_yaml_format(
     # Create dataset
     logger.warning("Creating dataset...")
     custom_config_path, _ = create_config_file(tracked_files)
-    
+
     dataset_name = f"dataset-yaml-{generate_random_string(6)}"
     run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
@@ -1122,7 +1122,7 @@ def test_namespace_asset_dataset_export_yaml_format(
         f"az iot ops ns asset custom dataset export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --format yaml"
     )
-    
+
     yaml_file = export_result["file_path"]
     tracked_files.append(yaml_file)
     logger.warning(f"Exported to {yaml_file}")

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -5,6 +5,7 @@
 # ----------------------------------------------------------------------------------------------
 
 import json
+import logging
 import pytest
 from typing import List
 
@@ -13,6 +14,7 @@ from ...helpers import run
 from .namespace_helpers import create_config_file, assert_point_properties, assert_dataset_properties
 
 
+logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.long_running
 
 
@@ -658,6 +660,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     WHY: Validates most common backup/restore workflow - ensures data integrity
     through full export → delete → import cycle.
     """
+    logger.warning("Starting test_namespace_asset_datapoint_export_import_json_roundtrip")
     instance_name = require_init["instanceName"]
     resource_group = require_init["resourceGroup"]
     device_name = f"dev-export-{generate_random_string(8, force_lower=True)}"
@@ -666,18 +669,21 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     dataset_name = f"dataset-{generate_random_string(6, force_lower=True)}"
 
     # Setup: Create device, endpoint, and asset
+    logger.warning("Creating device...")
     result = run(
         f"az iot ops ns device create --name {device_name} --instance {instance_name} "
         f"-g {resource_group}"
     )
     tracked_resources.append(result["id"])
 
+    logger.warning("Creating endpoint...")
     run(
         f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
         f"--instance {instance_name} -g {resource_group} --device {device_name} "
         f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
     )
 
+    logger.warning("Creating asset...")
     asset = run(
         f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
@@ -685,6 +691,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     tracked_resources.append(asset["id"])
 
     # Create dataset
+    logger.warning("Creating dataset...")
     run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
@@ -700,6 +707,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
         {"name": f"dp3-{generate_random_string(4)}", "source": "sensor/pressure", "config": custom_config_path},
     ]
 
+    logger.warning(f"Adding {len(datapoint_configs)} datapoints...")
     for dp in datapoint_configs:
         run(
             f"az iot ops ns asset custom datapoint add --asset {asset_name} "
@@ -708,6 +716,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
         )
 
     # EXPORT datapoints to JSON
+    logger.warning("Exporting datapoints...")
     export_result = run(
         f"az iot ops ns asset custom datapoint export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
@@ -716,6 +725,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
+    logger.warning(f"Exported to {exported_file}")
     
     # Verify file exists and contains expected datapoints
     with open(exported_file, 'r') as f:
@@ -726,6 +736,7 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     assert all(dp["name"] in exported_names for dp in datapoint_configs)
 
     # Delete all datapoints
+    logger.warning("Deleting datapoints...")
     for dp in datapoint_configs:
         run(
             f"az iot ops ns asset custom datapoint remove --asset {asset_name} "
@@ -741,12 +752,14 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     assert len(datapoints_after_delete) == 0
 
     # IMPORT datapoints back from file
+    logger.warning("Importing datapoints...")
     imported_datapoints = run(
         f"az iot ops ns asset custom datapoint import --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
         f"--input-file {exported_file}"
     )
 
+    logger.warning("Verifying import...")
     # Verify all datapoints restored
     assert len(imported_datapoints) == 3
     imported_names = [dp["name"] for dp in imported_datapoints]
@@ -756,6 +769,8 @@ def test_namespace_asset_datapoint_export_import_json_roundtrip(
     for original_dp in datapoint_configs:
         restored_dp = next(dp for dp in imported_datapoints if dp["name"] == original_dp["name"])
         assert restored_dp["dataSource"] == original_dp["source"]
+    
+    logger.warning("Test completed successfully.")
 
 
 def test_namespace_asset_datapoint_export_import_csv_format(
@@ -765,6 +780,7 @@ def test_namespace_asset_datapoint_export_import_csv_format(
     Test CSV format export/import for DOE web UI compatibility.
     WHY: CSV is critical for interoperability with DOE web interface.
     """
+    logger.warning("Starting test_namespace_asset_datapoint_export_import_csv_format")
     instance_name = require_init["instanceName"]
     resource_group = require_init["resourceGroup"]
     device_name = f"dev-csv-{generate_random_string(8, force_lower=True)}"
@@ -773,18 +789,21 @@ def test_namespace_asset_datapoint_export_import_csv_format(
     dataset_name = f"dataset-csv-{generate_random_string(6, force_lower=True)}"
 
     # Setup OPC UA asset (CSV commonly used with OPC UA)
+    logger.warning("Creating device...")
     result = run(
         f"az iot ops ns device create --name {device_name} --instance {instance_name} "
         f"-g {resource_group}"
     )
     tracked_resources.append(result["id"])
 
+    logger.warning("Creating endpoint...")
     run(
         f"az iot ops ns device endpoint inbound add opcua --name {endpoint_name} "
         f"--instance {instance_name} -g {resource_group} --device {device_name} "
         f"--endpoint-address 'opc.tcp://192.168.1.200:4840'"
     )
 
+    logger.warning("Creating asset...")
     asset = run(
         f"az iot ops ns asset opcua create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
@@ -792,10 +811,11 @@ def test_namespace_asset_datapoint_export_import_csv_format(
     tracked_resources.append(asset["id"])
 
     # Create dataset and datapoints
+    logger.warning("Creating dataset and datapoints...")
     run(
         f"az iot ops ns asset opcua dataset add --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
-        f"--data-source ns=2;i=1000 --publish-int 1000"
+        f"--data-source \"ns=2;i=1000\" --publish-int 1000"
     )
 
     datapoints = [
@@ -812,6 +832,7 @@ def test_namespace_asset_datapoint_export_import_csv_format(
         )
 
     # EXPORT to CSV
+    logger.warning("Exporting to CSV...")
     export_result = run(
         f"az iot ops ns asset opcua datapoint export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
@@ -820,9 +841,11 @@ def test_namespace_asset_datapoint_export_import_csv_format(
     
     csv_file = export_result["file_path"]
     tracked_files.append(csv_file)
+    logger.warning(f"Exported to {csv_file}")
     assert csv_file.endswith('.csv')
 
     # Delete datapoints
+    logger.warning("Deleting datapoints...")
     for dp in datapoints:
         run(
             f"az iot ops ns asset opcua datapoint remove --asset {asset_name} "
@@ -831,6 +854,7 @@ def test_namespace_asset_datapoint_export_import_csv_format(
         )
 
     # IMPORT from CSV
+    logger.warning("Importing from CSV...")
     imported_datapoints = run(
         f"az iot ops ns asset opcua datapoint import --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
@@ -838,9 +862,11 @@ def test_namespace_asset_datapoint_export_import_csv_format(
     )
 
     # Verify CSV round-trip successful
+    logger.warning("Verifying CSV round-trip...")
     assert len(imported_datapoints) == 2
     imported_names = [dp["name"] for dp in imported_datapoints]
     assert all(dp["name"] in imported_names for dp in datapoints)
+    logger.warning("Test completed successfully.")
 
 
 def test_namespace_asset_dataset_export_import_roundtrip(
@@ -850,6 +876,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     Test bulk dataset export/import workflow.
     WHY: Validates backup/restore of entire dataset configurations (without datapoints).
     """
+    logger.warning("Starting test_namespace_asset_dataset_export_import_roundtrip")
     instance_name = require_init["instanceName"]
     resource_group = require_init["resourceGroup"]
     device_name = f"dev-bulk-{generate_random_string(8, force_lower=True)}"
@@ -857,18 +884,21 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     asset_name = f"asset-bulk-{generate_random_string(8, force_lower=True)}"
 
     # Setup REST asset
+    logger.warning("Creating device...")
     result = run(
         f"az iot ops ns device create --name {device_name} --instance {instance_name} "
         f"-g {resource_group}"
     )
     tracked_resources.append(result["id"])
 
+    logger.warning("Creating endpoint...")
     run(
         f"az iot ops ns device endpoint inbound add rest --name {endpoint_name} "
         f"--instance {instance_name} -g {resource_group} --device {device_name} "
         f"--endpoint-address 'https://api.example.com/data'"
     )
 
+    logger.warning("Creating asset...")
     asset = run(
         f"az iot ops ns asset rest create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
@@ -876,6 +906,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     tracked_resources.append(asset["id"])
 
     # Create multiple datasets with different configurations
+    logger.warning("Creating datasets...")
     datasets = [
         {"name": f"dataset1-{generate_random_string(4)}", "source": "/api/temp", "sampling": 5000},
         {"name": f"dataset2-{generate_random_string(4)}", "source": "/api/humidity", "sampling": 10000},
@@ -890,6 +921,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
         )
 
     # EXPORT all datasets to JSON
+    logger.warning("Exporting datasets...")
     export_result = run(
         f"az iot ops ns asset rest dataset export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --format json"
@@ -897,6 +929,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
+    logger.warning(f"Exported to {exported_file}")
 
     # Verify exported content
     with open(exported_file, 'r') as f:
@@ -910,6 +943,7 @@ def test_namespace_asset_dataset_export_import_roundtrip(
         assert "dataSource" in ds
 
     # Delete all datasets
+    logger.warning("Deleting datasets...")
     for ds in datasets:
         run(
             f"az iot ops ns asset rest dataset remove --asset {asset_name} "
@@ -924,15 +958,18 @@ def test_namespace_asset_dataset_export_import_roundtrip(
     assert len(datasets_after_delete) == 0
 
     # IMPORT datasets back
+    logger.warning("Importing datasets...")
     imported_datasets = run(
         f"az iot ops ns asset rest dataset import --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --input-file {exported_file}"
     )
 
     # Verify all datasets restored
+    logger.warning("Verifying import...")
     assert len(imported_datasets) == 3
     imported_names = [ds["name"] for ds in imported_datasets]
     assert all(ds["name"] in imported_names for ds in datasets)
+    logger.warning("Test completed successfully.")
 
 
 def test_namespace_asset_datapoint_import_skip_duplicates(
@@ -942,6 +979,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     Test duplicate-skip behavior during datapoint import.
     WHY: Prevents data loss - ensures existing datapoints not overwritten accidentally.
     """
+    logger.warning("Starting test_namespace_asset_datapoint_import_skip_duplicates")
     instance_name = require_init["instanceName"]
     resource_group = require_init["resourceGroup"]
     device_name = f"dev-dup-{generate_random_string(8, force_lower=True)}"
@@ -950,24 +988,28 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     dataset_name = f"dataset-dup-{generate_random_string(6, force_lower=True)}"
 
     # Setup
+    logger.warning("Creating device...")
     result = run(
         f"az iot ops ns device create --name {device_name} --instance {instance_name} "
         f"-g {resource_group}"
     )
     tracked_resources.append(result["id"])
 
+    logger.warning("Creating endpoint...")
     run(
         f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
         f"--instance {instance_name} -g {resource_group} --device {device_name} "
         f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
     )
 
+    logger.warning("Creating asset...")
     asset = run(
         f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
     )
     tracked_resources.append(asset["id"])
 
+    logger.warning("Creating dataset...")
     run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
@@ -975,6 +1017,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     )
 
     # Add initial datapoints
+    logger.warning("Adding initial datapoints...")
     custom_config_path, _ = create_config_file(tracked_files)
     
     initial_datapoints = [
@@ -990,6 +1033,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
         )
 
     # Export initial datapoints
+    logger.warning("Exporting initial datapoints...")
     export_result = run(
         f"az iot ops ns asset custom datapoint export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
@@ -997,8 +1041,10 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     
     exported_file = export_result["file_path"]
     tracked_files.append(exported_file)
+    logger.warning(f"Exported to {exported_file}")
 
     # Add more datapoints manually (creating a mixed state)
+    logger.warning("Adding more datapoints manually...")
     run(
         f"az iot ops ns asset custom datapoint add --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
@@ -1006,6 +1052,7 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     )
 
     # Now import from file (contains dp1, dp2 which exist + dp3 was added manually)
+    logger.warning("Importing from file (should skip duplicates)...")
     imported_datapoints = run(
         f"az iot ops ns asset custom datapoint import --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
@@ -1013,11 +1060,13 @@ def test_namespace_asset_datapoint_import_skip_duplicates(
     )
 
     # Verify: Should have all 3 datapoints (2 from file skipped as duplicates, manual dp3 preserved)
+    logger.warning("Verifying results...")
     assert len(imported_datapoints) == 3
     datapoint_names = [dp["name"] for dp in imported_datapoints]
     assert "dp1" in datapoint_names
     assert "dp2" in datapoint_names
     assert "dp3" in datapoint_names
+    logger.warning("Test completed successfully.")
 
 
 def test_namespace_asset_dataset_export_yaml_format(
@@ -1027,6 +1076,7 @@ def test_namespace_asset_dataset_export_yaml_format(
     Test YAML format export for datasets.
     WHY: YAML is human-readable and commonly used in DevOps workflows.
     """
+    logger.warning("Starting test_namespace_asset_dataset_export_yaml_format")
     instance_name = require_init["instanceName"]
     resource_group = require_init["resourceGroup"]
     device_name = f"dev-yaml-{generate_random_string(8, force_lower=True)}"
@@ -1034,18 +1084,21 @@ def test_namespace_asset_dataset_export_yaml_format(
     asset_name = f"asset-yaml-{generate_random_string(8, force_lower=True)}"
 
     # Setup
+    logger.warning("Creating device...")
     result = run(
         f"az iot ops ns device create --name {device_name} --instance {instance_name} "
         f"-g {resource_group}"
     )
     tracked_resources.append(result["id"])
 
+    logger.warning("Creating endpoint...")
     run(
         f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
         f"--instance {instance_name} -g {resource_group} --device {device_name} "
         f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
     )
 
+    logger.warning("Creating asset...")
     asset = run(
         f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
         f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
@@ -1053,6 +1106,7 @@ def test_namespace_asset_dataset_export_yaml_format(
     tracked_resources.append(asset["id"])
 
     # Create dataset
+    logger.warning("Creating dataset...")
     custom_config_path, _ = create_config_file(tracked_files)
     
     dataset_name = f"dataset-yaml-{generate_random_string(6)}"
@@ -1063,6 +1117,7 @@ def test_namespace_asset_dataset_export_yaml_format(
     )
 
     # EXPORT to YAML
+    logger.warning("Exporting to YAML...")
     export_result = run(
         f"az iot ops ns asset custom dataset export --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --format yaml"
@@ -1070,20 +1125,25 @@ def test_namespace_asset_dataset_export_yaml_format(
     
     yaml_file = export_result["file_path"]
     tracked_files.append(yaml_file)
+    logger.warning(f"Exported to {yaml_file}")
     assert yaml_file.endswith('.yaml')
 
     # Delete dataset
+    logger.warning("Deleting dataset...")
     run(
         f"az iot ops ns asset custom dataset remove --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
     )
 
     # IMPORT from YAML
+    logger.warning("Importing from YAML...")
     imported_datasets = run(
         f"az iot ops ns asset custom dataset import --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --input-file {yaml_file}"
     )
 
     # Verify YAML round-trip successful
+    logger.warning("Verifying YAML round-trip...")
     assert len(imported_datasets) == 1
     assert imported_datasets[0]["name"] == dataset_name
+    logger.warning("Test completed successfully.")

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import json
 import pytest
 from typing import List
 
@@ -645,3 +646,444 @@ def test_namespace_rest_asset_dataset_lifecycle_operations(require_init, tracked
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
     assert dataset_name_1 not in remaining_dataset_names
+
+
+# ==================== EXPORT/IMPORT INTEGRATION TESTS ====================
+
+def test_namespace_asset_datapoint_export_import_json_roundtrip(
+    require_init, tracked_resources: List[str], tracked_files: List[str]
+):
+    """
+    Test complete export/import workflow for datapoints in JSON format.
+    WHY: Validates most common backup/restore workflow - ensures data integrity
+    through full export → delete → import cycle.
+    """
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-export-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"custom-{generate_random_string(8)}"
+    asset_name = f"asset-export-{generate_random_string(8, force_lower=True)}"
+    dataset_name = f"dataset-{generate_random_string(6, force_lower=True)}"
+
+    # Setup: Create device, endpoint, and asset
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    run(
+        f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
+    )
+
+    asset = run(
+        f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset["id"])
+
+    # Create dataset
+    run(
+        f"az iot ops ns asset custom dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--data-source sensor/data"
+    )
+
+    # Add multiple datapoints with different properties
+    custom_config_path, custom_config = create_config_file(tracked_files)
+    
+    datapoint_configs = [
+        {"name": f"dp1-{generate_random_string(4)}", "source": "sensor/temp", "config": custom_config_path},
+        {"name": f"dp2-{generate_random_string(4)}", "source": "sensor/humidity", "config": custom_config_path},
+        {"name": f"dp3-{generate_random_string(4)}", "source": "sensor/pressure", "config": custom_config_path},
+    ]
+
+    for dp in datapoint_configs:
+        run(
+            f"az iot ops ns asset custom datapoint add --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+            f"--name {dp['name']} --data-source {dp['source']} --config {dp['config']}"
+        )
+
+    # EXPORT datapoints to JSON
+    export_result = run(
+        f"az iot ops ns asset custom datapoint export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--format json"
+    )
+    
+    exported_file = export_result["file_path"]
+    tracked_files.append(exported_file)
+    
+    # Verify file exists and contains expected datapoints
+    with open(exported_file, 'r') as f:
+        exported_data = json.load(f)
+    
+    assert len(exported_data) == 3
+    exported_names = [dp["name"] for dp in exported_data]
+    assert all(dp["name"] in exported_names for dp in datapoint_configs)
+
+    # Delete all datapoints
+    for dp in datapoint_configs:
+        run(
+            f"az iot ops ns asset custom datapoint remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+            f"--name {dp['name']}"
+        )
+
+    # Verify datapoints deleted
+    datapoints_after_delete = run(
+        f"az iot ops ns asset custom datapoint list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+    )
+    assert len(datapoints_after_delete) == 0
+
+    # IMPORT datapoints back from file
+    imported_datapoints = run(
+        f"az iot ops ns asset custom datapoint import --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--input-file {exported_file}"
+    )
+
+    # Verify all datapoints restored
+    assert len(imported_datapoints) == 3
+    imported_names = [dp["name"] for dp in imported_datapoints]
+    assert all(dp["name"] in imported_names for dp in datapoint_configs)
+    
+    # Verify properties preserved
+    for original_dp in datapoint_configs:
+        restored_dp = next(dp for dp in imported_datapoints if dp["name"] == original_dp["name"])
+        assert restored_dp["dataSource"] == original_dp["source"]
+
+
+def test_namespace_asset_datapoint_export_import_csv_format(
+    require_init, tracked_resources: List[str], tracked_files: List[str]
+):
+    """
+    Test CSV format export/import for DOE web UI compatibility.
+    WHY: CSV is critical for interoperability with DOE web interface.
+    """
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-csv-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"opcua-{generate_random_string(8)}"
+    asset_name = f"asset-csv-{generate_random_string(8, force_lower=True)}"
+    dataset_name = f"dataset-csv-{generate_random_string(6, force_lower=True)}"
+
+    # Setup OPC UA asset (CSV commonly used with OPC UA)
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    run(
+        f"az iot ops ns device endpoint inbound add opcua --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'opc.tcp://192.168.1.200:4840'"
+    )
+
+    asset = run(
+        f"az iot ops ns asset opcua create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset["id"])
+
+    # Create dataset and datapoints
+    run(
+        f"az iot ops ns asset opcua dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--data-source ns=2;i=1000 --publish-int 1000"
+    )
+
+    datapoints = [
+        {"name": f"temp-{generate_random_string(4)}", "source": "ns=2;i=2001"},
+        {"name": f"pressure-{generate_random_string(4)}", "source": "ns=2;i=2002"},
+    ]
+
+    for dp in datapoints:
+        run(
+            f"az iot ops ns asset opcua datapoint add --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+            f"--name {dp['name']} --data-source \"{dp['source']}\" "
+            f"--queue-size 5 --sampling-int 500"
+        )
+
+    # EXPORT to CSV
+    export_result = run(
+        f"az iot ops ns asset opcua datapoint export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--format csv"
+    )
+    
+    csv_file = export_result["file_path"]
+    tracked_files.append(csv_file)
+    assert csv_file.endswith('.csv')
+
+    # Delete datapoints
+    for dp in datapoints:
+        run(
+            f"az iot ops ns asset opcua datapoint remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+            f"--name {dp['name']}"
+        )
+
+    # IMPORT from CSV
+    imported_datapoints = run(
+        f"az iot ops ns asset opcua datapoint import --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--input-file {csv_file}"
+    )
+
+    # Verify CSV round-trip successful
+    assert len(imported_datapoints) == 2
+    imported_names = [dp["name"] for dp in imported_datapoints]
+    assert all(dp["name"] in imported_names for dp in datapoints)
+
+
+def test_namespace_asset_dataset_export_import_roundtrip(
+    require_init, tracked_resources: List[str], tracked_files: List[str]
+):
+    """
+    Test bulk dataset export/import workflow.
+    WHY: Validates backup/restore of entire dataset configurations (without datapoints).
+    """
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-bulk-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"rest-{generate_random_string(8)}"
+    asset_name = f"asset-bulk-{generate_random_string(8, force_lower=True)}"
+
+    # Setup REST asset
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    run(
+        f"az iot ops ns device endpoint inbound add rest --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'https://api.example.com/data'"
+    )
+
+    asset = run(
+        f"az iot ops ns asset rest create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset["id"])
+
+    # Create multiple datasets with different configurations
+    datasets = [
+        {"name": f"dataset1-{generate_random_string(4)}", "source": "/api/temp", "sampling": 5000},
+        {"name": f"dataset2-{generate_random_string(4)}", "source": "/api/humidity", "sampling": 10000},
+        {"name": f"dataset3-{generate_random_string(4)}", "source": "/api/pressure", "sampling": 15000},
+    ]
+
+    for ds in datasets:
+        run(
+            f"az iot ops ns asset rest dataset add --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {ds['name']} "
+            f"--data-source {ds['source']} --sampling-int {ds['sampling']}"
+        )
+
+    # EXPORT all datasets to JSON
+    export_result = run(
+        f"az iot ops ns asset rest dataset export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --format json"
+    )
+    
+    exported_file = export_result["file_path"]
+    tracked_files.append(exported_file)
+
+    # Verify exported content
+    with open(exported_file, 'r') as f:
+        exported_datasets = json.load(f)
+    
+    assert len(exported_datasets) == 3
+    # Verify dataPoints arrays removed in export
+    for ds in exported_datasets:
+        assert "dataPoints" not in ds
+        assert "name" in ds
+        assert "dataSource" in ds
+
+    # Delete all datasets
+    for ds in datasets:
+        run(
+            f"az iot ops ns asset rest dataset remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {ds['name']}"
+        )
+
+    # Verify datasets deleted
+    datasets_after_delete = run(
+        f"az iot ops ns asset rest dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert len(datasets_after_delete) == 0
+
+    # IMPORT datasets back
+    imported_datasets = run(
+        f"az iot ops ns asset rest dataset import --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --input-file {exported_file}"
+    )
+
+    # Verify all datasets restored
+    assert len(imported_datasets) == 3
+    imported_names = [ds["name"] for ds in imported_datasets]
+    assert all(ds["name"] in imported_names for ds in datasets)
+
+
+def test_namespace_asset_datapoint_import_skip_duplicates(
+    require_init, tracked_resources: List[str], tracked_files: List[str]
+):
+    """
+    Test duplicate-skip behavior during datapoint import.
+    WHY: Prevents data loss - ensures existing datapoints not overwritten accidentally.
+    """
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-dup-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"custom-{generate_random_string(8)}"
+    asset_name = f"asset-dup-{generate_random_string(8, force_lower=True)}"
+    dataset_name = f"dataset-dup-{generate_random_string(6, force_lower=True)}"
+
+    # Setup
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    run(
+        f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
+    )
+
+    asset = run(
+        f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset["id"])
+
+    run(
+        f"az iot ops ns asset custom dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--data-source sensor/data"
+    )
+
+    # Add initial datapoints
+    custom_config_path, _ = create_config_file(tracked_files)
+    
+    initial_datapoints = [
+        {"name": "dp1", "source": "sensor/temp"},
+        {"name": "dp2", "source": "sensor/humidity"},
+    ]
+
+    for dp in initial_datapoints:
+        run(
+            f"az iot ops ns asset custom datapoint add --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+            f"--name {dp['name']} --data-source {dp['source']} --config {custom_config_path}"
+        )
+
+    # Export initial datapoints
+    export_result = run(
+        f"az iot ops ns asset custom datapoint export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+    )
+    
+    exported_file = export_result["file_path"]
+    tracked_files.append(exported_file)
+
+    # Add more datapoints manually (creating a mixed state)
+    run(
+        f"az iot ops ns asset custom datapoint add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--name dp3 --data-source sensor/pressure --config {custom_config_path}"
+    )
+
+    # Now import from file (contains dp1, dp2 which exist + dp3 was added manually)
+    imported_datapoints = run(
+        f"az iot ops ns asset custom datapoint import --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name} "
+        f"--input-file {exported_file}"
+    )
+
+    # Verify: Should have all 3 datapoints (2 from file skipped as duplicates, manual dp3 preserved)
+    assert len(imported_datapoints) == 3
+    datapoint_names = [dp["name"] for dp in imported_datapoints]
+    assert "dp1" in datapoint_names
+    assert "dp2" in datapoint_names
+    assert "dp3" in datapoint_names
+
+
+def test_namespace_asset_dataset_export_yaml_format(
+    require_init, tracked_resources: List[str], tracked_files: List[str]
+):
+    """
+    Test YAML format export for datasets.
+    WHY: YAML is human-readable and commonly used in DevOps workflows.
+    """
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-yaml-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"custom-{generate_random_string(8)}"
+    asset_name = f"asset-yaml-{generate_random_string(8, force_lower=True)}"
+
+    # Setup
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    run(
+        f"az iot ops ns device endpoint inbound add custom --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'http://192.168.1.100:8000/api' --endpoint-type custom"
+    )
+
+    asset = run(
+        f"az iot ops ns asset custom create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset["id"])
+
+    # Create dataset
+    custom_config_path, _ = create_config_file(tracked_files)
+    
+    dataset_name = f"dataset-yaml-{generate_random_string(6)}"
+    run(
+        f"az iot ops ns asset custom dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name} "
+        f"--data-source sensor/data --config {custom_config_path}"
+    )
+
+    # EXPORT to YAML
+    export_result = run(
+        f"az iot ops ns asset custom dataset export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --format yaml"
+    )
+    
+    yaml_file = export_result["file_path"]
+    tracked_files.append(yaml_file)
+    assert yaml_file.endswith('.yaml')
+
+    # Delete dataset
+    run(
+        f"az iot ops ns asset custom dataset remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+    )
+
+    # IMPORT from YAML
+    imported_datasets = run(
+        f"az iot ops ns asset custom dataset import --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --input-file {yaml_file}"
+    )
+
+    # Verify YAML round-trip successful
+    assert len(imported_datasets) == 1
+    assert imported_datasets[0]["name"] == dataset_name

--- a/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
@@ -947,11 +947,11 @@ def test_export_namespace_asset_dataset_datapoints(
     dataset_name = "temperatureDataset"
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Create mock asset with dataset and datapoints
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -975,7 +975,7 @@ def test_export_namespace_asset_dataset_datapoints(
             ]
         }
     ]
-    
+
     # Mock GET asset response
     mocked_responses.add(
         method=responses.GET,
@@ -988,16 +988,16 @@ def test_export_namespace_asset_dataset_datapoints(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock dump_content_to_file
     expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.json"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
-    
+
     result = export_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1007,10 +1007,10 @@ def test_export_namespace_asset_dataset_datapoints(
         format="json",
         output_dir="."
     )
-    
+
     # Verify result
     assert result == {"file_path": expected_file_path}
-    
+
     # Verify dump_content_to_file was called with correct datapoints
     assert mock_dump.call_count == 1
     call_kwargs = mock_dump.call_args[1]
@@ -1031,11 +1031,11 @@ def test_export_namespace_asset_dataset_datapoints_csv(
     dataset_name = "pressureDataset"
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
@@ -1050,7 +1050,7 @@ def test_export_namespace_asset_dataset_datapoints_csv(
             ]
         }
     ]
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1062,15 +1062,15 @@ def test_export_namespace_asset_dataset_datapoints_csv(
         status=200,
         content_type="application/json",
     )
-    
+
     expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.csv"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
-    
+
     result = export_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1080,7 +1080,7 @@ def test_export_namespace_asset_dataset_datapoints_csv(
         format="csv",
         output_dir="."
     )
-    
+
     assert result == {"file_path": expected_file_path}
     assert mock_dump.call_count == 1
     call_kwargs = mock_dump.call_args[1]
@@ -1100,11 +1100,11 @@ def test_import_namespace_asset_dataset_datapoints(
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
     input_file = "/tmp/datapoints.json"
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Existing asset with one datapoint
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -1119,13 +1119,13 @@ def test_import_namespace_asset_dataset_datapoints(
             ]
         }
     ]
-    
+
     # File contains new datapoints
-    file_datapoints = [
+    [
         {"name": "new1", "dataSource": "newSource1"},
         {"name": "new2", "dataSource": "newSource2"}
     ]
-    
+
     # Mock _process_asset_sub_points_file_path (merge logic)
     # This function internally handles file deserialization
     merged_datapoints = [
@@ -1137,7 +1137,7 @@ def test_import_namespace_asset_dataset_datapoints(
         "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
         return_value=merged_datapoints
     )
-    
+
     # Mock GET asset response (initial)
     mocked_responses.add(
         method=responses.GET,
@@ -1150,7 +1150,7 @@ def test_import_namespace_asset_dataset_datapoints(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock PATCH update response
     updated_asset = deepcopy(mock_asset_record)
     updated_asset["properties"]["datasets"][0]["dataPoints"] = merged_datapoints
@@ -1165,7 +1165,7 @@ def test_import_namespace_asset_dataset_datapoints(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock GET asset response (final)
     mocked_responses.add(
         method=responses.GET,
@@ -1178,9 +1178,9 @@ def test_import_namespace_asset_dataset_datapoints(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
-    
+
     result = import_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1190,10 +1190,10 @@ def test_import_namespace_asset_dataset_datapoints(
         input_file=input_file,
         wait_sec=0
     )
-    
+
     # Verify result contains merged datapoints
     assert result == merged_datapoints
-    
+
     # Verify _process_asset_sub_points_file_path was called with correct parameters
     mock_process.assert_called_once()
     call_kwargs = mock_process.call_args[1]
@@ -1212,11 +1212,11 @@ def test_export_namespace_asset_datasets(
     asset_name = generate_random_string()
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Create mock asset with multiple datasets
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -1239,7 +1239,7 @@ def test_export_namespace_asset_datasets(
             ]
         }
     ]
-    
+
     # Mock GET asset response
     mocked_responses.add(
         method=responses.GET,
@@ -1252,16 +1252,16 @@ def test_export_namespace_asset_datasets(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock dump_content_to_file
     expected_file_path = f"./{asset_name}_dataset.json"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
-    
+
     result = export_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1270,15 +1270,15 @@ def test_export_namespace_asset_datasets(
         format="json",
         output_dir="."
     )
-    
+
     # Verify result
     assert result == {"file_path": expected_file_path}
-    
+
     # Verify dump_content_to_file was called with datasets WITHOUT dataPoints
     assert mock_dump.call_count == 1
     call_kwargs = mock_dump.call_args[1]
     exported_datasets = call_kwargs["content"]
-    
+
     # Check that dataPoints are removed
     for dataset in exported_datasets:
         assert "dataPoints" not in dataset
@@ -1296,11 +1296,11 @@ def test_export_namespace_asset_datasets_yaml(
     asset_name = generate_random_string()
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
@@ -1309,7 +1309,7 @@ def test_export_namespace_asset_datasets_yaml(
     mock_asset_record["properties"]["datasets"] = [
         {"name": "dataset1", "dataPoints": []}
     ]
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1321,15 +1321,15 @@ def test_export_namespace_asset_datasets_yaml(
         status=200,
         content_type="application/json",
     )
-    
+
     expected_file_path = f"./{asset_name}_dataset.yaml"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
-    
+
     result = export_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1338,7 +1338,7 @@ def test_export_namespace_asset_datasets_yaml(
         format="yaml",
         output_dir="."
     )
-    
+
     assert result == {"file_path": expected_file_path}
     call_kwargs = mock_dump.call_args[1]
     assert call_kwargs["extension"] == "yaml"
@@ -1356,11 +1356,11 @@ def test_import_namespace_asset_datasets(
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
     input_file = "/tmp/datasets.json"
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Existing asset with one dataset
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -1373,19 +1373,19 @@ def test_import_namespace_asset_datasets(
             "dataPoints": [{"name": "existingDp", "dataSource": "existingSource"}]
         }
     ]
-    
+
     # File contains new datasets
     file_datasets = [
         {"name": "newDataset1", "datasetConfiguration": json.dumps({"publishingInterval": 1000})},
         {"name": "newDataset2", "datasetConfiguration": json.dumps({"publishingInterval": 2000})}
     ]
-    
+
     # Mock deserialize_file_content
     mock_deserialize = mocker.patch(
         "azext_edge.edge.util.deserialize_file_content",
         return_value=file_datasets
     )
-    
+
     # Mock GET asset response (initial)
     mocked_responses.add(
         method=responses.GET,
@@ -1398,7 +1398,7 @@ def test_import_namespace_asset_datasets(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock PATCH update response
     updated_asset = deepcopy(mock_asset_record)
     # Merge logic: keep existing, add new datasets
@@ -1407,7 +1407,7 @@ def test_import_namespace_asset_datasets(
         file_datasets[0],  # new1
         file_datasets[1]   # new2
     ]
-    
+
     mocked_responses.add(
         method=responses.PATCH,
         url=get_namespace_asset_mgmt_uri(
@@ -1419,7 +1419,7 @@ def test_import_namespace_asset_datasets(
         status=200,
         content_type="application/json",
     )
-    
+
     # Mock GET asset response (final)
     mocked_responses.add(
         method=responses.GET,
@@ -1432,9 +1432,9 @@ def test_import_namespace_asset_datasets(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import import_namespace_asset_datasets
-    
+
     result = import_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1443,14 +1443,14 @@ def test_import_namespace_asset_datasets(
         input_file=input_file,
         wait_sec=0
     )
-    
+
     # Verify result contains all datasets
     assert len(result) == 3
     dataset_names = [ds["name"] for ds in result]
     assert "existingDataset" in dataset_names
     assert "newDataset1" in dataset_names
     assert "newDataset2" in dataset_names
-    
+
     # Verify mocks were called
     mock_deserialize.assert_called_once_with(file_path=input_file)
 
@@ -1470,11 +1470,11 @@ def test_export_dataset_datapoints_dataset_not_found(
     dataset_name = "nonexistentDataset"
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Asset has no matching dataset
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -1484,7 +1484,7 @@ def test_export_dataset_datapoints_dataset_not_found(
     mock_asset_record["properties"]["datasets"] = [
         {"name": "otherDataset", "dataPoints": []}
     ]
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1496,9 +1496,9 @@ def test_export_dataset_datapoints_dataset_not_found(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
-    
+
     # Should raise InvalidArgumentValueError
     with pytest.raises(InvalidArgumentValueError) as exc_info:
         export_namespace_asset_dataset_points(
@@ -1508,7 +1508,7 @@ def test_export_dataset_datapoints_dataset_not_found(
             instance_name=instance_name,
             instance_resource_group=instance_resource_group,
         )
-    
+
     assert f"Dataset '{dataset_name}' not found" in str(exc_info.value)
 
 
@@ -1526,11 +1526,11 @@ def test_export_dataset_datapoints_empty_datapoints(
     dataset_name = "emptyDataset"
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
@@ -1539,7 +1539,7 @@ def test_export_dataset_datapoints_empty_datapoints(
     mock_asset_record["properties"]["datasets"] = [
         {"name": dataset_name, "dataPoints": []}  # Empty array
     ]
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1551,15 +1551,15 @@ def test_export_dataset_datapoints_empty_datapoints(
         status=200,
         content_type="application/json",
     )
-    
+
     expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.json"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
-    
+
     result = export_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1567,7 +1567,7 @@ def test_export_dataset_datapoints_empty_datapoints(
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
     )
-    
+
     # Should still succeed and export empty array
     assert result == {"file_path": expected_file_path}
     call_kwargs = mock_dump.call_args[1]
@@ -1590,17 +1590,17 @@ def test_import_dataset_datapoints_all_duplicates(
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
     input_file = "/tmp/duplicates.json"
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Existing datapoints
     existing_datapoints = [
         {"name": "dp1", "dataSource": "source1"},
         {"name": "dp2", "dataSource": "source2"}
     ]
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
@@ -1609,13 +1609,13 @@ def test_import_dataset_datapoints_all_duplicates(
     mock_asset_record["properties"]["datasets"] = [
         {"name": dataset_name, "dataPoints": existing_datapoints}
     ]
-    
+
     # Mock returns same datapoints (all duplicates skipped)
-    mock_process = mocker.patch(
+    mocker.patch(
         "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
         return_value=existing_datapoints
     )
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1627,7 +1627,7 @@ def test_import_dataset_datapoints_all_duplicates(
         status=200,
         content_type="application/json",
     )
-    
+
     # Update response (no changes)
     mocked_responses.add(
         method=responses.PATCH,
@@ -1640,7 +1640,7 @@ def test_import_dataset_datapoints_all_duplicates(
         status=200,
         content_type="application/json",
     )
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1652,9 +1652,9 @@ def test_import_dataset_datapoints_all_duplicates(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
-    
+
     result = import_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1664,7 +1664,7 @@ def test_import_dataset_datapoints_all_duplicates(
         input_file=input_file,
         wait_sec=0
     )
-    
+
     # Result should be unchanged
     assert result == existing_datapoints
     assert len(result) == 2
@@ -1683,18 +1683,18 @@ def test_export_datasets_no_datasets(
     asset_name = generate_random_string()
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
         resource_group_name=namespace_resource_group
     )
     mock_asset_record["properties"]["datasets"] = []  # No datasets
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1706,22 +1706,22 @@ def test_export_datasets_no_datasets(
         status=200,
         content_type="application/json",
     )
-    
+
     expected_file_path = f"./{asset_name}_dataset.json"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
-    
+
     result = export_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
     )
-    
+
     assert result == {"file_path": expected_file_path}
     call_kwargs = mock_dump.call_args[1]
     assert call_kwargs["content"] == []
@@ -1742,37 +1742,37 @@ def test_import_datasets_duplicate_skip(
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
     input_file = "/tmp/datasets_with_dup.json"
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     existing_dataset = {
         "name": "dataset1",
         "dataPoints": [{"name": "existingDp", "dataSource": "existingSource"}]
     }
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
         resource_group_name=namespace_resource_group
     )
     mock_asset_record["properties"]["datasets"] = [existing_dataset]
-    
+
     # File contains: 1 duplicate (dataset1) + 1 new (dataset2)
     file_datasets = [
         {"name": "dataset1", "datasetConfiguration": json.dumps({"publishingInterval": 9999})},  # Duplicate
         {"name": "dataset2", "datasetConfiguration": json.dumps({"publishingInterval": 2000})}   # New
     ]
-    
-    mock_deserialize = mocker.patch(
+
+    mocker.patch(
         "azext_edge.edge.util.deserialize_file_content",
         return_value=file_datasets
     )
-    
+
     # Mock logger to verify warning is logged
     mock_logger = mocker.patch("azext_edge.edge.providers.adr.namespace_assets.logger")
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1784,14 +1784,14 @@ def test_import_datasets_duplicate_skip(
         status=200,
         content_type="application/json",
     )
-    
+
     # Updated asset: existing dataset unchanged, only new dataset added
     updated_asset = deepcopy(mock_asset_record)
     updated_asset["properties"]["datasets"] = [
         existing_dataset,  # Original preserved
         {"name": "dataset2", "dataPoints": [], "datasetConfiguration": json.dumps({"publishingInterval": 2000})}
     ]
-    
+
     mocked_responses.add(
         method=responses.PATCH,
         url=get_namespace_asset_mgmt_uri(
@@ -1803,7 +1803,7 @@ def test_import_datasets_duplicate_skip(
         status=200,
         content_type="application/json",
     )
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1815,9 +1815,9 @@ def test_import_datasets_duplicate_skip(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import import_namespace_asset_datasets
-    
+
     result = import_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -1826,17 +1826,17 @@ def test_import_datasets_duplicate_skip(
         input_file=input_file,
         wait_sec=0
     )
-    
+
     # Verify: 2 datasets total, duplicate was skipped
     assert len(result) == 2
     dataset_names = [ds["name"] for ds in result]
     assert "dataset1" in dataset_names
     assert "dataset2" in dataset_names
-    
+
     # Verify existing dataset is unchanged (not overwritten)
     existing_in_result = next(ds for ds in result if ds["name"] == "dataset1")
     assert existing_in_result == existing_dataset
-    
+
     # Verify warning was logged for duplicate
     mock_logger.warning.assert_called_once()
     warning_msg = mock_logger.warning.call_args[0][0]
@@ -1857,11 +1857,11 @@ def test_export_datasets_with_complex_configurations(
     asset_name = generate_random_string()
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Complex dataset with nested configurations
     complex_config = {
         "publishingInterval": 1000,
@@ -1872,7 +1872,7 @@ def test_export_datasets_with_complex_configurations(
             "encryption": {"enabled": True, "algorithm": "AES256"}
         }
     }
-    
+
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
         namespace_name=namespace_name,
@@ -1885,7 +1885,7 @@ def test_export_datasets_with_complex_configurations(
             "dataPoints": [{"name": "dp1", "dataSource": "src1"}]  # Will be removed in export
         }
     ]
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1897,25 +1897,25 @@ def test_export_datasets_with_complex_configurations(
         status=200,
         content_type="application/json",
     )
-    
+
     expected_file_path = f"./{asset_name}_dataset.json"
     mock_dump = mocker.patch(
         "azext_edge.edge.util.dump_content_to_file",
         return_value=expected_file_path
     )
-    
+
     from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
-    
+
     result = export_namespace_asset_datasets(
         cmd=mocked_cmd,
         asset_name=asset_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
     )
-    
+
     # Verify export succeeded
     assert result == {"file_path": expected_file_path}
-    
+
     # Verify complex configuration is preserved but dataPoints removed
     exported_datasets = mock_dump.call_args[1]["content"]
     assert len(exported_datasets) == 1
@@ -1939,11 +1939,11 @@ def test_import_dataset_datapoints_into_empty_dataset(
     instance_name = generate_random_string()
     instance_resource_group = generate_random_string()
     input_file = "/tmp/first_datapoints.json"
-    
+
     namespace_resource = mocked_get_namespace_for_instance.return_value
     namespace_name = namespace_resource["name"]
     namespace_resource_group = namespace_resource["resource_group"]
-    
+
     # Dataset with no datapoints
     mock_asset_record = get_namespace_asset_record(
         asset_name=asset_name,
@@ -1953,19 +1953,19 @@ def test_import_dataset_datapoints_into_empty_dataset(
     mock_asset_record["properties"]["datasets"] = [
         {"name": dataset_name, "dataPoints": []}  # Empty
     ]
-    
+
     # File contains first datapoints
     new_datapoints = [
         {"name": "dp1", "dataSource": "source1"},
         {"name": "dp2", "dataSource": "source2"},
         {"name": "dp3", "dataSource": "source3"}
     ]
-    
-    mock_process = mocker.patch(
+
+    mocker.patch(
         "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
         return_value=new_datapoints
     )
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -1977,10 +1977,10 @@ def test_import_dataset_datapoints_into_empty_dataset(
         status=200,
         content_type="application/json",
     )
-    
+
     updated_asset = deepcopy(mock_asset_record)
     updated_asset["properties"]["datasets"][0]["dataPoints"] = new_datapoints
-    
+
     mocked_responses.add(
         method=responses.PATCH,
         url=get_namespace_asset_mgmt_uri(
@@ -1992,7 +1992,7 @@ def test_import_dataset_datapoints_into_empty_dataset(
         status=200,
         content_type="application/json",
     )
-    
+
     mocked_responses.add(
         method=responses.GET,
         url=get_namespace_asset_mgmt_uri(
@@ -2004,9 +2004,9 @@ def test_import_dataset_datapoints_into_empty_dataset(
         status=200,
         content_type="application/json",
     )
-    
+
     from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
-    
+
     result = import_namespace_asset_dataset_points(
         cmd=mocked_cmd,
         asset_name=asset_name,
@@ -2016,7 +2016,7 @@ def test_import_dataset_datapoints_into_empty_dataset(
         input_file=input_file,
         wait_sec=0
     )
-    
+
     # All datapoints should be imported
     assert result == new_datapoints
     assert len(result) == 3

--- a/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
@@ -932,3 +932,1091 @@ def assert_asset_properties(result_props: dict, expected: dict):
     for key in expected_configs:
         assert key in result_props
         assert result_props[key] == expected_configs[key]
+
+
+# ==================== EXPORT/IMPORT TESTS ====================
+
+def test_export_namespace_asset_dataset_datapoints(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """Test exporting datapoints from a dataset to JSON file."""
+    asset_name = generate_random_string()
+    dataset_name = "temperatureDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Create mock asset with dataset and datapoints
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": dataset_name,
+            "dataPoints": [
+                {
+                    "name": "temperature1",
+                    "dataSource": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1",
+                    "dataPointConfiguration": json.dumps({"samplingInterval": 1000, "queueSize": 10})
+                },
+                {
+                    "name": "temperature2",
+                    "dataSource": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt2",
+                    "dataPointConfiguration": json.dumps({"samplingInterval": 2000, "queueSize": 20})
+                }
+            ]
+        }
+    ]
+    
+    # Mock GET asset response
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock dump_content_to_file
+    expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.json"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
+    
+    result = export_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format="json",
+        output_dir="."
+    )
+    
+    # Verify result
+    assert result == {"file_path": expected_file_path}
+    
+    # Verify dump_content_to_file was called with correct datapoints
+    assert mock_dump.call_count == 1
+    call_kwargs = mock_dump.call_args[1]
+    assert call_kwargs["content"] == mock_asset_record["properties"]["datasets"][0]["dataPoints"]
+    assert call_kwargs["file_name"] == f"{asset_name}_datapoint_{dataset_name}"
+    assert call_kwargs["extension"] == "json"
+    assert call_kwargs["output_dir"] == "."
+
+
+def test_export_namespace_asset_dataset_datapoints_csv(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """Test exporting datapoints to CSV format."""
+    asset_name = generate_random_string()
+    dataset_name = "pressureDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": dataset_name,
+            "dataPoints": [
+                {"name": "pressure1", "dataSource": "source1"},
+                {"name": "pressure2", "dataSource": "source2"}
+            ]
+        }
+    ]
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.csv"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
+    
+    result = export_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format="csv",
+        output_dir="."
+    )
+    
+    assert result == {"file_path": expected_file_path}
+    assert mock_dump.call_count == 1
+    call_kwargs = mock_dump.call_args[1]
+    assert call_kwargs["extension"] == "csv"
+
+
+def test_import_namespace_asset_dataset_datapoints(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocked_check_cluster_connectivity,
+    mocker
+):
+    """Test importing datapoints from a JSON file."""
+    asset_name = generate_random_string()
+    dataset_name = "importDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    input_file = "/tmp/datapoints.json"
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Existing asset with one datapoint
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": dataset_name,
+            "dataPoints": [
+                {"name": "existing1", "dataSource": "existingSource"}
+            ]
+        }
+    ]
+    
+    # File contains new datapoints
+    file_datapoints = [
+        {"name": "new1", "dataSource": "newSource1"},
+        {"name": "new2", "dataSource": "newSource2"}
+    ]
+    
+    # Mock _process_asset_sub_points_file_path (merge logic)
+    # This function internally handles file deserialization
+    merged_datapoints = [
+        {"name": "existing1", "dataSource": "existingSource"},
+        {"name": "new1", "dataSource": "newSource1"},
+        {"name": "new2", "dataSource": "newSource2"}
+    ]
+    mock_process = mocker.patch(
+        "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
+        return_value=merged_datapoints
+    )
+    
+    # Mock GET asset response (initial)
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock PATCH update response
+    updated_asset = deepcopy(mock_asset_record)
+    updated_asset["properties"]["datasets"][0]["dataPoints"] = merged_datapoints
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock GET asset response (final)
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
+    
+    result = import_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        wait_sec=0
+    )
+    
+    # Verify result contains merged datapoints
+    assert result == merged_datapoints
+    
+    # Verify _process_asset_sub_points_file_path was called with correct parameters
+    mock_process.assert_called_once()
+    call_kwargs = mock_process.call_args[1]
+    assert call_kwargs["file_path"] == input_file
+    assert call_kwargs["point_key"] == "name"
+    assert call_kwargs["replace"] is False
+
+
+def test_export_namespace_asset_datasets(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """Test exporting all datasets from an asset to JSON file."""
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Create mock asset with multiple datasets
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": "dataset1",
+            "datasetConfiguration": json.dumps({"publishingInterval": 1000}),
+            "dataPoints": [
+                {"name": "dp1", "dataSource": "source1"}
+            ]
+        },
+        {
+            "name": "dataset2",
+            "datasetConfiguration": json.dumps({"publishingInterval": 2000}),
+            "dataPoints": [
+                {"name": "dp2", "dataSource": "source2"}
+            ]
+        }
+    ]
+    
+    # Mock GET asset response
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock dump_content_to_file
+    expected_file_path = f"./{asset_name}_dataset.json"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
+    
+    result = export_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format="json",
+        output_dir="."
+    )
+    
+    # Verify result
+    assert result == {"file_path": expected_file_path}
+    
+    # Verify dump_content_to_file was called with datasets WITHOUT dataPoints
+    assert mock_dump.call_count == 1
+    call_kwargs = mock_dump.call_args[1]
+    exported_datasets = call_kwargs["content"]
+    
+    # Check that dataPoints are removed
+    for dataset in exported_datasets:
+        assert "dataPoints" not in dataset
+        assert dataset["name"] in ["dataset1", "dataset2"]
+        assert "datasetConfiguration" in dataset
+
+
+def test_export_namespace_asset_datasets_yaml(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """Test exporting datasets to YAML format."""
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {"name": "dataset1", "dataPoints": []}
+    ]
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    expected_file_path = f"./{asset_name}_dataset.yaml"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
+    
+    result = export_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        format="yaml",
+        output_dir="."
+    )
+    
+    assert result == {"file_path": expected_file_path}
+    call_kwargs = mock_dump.call_args[1]
+    assert call_kwargs["extension"] == "yaml"
+
+
+def test_import_namespace_asset_datasets(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocked_check_cluster_connectivity,
+    mocker
+):
+    """Test importing datasets from a JSON file."""
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    input_file = "/tmp/datasets.json"
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Existing asset with one dataset
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": "existingDataset",
+            "dataPoints": [{"name": "existingDp", "dataSource": "existingSource"}]
+        }
+    ]
+    
+    # File contains new datasets
+    file_datasets = [
+        {"name": "newDataset1", "datasetConfiguration": json.dumps({"publishingInterval": 1000})},
+        {"name": "newDataset2", "datasetConfiguration": json.dumps({"publishingInterval": 2000})}
+    ]
+    
+    # Mock deserialize_file_content
+    mock_deserialize = mocker.patch(
+        "azext_edge.edge.util.deserialize_file_content",
+        return_value=file_datasets
+    )
+    
+    # Mock GET asset response (initial)
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock PATCH update response
+    updated_asset = deepcopy(mock_asset_record)
+    # Merge logic: keep existing, add new datasets
+    updated_asset["properties"]["datasets"] = [
+        mock_asset_record["properties"]["datasets"][0],  # existing
+        file_datasets[0],  # new1
+        file_datasets[1]   # new2
+    ]
+    
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Mock GET asset response (final)
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import import_namespace_asset_datasets
+    
+    result = import_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        wait_sec=0
+    )
+    
+    # Verify result contains all datasets
+    assert len(result) == 3
+    dataset_names = [ds["name"] for ds in result]
+    assert "existingDataset" in dataset_names
+    assert "newDataset1" in dataset_names
+    assert "newDataset2" in dataset_names
+    
+    # Verify mocks were called
+    mock_deserialize.assert_called_once_with(file_path=input_file)
+
+
+# ==================== EDGE CASE TESTS ====================
+
+def test_export_dataset_datapoints_dataset_not_found(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+):
+    """
+    Test exporting datapoints when the specified dataset doesn't exist.
+    WHY: Validates proper error handling when user specifies wrong dataset name.
+    """
+    asset_name = generate_random_string()
+    dataset_name = "nonexistentDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Asset has no matching dataset
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {"name": "otherDataset", "dataPoints": []}
+    ]
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
+    
+    # Should raise InvalidArgumentValueError
+    with pytest.raises(InvalidArgumentValueError) as exc_info:
+        export_namespace_asset_dataset_points(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            dataset_name=dataset_name,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+    
+    assert f"Dataset '{dataset_name}' not found" in str(exc_info.value)
+
+
+def test_export_dataset_datapoints_empty_datapoints(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """
+    Test exporting when dataset has no datapoints.
+    WHY: Ensures system handles empty collections gracefully (common in new assets).
+    """
+    asset_name = generate_random_string()
+    dataset_name = "emptyDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {"name": dataset_name, "dataPoints": []}  # Empty array
+    ]
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    expected_file_path = f"./{asset_name}_datapoint_{dataset_name}.json"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_dataset_points
+    
+    result = export_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+    )
+    
+    # Should still succeed and export empty array
+    assert result == {"file_path": expected_file_path}
+    call_kwargs = mock_dump.call_args[1]
+    assert call_kwargs["content"] == []
+
+
+def test_import_dataset_datapoints_all_duplicates(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocked_check_cluster_connectivity,
+    mocker
+):
+    """
+    Test importing when all datapoints from file are duplicates.
+    WHY: Validates skip-duplicate logic doesn't break when nothing needs importing.
+    """
+    asset_name = generate_random_string()
+    dataset_name = "dataset1"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    input_file = "/tmp/duplicates.json"
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Existing datapoints
+    existing_datapoints = [
+        {"name": "dp1", "dataSource": "source1"},
+        {"name": "dp2", "dataSource": "source2"}
+    ]
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {"name": dataset_name, "dataPoints": existing_datapoints}
+    ]
+    
+    # Mock returns same datapoints (all duplicates skipped)
+    mock_process = mocker.patch(
+        "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
+        return_value=existing_datapoints
+    )
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Update response (no changes)
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
+    
+    result = import_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        wait_sec=0
+    )
+    
+    # Result should be unchanged
+    assert result == existing_datapoints
+    assert len(result) == 2
+
+
+def test_export_datasets_no_datasets(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """
+    Test exporting when asset has no datasets at all.
+    WHY: New assets or certain asset types may have no datasets - must handle gracefully.
+    """
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = []  # No datasets
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    expected_file_path = f"./{asset_name}_dataset.json"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
+    
+    result = export_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+    )
+    
+    assert result == {"file_path": expected_file_path}
+    call_kwargs = mock_dump.call_args[1]
+    assert call_kwargs["content"] == []
+
+
+def test_import_datasets_duplicate_skip(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocked_check_cluster_connectivity,
+    mocker
+):
+    """
+    Test that duplicate datasets are properly skipped during import.
+    WHY: Prevents accidental overwrites - user should see warning, data preserved.
+    """
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    input_file = "/tmp/datasets_with_dup.json"
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    existing_dataset = {
+        "name": "dataset1",
+        "dataPoints": [{"name": "existingDp", "dataSource": "existingSource"}]
+    }
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [existing_dataset]
+    
+    # File contains: 1 duplicate (dataset1) + 1 new (dataset2)
+    file_datasets = [
+        {"name": "dataset1", "datasetConfiguration": json.dumps({"publishingInterval": 9999})},  # Duplicate
+        {"name": "dataset2", "datasetConfiguration": json.dumps({"publishingInterval": 2000})}   # New
+    ]
+    
+    mock_deserialize = mocker.patch(
+        "azext_edge.edge.util.deserialize_file_content",
+        return_value=file_datasets
+    )
+    
+    # Mock logger to verify warning is logged
+    mock_logger = mocker.patch("azext_edge.edge.providers.adr.namespace_assets.logger")
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    # Updated asset: existing dataset unchanged, only new dataset added
+    updated_asset = deepcopy(mock_asset_record)
+    updated_asset["properties"]["datasets"] = [
+        existing_dataset,  # Original preserved
+        {"name": "dataset2", "dataPoints": [], "datasetConfiguration": json.dumps({"publishingInterval": 2000})}
+    ]
+    
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import import_namespace_asset_datasets
+    
+    result = import_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        wait_sec=0
+    )
+    
+    # Verify: 2 datasets total, duplicate was skipped
+    assert len(result) == 2
+    dataset_names = [ds["name"] for ds in result]
+    assert "dataset1" in dataset_names
+    assert "dataset2" in dataset_names
+    
+    # Verify existing dataset is unchanged (not overwritten)
+    existing_in_result = next(ds for ds in result if ds["name"] == "dataset1")
+    assert existing_in_result == existing_dataset
+    
+    # Verify warning was logged for duplicate
+    mock_logger.warning.assert_called_once()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "dataset1" in warning_msg
+    assert "already exists" in warning_msg
+
+
+def test_export_datasets_with_complex_configurations(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocker
+):
+    """
+    Test exporting datasets with complex nested configurations.
+    WHY: Real-world datasets have nested JSON configs - ensure proper serialization.
+    """
+    asset_name = generate_random_string()
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Complex dataset with nested configurations
+    complex_config = {
+        "publishingInterval": 1000,
+        "samplingInterval": 500,
+        "queueSize": 10,
+        "advanced": {
+            "compression": "gzip",
+            "encryption": {"enabled": True, "algorithm": "AES256"}
+        }
+    }
+    
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {
+            "name": "complexDataset",
+            "datasetConfiguration": json.dumps(complex_config),
+            "dataPoints": [{"name": "dp1", "dataSource": "src1"}]  # Will be removed in export
+        }
+    ]
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    expected_file_path = f"./{asset_name}_dataset.json"
+    mock_dump = mocker.patch(
+        "azext_edge.edge.util.dump_content_to_file",
+        return_value=expected_file_path
+    )
+    
+    from azext_edge.edge.commands_namespaces import export_namespace_asset_datasets
+    
+    result = export_namespace_asset_datasets(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+    )
+    
+    # Verify export succeeded
+    assert result == {"file_path": expected_file_path}
+    
+    # Verify complex configuration is preserved but dataPoints removed
+    exported_datasets = mock_dump.call_args[1]["content"]
+    assert len(exported_datasets) == 1
+    assert "dataPoints" not in exported_datasets[0]
+    assert exported_datasets[0]["datasetConfiguration"] == json.dumps(complex_config)
+
+
+def test_import_dataset_datapoints_into_empty_dataset(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_namespace_for_instance,
+    mocked_check_cluster_connectivity,
+    mocker
+):
+    """
+    Test importing datapoints into a dataset that has no existing datapoints.
+    WHY: Common scenario for newly created datasets - all imports should succeed.
+    """
+    asset_name = generate_random_string()
+    dataset_name = "newDataset"
+    instance_name = generate_random_string()
+    instance_resource_group = generate_random_string()
+    input_file = "/tmp/first_datapoints.json"
+    
+    namespace_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = namespace_resource["name"]
+    namespace_resource_group = namespace_resource["resource_group"]
+    
+    # Dataset with no datapoints
+    mock_asset_record = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=namespace_resource_group
+    )
+    mock_asset_record["properties"]["datasets"] = [
+        {"name": dataset_name, "dataPoints": []}  # Empty
+    ]
+    
+    # File contains first datapoints
+    new_datapoints = [
+        {"name": "dp1", "dataSource": "source1"},
+        {"name": "dp2", "dataSource": "source2"},
+        {"name": "dp3", "dataSource": "source3"}
+    ]
+    
+    mock_process = mocker.patch(
+        "azext_edge.edge.providers.adr.assets._process_asset_sub_points_file_path",
+        return_value=new_datapoints
+    )
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=mock_asset_record,
+        status=200,
+        content_type="application/json",
+    )
+    
+    updated_asset = deepcopy(mock_asset_record)
+    updated_asset["properties"]["datasets"][0]["dataPoints"] = new_datapoints
+    
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_asset_mgmt_uri(
+            asset_name=asset_name,
+            namespace_name=namespace_name,
+            resource_group_name=namespace_resource_group
+        ),
+        json=updated_asset,
+        status=200,
+        content_type="application/json",
+    )
+    
+    from azext_edge.edge.commands_namespaces import import_namespace_asset_dataset_points
+    
+    result = import_namespace_asset_dataset_points(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        dataset_name=dataset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        input_file=input_file,
+        wait_sec=0
+    )
+    
+    # All datapoints should be imported
+    assert result == new_datapoints
+    assert len(result) == 3

--- a/azext_edge/tests/edge/adr/test_validator_int.py
+++ b/azext_edge/tests/edge/adr/test_validator_int.py
@@ -1,0 +1,517 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""
+Integration tests for ConnectorMetadataValidator.
+These tests validate the complete flow: Asset → Device → Connector Template → OCI Metadata → Validation
+"""
+
+import pytest
+import json
+from unittest.mock import patch, MagicMock, Mock
+from azext_edge.edge.providers.adr.validator import ConnectorMetadataValidator
+from azure.cli.core.azclierror import ValidationError
+
+pytestmark = pytest.mark.integration
+
+
+# Real metadata examples from actual connector metadata files
+REST_HTTP_METADATA = {
+    "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+    "name": "Azure IoT Operations connector for REST/HTTP",
+    "version": "1.0.5",
+    "inboundEndpoints": [
+        {
+            "endpointType": "Microsoft.Http",
+            "version": "1.0",
+            "datasets": {
+                "datasetConfigurationSchema": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "title": "REST Dataset Config Schema",
+                    "type": "object",
+                    "properties": {
+                        "samplingIntervalInMilliseconds": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 18446744073709551615
+                        },
+                        "transform": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "fields": {
+                    "dataSource": {
+                        "input": "required"
+                    }
+                }
+            }
+        }
+    ]
+}
+
+ONVIF_METADATA = {
+    "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+    "name": "Azure IoT Operations connector for ONVIF",
+    "version": "1.2.37",
+    "inboundEndpoints": [
+        {
+            "endpointType": "Microsoft.Onvif",
+            "additionalConfigurationSchema": {
+                "type": "object",
+                "properties": {
+                    "acceptInvalidHostnames": {
+                        "type": "boolean",
+                        "default": False
+                    },
+                    "acceptInvalidCertificates": {
+                        "type": "boolean",
+                        "default": False
+                    }
+                },
+                "required": []
+            },
+            "eventGroups": {
+                "events": {
+                    "eventConfigurationSchema": {}
+                }
+            },
+            "managementGroups": {
+                "managementGroupConfigurationSchema": {},
+                "managementGroupActions": {
+                    "actionConfigurationSchema": {}
+                }
+            }
+        }
+    ]
+}
+
+
+class TestConnectorMetadataValidatorIntegration:
+    """Integration tests for ConnectorMetadataValidator with the complete lookup flow."""
+
+    def setup_method(self):
+        """Reset the metadata cache before each test."""
+        ConnectorMetadataValidator._METADATA_CACHE.clear()
+
+    def _create_mock_cmd(self):
+        """Helper to create a mock cmd object."""
+        cmd = Mock()
+        cmd.cli_ctx = Mock()
+        cmd.cli_ctx.cloud = Mock()
+        cmd.cli_ctx.cloud.endpoints = Mock()
+        cmd.cli_ctx.cloud.endpoints.resource_manager = "https://management.azure.com"
+        cmd.cli_ctx.data = {"subscription_id": "eab4c10d-b020-4cb2-8959-d53cf2df388d"}
+        return cmd
+
+    def _create_mock_connector_template(self, endpoint_type, version=None, metadata_ref=None):
+        """Helper to create a mock connector template response."""
+        return {
+            "name": f"{endpoint_type.lower()}-connector-template",
+            "properties": {
+                "deviceInboundEndpointTypes": [
+                    {
+                        "endpointType": endpoint_type,
+                        "version": version
+                    }
+                ],
+                "connectorMetadataRef": metadata_ref or f"mcr.microsoft.com/azureiotoperations/akri-connectors/{endpoint_type.lower()}-metadata:1.0.0"
+            }
+        }
+
+    # ========== Direct Constructor with Metadata Lookup Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_rest_constructor_with_connector_template_lookup(self, mock_get_client):
+        """Test the complete flow: constructor → list templates → fetch OCI → validate."""
+        cmd = self._create_mock_cmd()
+        
+        # Mock IoT Ops client
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # Mock connector template list
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[
+                self._create_mock_connector_template("Microsoft.Http", "1.0", 
+                    "mcr.microsoft.com/azureiotoperations/akri-connectors/rest-metadata:1.0.5")
+            ]
+        )
+        
+        # Mock OCI fetch
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="doe-int-e2e-2510",
+                instance_name="aio-141713881",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            # Verify metadata was fetched
+            assert validator.metadata == REST_HTTP_METADATA
+            assert "inboundEndpoints" in validator.metadata
+            
+            # Verify connector template was queried
+            mock_client.akri_connector_template.list_by_instance_resource.assert_called_once()
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_onvif_constructor_no_version(self, mock_get_client):
+        """Test ONVIF connector which typically has no version."""
+        cmd = self._create_mock_cmd()
+        
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        
+        # ONVIF template without version
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[
+                self._create_mock_connector_template("Microsoft.Onvif", None, 
+                    "mcr.microsoft.com/azureiotoperations/akri-connectors/onvif-metadata:1.2.37")
+            ]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=ONVIF_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="doe-int-e2e-2510",
+                instance_name="aio-141713881",
+                endpoint_type="Microsoft.Onvif",
+                endpoint_version=None
+            )
+            
+            assert validator.metadata == ONVIF_METADATA
+            assert validator.endpoint_version is None
+
+    # ========== Dataset Validation Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_validate_rest_dataset_valid(self, mock_get_client):
+        """Test REST dataset validation with valid configuration."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Http", "1.0")]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            valid_config = {
+                "samplingIntervalInMilliseconds": 5000,
+                "transform": "http://example.com/transform.wasm"
+            }
+            
+            # Should not raise
+            validator.validate_dataset(valid_config)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_validate_rest_dataset_invalid_negative_interval(self, mock_get_client):
+        """Test REST dataset validation fails with negative sampling interval."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Http", "1.0")]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            invalid_config = {
+                "samplingIntervalInMilliseconds": -100
+            }
+            
+            with pytest.raises(ValidationError) as exc_info:
+                validator.validate_dataset(invalid_config)
+            assert "Dataset configuration is invalid" in str(exc_info.value)
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_validate_rest_dataset_invalid_zero_interval(self, mock_get_client):
+        """Test REST dataset validation fails with zero (exclusiveMinimum)."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Http", "1.0")]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            invalid_config = {
+                "samplingIntervalInMilliseconds": 0
+            }
+            
+            with pytest.raises(ValidationError):
+                validator.validate_dataset(invalid_config)
+
+    # ========== Event Validation Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_validate_onvif_event_empty_schema(self, mock_get_client):
+        """Test ONVIF event validation with empty schema (allows anything)."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Onvif", None)]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=ONVIF_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Onvif",
+                endpoint_version=None
+            )
+            
+            # Empty schema should allow any object
+            config = {"filter": "Topic = 'motion'"}
+            validator.validate_event(config)
+
+    # ========== Schema Extraction Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_get_schema_dataset_configuration(self, mock_get_client):
+        """Test extracting dataset configuration schema."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Http", "1.0")]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            schema = validator._get_schema("datasetConfigurationSchema")
+            assert schema is not None
+            assert "samplingIntervalInMilliseconds" in schema["properties"]
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_get_schema_additional_configuration(self, mock_get_client):
+        """Test extracting additional configuration schema."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Onvif", None)]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=ONVIF_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Onvif",
+                endpoint_version=None
+            )
+            
+            schema = validator._get_schema("additionalConfigurationSchema")
+            assert schema is not None
+            assert "acceptInvalidHostnames" in schema["properties"]
+
+    # ========== OCI Artifact Fetching Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator._get_auth_token')
+    @patch('azext_edge.edge.providers.adr.validator.requests.get')
+    def test_fetch_oci_artifact_success(self, mock_get, mock_get_auth_token):
+        """Test successful OCI artifact fetching."""
+        # Mock auth token
+        mock_get_auth_token.return_value = None  # Anonymous access
+        
+        # Mock manifest response
+        manifest_response = Mock()
+        manifest_response.status_code = 200
+        manifest_response.json.return_value = {
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": "sha256:config123"
+            },
+            "layers": [
+                {
+                    "mediaType": "application/vnd.microsoft.akri-connector.v1+json",
+                    "digest": "sha256:abc123"
+                }
+            ]
+        }
+        
+        # Mock blob response
+        blob_response = Mock()
+        blob_response.status_code = 200
+        blob_response.json.return_value = REST_HTTP_METADATA
+        
+        mock_get.side_effect = [manifest_response, blob_response]
+        
+        result = ConnectorMetadataValidator.fetch_oci_artifact("mcr.microsoft.com/azureiotoperations/akri-connectors/rest-metadata:1.0.5")
+        
+        assert result == REST_HTTP_METADATA
+        assert mock_get.call_count == 2
+
+    def test_fetch_oci_artifact_invalid_reference(self):
+        """Test OCI artifact fetching with invalid reference."""
+        with pytest.raises(ValidationError) as exc_info:
+            ConnectorMetadataValidator.fetch_oci_artifact("invalid-reference")
+        assert "Invalid OCI reference" in str(exc_info.value)
+
+    @patch('azext_edge.edge.providers.adr.validator.requests.get')
+    def test_fetch_oci_artifact_manifest_not_found(self, mock_get):
+        """Test OCI artifact fetching when manifest is not found."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_get.return_value = mock_response
+        
+        with pytest.raises(ValidationError) as exc_info:
+            ConnectorMetadataValidator.fetch_oci_artifact("mcr.microsoft.com/repo:tag")
+        assert "Failed to fetch manifest" in str(exc_info.value)
+
+    # ========== Caching Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_metadata_caching(self, mock_get_client):
+        """Test that metadata is cached and not fetched multiple times."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[self._create_mock_connector_template("Microsoft.Http", "1.0")]
+        )
+        
+        with patch.object(ConnectorMetadataValidator, 'fetch_oci_artifact', return_value=REST_HTTP_METADATA) as mock_fetch:
+            # First validator
+            validator1 = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            # Second validator with same endpoint type/version
+            validator2 = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            # OCI fetch should only happen once
+            assert mock_fetch.call_count == 1
+            assert validator1.metadata == validator2.metadata
+
+    # ========== Error Handling Tests ==========
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_no_matching_connector_template(self, mock_get_client):
+        """Test graceful handling when no connector template matches."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(
+            return_value=[]  # No templates
+        )
+        
+        validator = ConnectorMetadataValidator(
+            cmd=cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Unknown",
+            endpoint_version="1.0"
+        )
+        
+        # Should return empty metadata
+        assert validator.metadata == {}
+        
+        # Validation should be skipped
+        validator.validate_dataset({"any": "data"})  # Should not raise
+
+    @patch('azext_edge.edge.providers.adr.validator.get_iotops_mgmt_client')
+    def test_connector_template_missing_metadata_ref(self, mock_get_client):
+        """Test handling when connector template has no connectorMetadataRef."""
+        cmd = self._create_mock_cmd()
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.akri_connector_template = Mock()
+        
+        # Template without connectorMetadataRef
+        template = {
+            "name": "broken-template",
+            "properties": {
+                "deviceInboundEndpointTypes": [
+                    {"endpointType": "Microsoft.Http", "version": "1.0"}
+                ]
+                # Missing connectorMetadataRef
+            }
+        }
+        mock_client.akri_connector_template.list_by_instance_resource = Mock(return_value=[template])
+        
+        validator = ConnectorMetadataValidator(
+            cmd=cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Http",
+            endpoint_version="1.0"
+        )
+        
+        assert validator.metadata == {}
+
+    def test_validator_no_jsonschema_library(self):
+        """Test validator gracefully handles missing jsonschema library."""
+        cmd = self._create_mock_cmd()
+        
+        with patch.object(ConnectorMetadataValidator, '_get_metadata', return_value=REST_HTTP_METADATA):
+            validator = ConnectorMetadataValidator(
+                cmd=cmd,
+                resource_group_name="test-rg",
+                instance_name="test-instance",
+                endpoint_type="Microsoft.Http",
+                endpoint_version="1.0"
+            )
+            
+            # Mock ImportError for jsonschema
+            with patch('jsonschema.validate', side_effect=ImportError):
+                config = {"samplingIntervalInMilliseconds": 1000}
+                # Should not raise, just log warning
+                validator.validate_dataset(config)

--- a/azext_edge/tests/edge/adr/test_validator_unit.py
+++ b/azext_edge/tests/edge/adr/test_validator_unit.py
@@ -1,0 +1,206 @@
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import patch, MagicMock, Mock
+from azext_edge.edge.providers.adr.validator import ConnectorMetadataValidator
+from azure.cli.core.azclierror import ValidationError
+
+# Mock Metadata for REST
+REST_METADATA = {
+  "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+  "name": "Azure IoT Operations connector for REST/HTTP",
+  "version": "1.0.4",
+  "inboundEndpoints": [
+    {
+      "endpointType": "Microsoft.Http",
+      "version": "1.0",
+      "datasets": {
+        "datasetConfigurationSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "REST Dataset Config Schema",
+          "type": "object",
+          "properties": {
+            "samplingIntervalInMilliseconds": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "transform": {
+              "type": "string"
+            }
+          },
+          "required": ["samplingIntervalInMilliseconds"]
+        }
+      }
+    }
+  ]
+}
+
+# Mock Metadata for ONVIF
+ONVIF_METADATA = {
+  "$schema": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json",
+  "name": "Azure IoT Operations connector for ONVIF",
+  "version": "1.2.37",
+  "inboundEndpoints": [
+    {
+      "endpointType": "Microsoft.Onvif",
+      "additionalConfigurationSchema": {
+        "type": "object",
+        "properties": {
+          "acceptInvalidHostnames": {
+            "type": "boolean"
+          }
+        }
+      },
+      "eventGroups": {
+        "events": {
+          "eventConfigurationSchema": {
+             "type": "object",
+             "properties": {
+                 "filter": {"type": "string"}
+             }
+          }
+        }
+      }
+    }
+  ]
+}
+
+class TestConnectorMetadataValidator(unittest.TestCase):
+
+    def setUp(self):
+        # Patch _get_metadata to avoid network calls or complex lookup logic during init
+        self.patcher = patch('azext_edge.edge.providers.adr.validator.ConnectorMetadataValidator._get_metadata')
+        self.mock_get_metadata = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_validate_dataset_rest_valid(self):
+        self.mock_get_metadata.return_value = REST_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Http",
+            endpoint_version="1.0"
+        )
+        
+        valid_config = {
+            "samplingIntervalInMilliseconds": 1000,
+            "transform": "http://example.com/transform.wasm"
+        }
+        
+        # Should not raise exception
+        validator.validate_dataset(valid_config)
+
+    def test_validate_dataset_rest_invalid(self):
+        self.mock_get_metadata.return_value = REST_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Http",
+            endpoint_version="1.0"
+        )
+        
+        invalid_config = {
+            "samplingIntervalInMilliseconds": -10 # Invalid: exclusiveMinimum 0
+        }
+        
+        with self.assertRaises(ValidationError) as cm:
+            validator.validate_dataset(invalid_config)
+        self.assertIn("Dataset configuration is invalid", str(cm.exception))
+
+    def test_validate_dataset_rest_missing_required(self):
+        self.mock_get_metadata.return_value = REST_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Http",
+            endpoint_version="1.0"
+        )
+        
+        invalid_config = {
+            "transform": "http://example.com/transform.wasm"
+        }
+        # Missing samplingIntervalInMilliseconds
+        
+        with self.assertRaises(ValidationError) as cm:
+            validator.validate_dataset(invalid_config)
+        self.assertIn("Dataset configuration is invalid", str(cm.exception))
+
+    def test_validate_event_onvif_valid(self):
+        self.mock_get_metadata.return_value = ONVIF_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Onvif",
+            endpoint_version="1.0"
+        )
+        
+        valid_config = {
+            "filter": "Topic = 'motion'"
+        }
+        
+        validator.validate_event(valid_config)
+
+    def test_validate_event_onvif_invalid(self):
+        self.mock_get_metadata.return_value = ONVIF_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Onvif",
+            endpoint_version="1.0"
+        )
+        
+        invalid_config = {
+            "filter": 123 # Should be string
+        }
+        
+        with self.assertRaises(ValidationError):
+            validator.validate_event(invalid_config)
+
+    def test_get_schema_traversal(self):
+        self.mock_get_metadata.return_value = ONVIF_METADATA
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Onvif",
+            endpoint_version="1.0"
+        )
+        
+        # Test additionalConfigurationSchema extraction
+        schema = validator._get_schema("additionalConfigurationSchema")
+        self.assertIsNotNone(schema)
+        self.assertIn("acceptInvalidHostnames", schema["properties"])
+
+    def test_no_schema_found(self):
+        self.mock_get_metadata.return_value = REST_METADATA
+        # Wrong endpoint type
+        mock_cmd = Mock()
+        validator = ConnectorMetadataValidator(
+            cmd=mock_cmd,
+            resource_group_name="test-rg",
+            instance_name="test-instance",
+            endpoint_type="Microsoft.Mqtt",
+            endpoint_version="1.0"
+        )
+        
+        schema = validator._get_schema("datasetConfigurationSchema")
+        self.assertIsNone(schema)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "opentelemetry-proto~=1.20.0",
     "packaging>=23.2",
     "semver>=3.0.4,<4",
+    "jsonschema>=4.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Implements export/import functionality for ADR v2 namespace asset datasets and datapoints across all asset types (custom, OPC UA, REST), supporting multiple file formats (JSON, CSV, YAML).

- **namespace_assets.py**: Added 4 new methods
  - `export_dataset_datapoints()` - Export datapoints with CSV/JSON/YAML support
  - `import_dataset_datapoints()` - Import datapoints with duplicate-skip logic
  - `export_datasets()` - Export datasets (excludes dataPoints arrays)
  - `import_datasets()` - Import datasets with merge behavior
  
- **commands_namespaces.py**: Added 4 command wrappers for CLI entry points

- **command_map.py**: Registered new commands in existing command groups
  - `az iot ops ns asset {custom|opcua|rest} datapoint {export|import}`
  - `az iot ops ns asset {custom|opcua|rest} dataset {export|import}`

- **params.py**: Added argument contexts with `--format`, `--output-dir`, `--input-file` parameters

- **_help.py**: Added comprehensive help documentation for all asset types

- **Unit tests** (13 tests, all passing)
  - 6 happy path tests covering JSON/CSV/YAML formats
  - 7 edge case tests (empty collections, duplicates, complex configs)
  
- **Integration tests** (5 new tests)
  - JSON roundtrip validation (custom assets)
  - CSV format DOE compatibility (OPC UA assets)
  - Bulk dataset export/import (REST assets)
  - Duplicate-skip merge logic verification
  - YAML format roundtrip

<img width="3833" height="2026" alt="image" src="https://github.com/user-attachments/assets/3c68b6ff-3f23-40ec-8666-916dd71a7843" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
