### PR TITLE
feat: Add MQTT connector support for namespaced assets and device endpoints

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -285,6 +285,7 @@ def load_iotops_commands(self, _):
         cmd_group.command("opcua", "add_inbound_opcua_device_endpoint")
         cmd_group.command("rest", "add_inbound_rest_device_endpoint")
         cmd_group.command("sse", "add_inbound_sse_device_endpoint")
+        cmd_group.command("mqtt", "add_inbound_mqtt_device_endpoint")
 
     with self.command_group(
         "iot ops ns asset",
@@ -295,7 +296,7 @@ def load_iotops_commands(self, _):
         cmd_group.show_command("show", "show_namespace_asset")
 
     # create and update
-    for asset_type in ["custom", "media", "onvif", "opcua", "rest", "sse"]:
+    for asset_type in ["custom", "media", "onvif", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(
             f"iot ops ns asset {asset_type}",
             command_type=namespace_resource_ops,
@@ -304,7 +305,7 @@ def load_iotops_commands(self, _):
             cmd_group.command("update", f"update_namespace_{asset_type}_asset")
 
     # dataset
-    for asset_type in ["custom", "opcua", "rest", "sse"]:
+    for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(
             f"iot ops ns asset {asset_type} dataset",
             command_type=namespace_resource_ops,

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -419,6 +419,30 @@ def add_inbound_sse_device_endpoint(
     )
 
 
+def add_inbound_mqtt_device_endpoint(
+    cmd,
+    device_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    endpoint_name: str,
+    endpoint_address: str,
+    endpoint_version: Optional[str] = None,
+    replace: Optional[bool] = False,
+    **kwargs
+):
+    return NamespaceDevices(cmd).add_inbound_endpoint(
+        device_name=device_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        endpoint_name=endpoint_name,
+        endpoint_type=DeviceEndpointType.MQTT.value,
+        endpoint_address=endpoint_address,
+        endpoint_version=endpoint_version,
+        replace=replace,
+        **kwargs
+    )
+
+
 def list_inbound_device_endpoints(
     cmd,
     device_name: str,
@@ -826,6 +850,58 @@ def create_namespace_sse_asset(
     )
 
 
+def create_namespace_mqtt_asset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    device_name: str,
+    device_endpoint_name: str,
+    asset_type_refs: Optional[List[str]] = None,
+    attributes: Optional[List[str]] = None,
+    dataset_destinations: Optional[str] = None,
+    description: Optional[str] = None,
+    disabled: Optional[bool] = None,
+    display_name: Optional[str] = None,
+    documentation_uri: Optional[str] = None,
+    external_asset_id: Optional[str] = None,
+    hardware_revision: Optional[str] = None,
+    manufacturer: Optional[str] = None,
+    manufacturer_uri: Optional[str] = None,
+    model: Optional[str] = None,
+    product_code: Optional[str] = None,
+    serial_number: Optional[str] = None,
+    software_revision: Optional[str] = None,
+    tags: Optional[Dict[str, str]] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).create(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        asset_type=DeviceEndpointType.MQTT.value,
+        device_name=device_name,
+        device_endpoint_name=device_endpoint_name,
+        dataset_destinations=dataset_destinations,
+        asset_type_refs=asset_type_refs,
+        attributes=attributes,
+        description=description,
+        disabled=disabled,
+        display_name=display_name,
+        documentation_uri=documentation_uri,
+        external_asset_id=external_asset_id,
+        hardware_revision=hardware_revision,
+        manufacturer=manufacturer,
+        manufacturer_uri=manufacturer_uri,
+        model=model,
+        product_code=product_code,
+        serial_number=serial_number,
+        software_revision=software_revision,
+        tags=tags,
+        **kwargs
+    )
+
+
 def show_namespace_asset(
     cmd,
     asset_name: str,
@@ -1203,6 +1279,54 @@ def update_namespace_sse_asset(
     )
 
 
+def update_namespace_mqtt_asset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_destinations: Optional[str] = None,
+    asset_type_refs: Optional[List[str]] = None,
+    attributes: Optional[List[str]] = None,
+    description: Optional[str] = None,
+    disabled: Optional[bool] = None,
+    display_name: Optional[str] = None,
+    documentation_uri: Optional[str] = None,
+    external_asset_id: Optional[str] = None,
+    hardware_revision: Optional[str] = None,
+    manufacturer: Optional[str] = None,
+    manufacturer_uri: Optional[str] = None,
+    model: Optional[str] = None,
+    product_code: Optional[str] = None,
+    serial_number: Optional[str] = None,
+    software_revision: Optional[str] = None,
+    tags: Optional[Dict[str, str]] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        asset_type=DeviceEndpointType.MQTT.value,
+        dataset_destinations=dataset_destinations,
+        asset_type_refs=asset_type_refs,
+        attributes=attributes,
+        description=description,
+        disabled=disabled,
+        display_name=display_name,
+        documentation_uri=documentation_uri,
+        external_asset_id=external_asset_id,
+        hardware_revision=hardware_revision,
+        manufacturer=manufacturer,
+        manufacturer_uri=manufacturer_uri,
+        model=model,
+        product_code=product_code,
+        serial_number=serial_number,
+        software_revision=software_revision,
+        tags=tags,
+        **kwargs
+    )
+
+
 def query_namespace_assets(
     cmd,
     asset_name: Optional[str] = None,
@@ -1328,6 +1452,7 @@ def add_namespace_rest_asset_dataset(
         data_source=data_source,
         rest_dataset_sampling_interval=rest_dataset_sampling_interval,
         dataset_destinations=dataset_destinations,
+        type_ref=type_ref,
         replace=replace,
         **kwargs
     )
@@ -1353,6 +1478,33 @@ def add_namespace_sse_asset_dataset(
         asset_type=DeviceEndpointType.SSE.value,
         data_source=data_source,
         dataset_destinations=dataset_destinations,
+        type_ref=type_ref,
+        replace=replace,
+        **kwargs
+    )
+
+
+def add_namespace_mqtt_asset_dataset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_name: str,
+    data_source: str,
+    dataset_destinations: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).add_dataset(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        asset_type=DeviceEndpointType.MQTT.value,
+        data_source=data_source,
+        dataset_destinations=dataset_destinations,
+        type_ref=type_ref,
         replace=replace,
         **kwargs
     )
@@ -1479,6 +1631,26 @@ def update_namespace_sse_asset_dataset(
         instance_resource_group=instance_resource_group,
         dataset_name=dataset_name,
         asset_type=DeviceEndpointType.SSE.value,
+        dataset_destinations=dataset_destinations,
+        **kwargs
+    )
+
+
+def update_namespace_mqtt_asset_dataset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_name: str,
+    dataset_destinations: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update_dataset(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        asset_type=DeviceEndpointType.MQTT.value,
         dataset_destinations=dataset_destinations,
         **kwargs
     )

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -870,6 +870,25 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns device endpoint inbound add mqtt"
+    ] = """
+        type: command
+        short-summary: Add an MQTT inbound endpoint to a device in a Device Registry namespace.
+
+        examples:
+        - name: Add a basic MQTT endpoint to a device connecting to in-cluster broker
+          text: >
+            az iot ops ns device endpoint inbound add mqtt --device mydevice --instance myInstance
+            -g myInstanceResourceGroup --name myMqttEndpoint --endpoint-address "aio-broker:18883"
+
+        - name: Add an MQTT endpoint with version specification
+          text: >
+            az iot ops ns device endpoint inbound add mqtt --device mydevice --instance myInstance
+            -g myInstanceResourceGroup --name myMqttEndpoint --endpoint-address "aio-broker:18883"
+            --version "0.3.4"
+    """
+
+    helps[
         "iot ops ns asset"
     ] = """
         type: group
@@ -3071,4 +3090,141 @@ def load_iotops_adr_help():
           text: >
             az iot ops ns asset sse event remove --asset mysseAsset --instance myInstance
             -g myInstanceResourceGroup --event-group alertEvents --name temperature
+    """
+
+    # MQTT connector help
+    helps[
+        "iot ops ns asset mqtt"
+    ] = """
+        type: group
+        short-summary: Manage namespaced assets that point to MQTT device endpoints.
+    """
+
+    helps[
+        "iot ops ns asset mqtt create"
+    ] = """
+        type: command
+        short-summary: Create an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Create a basic MQTT asset
+          text: >
+            az iot ops ns asset mqtt create --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --device myMqttDevice --endpoint myMqttEndpoint
+
+        - name: Create an MQTT asset with dataset destination
+          text: >
+            az iot ops ns asset mqtt create --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --device myMqttDevice --endpoint myMqttEndpoint
+            --dataset-dest topic="factory/mqtt/data" retain=Never qos=Qos1 ttl=3600
+
+        - name: Create an MQTT asset with BrokerStateStore destination
+          text: >
+            az iot ops ns asset mqtt create --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --device myMqttDevice --endpoint myMqttEndpoint
+            --dataset-dest key="mqtt-data-cache"
+
+        - name: Create an MQTT asset with metadata
+          text: >
+            az iot ops ns asset mqtt create --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --device myMqttDevice --endpoint myMqttEndpoint --description "In-cluster MQTT topic subscriber"
+            --display-name "Factory MQTT Stream" --model "MQTT-SUB-100" --manufacturer "BrokerCorp"
+    """
+
+    helps[
+        "iot ops ns asset mqtt update"
+    ] = """
+        type: command
+        short-summary: Update an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Update MQTT asset dataset destination
+          text: >
+            az iot ops ns asset mqtt update --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --dataset-dest topic="updated/mqtt/data" retain=Keep qos=Qos1 ttl=7200
+
+        - name: Update MQTT asset metadata
+          text: >
+            az iot ops ns asset mqtt update --name myMqttAsset --instance myInstance -g myInstanceResourceGroup
+            --description "Updated MQTT topic subscriber"
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset"
+    ] = """
+        type: group
+        short-summary: Manage datasets for MQTT namespaced assets.
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset add"
+    ] = """
+        type: command
+        short-summary: Add a dataset to an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Add a dataset to an MQTT asset with MQTT topic
+          text: >
+            az iot ops ns asset mqtt dataset add --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup --name sensorData --data-source "some/mqtt/topic"
+            --dest topic="factory/processed/data" retain=Keep qos=Qos1 ttl=3600
+
+        - name: Add a dataset with BrokerStateStore destination
+          text: >
+            az iot ops ns asset mqtt dataset add --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup --name sensorData --data-source "some/mqtt/topic"
+            --dest key="mqtt-data-store"
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset list"
+    ] = """
+        type: command
+        short-summary: List datasets for an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: List all datasets for an MQTT asset
+          text: >
+            az iot ops ns asset mqtt dataset list --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset remove"
+    ] = """
+        type: command
+        short-summary: Remove a dataset from an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Remove a dataset from an MQTT asset
+          text: >
+            az iot ops ns asset mqtt dataset remove --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup --name sensorData
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset show"
+    ] = """
+        type: command
+        short-summary: Show details of a dataset for an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Show dataset details
+          text: >
+            az iot ops ns asset mqtt dataset show --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup --name sensorData
+    """
+
+    helps[
+        "iot ops ns asset mqtt dataset update"
+    ] = """
+        type: command
+        short-summary: Update a dataset for an MQTT namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Update MQTT dataset destination
+          text: >
+            az iot ops ns asset mqtt dataset update --asset myMqttAsset --instance myInstance
+            -g myInstanceResourceGroup --name sensorData
+            --dest topic="updated/mqtt/topic" retain=Never qos=Qos0 ttl=1800
     """

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -392,7 +392,7 @@ class NamespaceAssets(Queryable):
         asset_type: str,
         dataset_name: str,
         data_source: str,
-        type_ref: Optional[str] = None,  # TODO: check where type ref is supported
+        type_ref: Optional[str] = None,
         replace: bool = False,
         # TODO: future pr, import datapoints from file
         **kwargs

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -44,6 +44,7 @@ class DeviceEndpointType(ListableEnum):
     MEDIA = "Microsoft.Media"
     REST = "Microsoft.Http"
     SSE = "Microsoft.SSEHttp"
+    MQTT = "Microsoft.Mqtt"
 
     @classmethod
     def get_type_from_keyword(cls, keyword: str, return_custom_keyword: bool = True) -> Optional[str]:
@@ -58,7 +59,8 @@ class DeviceEndpointType(ListableEnum):
             "opcua": cls.OPCUA.value,
             "onvif": cls.ONVIF.value,
             "media": cls.MEDIA.value,
-            "rest": cls.REST.value
+            "rest": cls.REST.value,
+            "mqtt": cls.MQTT.value
         }
         return mapped_types.get(keyword.lower(), "custom" if return_custom_keyword else keyword)
 

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -1329,8 +1329,16 @@ def load_adr_arguments(self, _):
                 nargs="+",
             )
 
+        with self.argument_context(f"iot ops ns asset mqtt {command}") as context:
+            context.argument(
+                "dataset_destinations",
+                options_list=["--dataset-dest", "--dsd"],
+                help=DEST_HELP_DATASET_BROKER_OR_MQTT,
+                nargs="+",
+            )
+
     # shared dataset, event, stream, management arguments
-    for asset_type in ("custom", "opcua", "onvif", "media", "rest", "sse"):
+    for asset_type in ("custom", "opcua", "onvif", "media", "rest", "sse", "mqtt"):
         with self.argument_context(f"iot ops ns asset {asset_type} dataset") as context:
             context.argument(
                 "asset_name",
@@ -1622,6 +1630,14 @@ def load_adr_arguments(self, _):
         )
 
     with self.argument_context("iot ops ns asset sse dataset") as context:
+        context.argument(
+            "dataset_destinations",
+            options_list=["--destination", "--dest"],
+            help=DEST_HELP_DATASET_BROKER_OR_MQTT,
+            nargs="+",
+        )
+
+    with self.argument_context("iot ops ns asset mqtt dataset") as context:
         context.argument(
             "dataset_destinations",
             options_list=["--destination", "--dest"],

--- a/azext_edge/edge/providers/adr/user_strings.py
+++ b/azext_edge/edge/providers/adr/user_strings.py
@@ -5,24 +5,7 @@
 # ----------------------------------------------------------------------------------------------
 
 from .common import TopicRetain, DestinationQos
-
-
-def _format_enum_list(values: list) -> str:
-    """
-    Format a list of enum values with proper grammar.
-    - 2 values: `Value1` and `Value2`
-    - 3+ values: `Value1`, `Value2`, and `Value3`
-    """
-    if len(values) == 0:
-        return ""
-    elif len(values) == 1:
-        return f"`{values[0]}`"
-    elif len(values) == 2:
-        return f"`{values[0]}` and `{values[1]}`"
-    else:
-        # 3 or more values: use commas with "and" before last
-        formatted = ", ".join(f"`{v}`" for v in values[:-1])
-        return f"{formatted}, and `{values[-1]}`"
+from ...util.common import format_value_list
 
 
 # Base Strings
@@ -65,8 +48,8 @@ UNRECOGNIZED_TRANS_AUTH_PROP_ERROR = "Transport authentication ({0}) has unrecog
 
 # Destination Help Text Constants
 # These are calculated once to avoid repeated list comprehension on every help call
-_RETAIN_VALUES = _format_enum_list(TopicRetain.list())
-_QOS_VALUES = _format_enum_list(DestinationQos.list())
+_RETAIN_VALUES = format_value_list(TopicRetain.list())
+_QOS_VALUES = format_value_list(DestinationQos.list())
 
 # Common help text fragments for destinations
 DEST_HELP_MQTT_VALUES = (

--- a/azext_edge/edge/util/common.py
+++ b/azext_edge/edge/util/common.py
@@ -297,3 +297,37 @@ def str_to_bool(s: str) -> bool:
         return False
 
     raise ValueError(f"Invalid boolean string: {s}. Use 'true' or 'false'.")
+
+
+def format_value_list(values: List[str]) -> str:
+    """
+    Format a list of string values with proper grammar for display in help text or error messages.
+
+    Args:
+        values: A list of string values (e.g., from EnumClass.list())
+
+    Returns:
+        Formatted string with proper grammar:
+        - 0 values: empty string
+        - 1 value: `Value1`
+        - 2 values: `Value1` and `Value2`
+        - 3+ values: `Value1`, `Value2`, and `Value3`
+
+    Example:
+        >>> format_value_list(["Keep", "Never"])
+        '`Keep` and `Never`'
+        >>> format_value_list(["Qos0", "Qos1", "Qos2"])
+        '`Qos0`, `Qos1`, and `Qos2`'
+    """
+    if not values:
+        return ""
+
+    if len(values) == 1:
+        return f"`{values[0]}`"
+
+    if len(values) == 2:
+        return f"`{values[0]}` and `{values[1]}`"
+
+    # 3 or more values: use commas with "and" before last
+    formatted = ", ".join(f"`{v}`" for v in values[:-1])
+    return f"{formatted}, and `{values[-1]}`"

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -798,3 +798,156 @@ def test_namespace_sse_asset_dataset_lifecycle_operations(require_init, tracked_
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
     assert dataset_name_1 not in remaining_dataset_names
+
+
+def test_namespace_mqtt_asset_dataset_lifecycle_operations(require_init, tracked_resources: List[str]):
+    """Test complete lifecycle of MQTT asset dataset operations."""
+    # Setup test variables
+    instance_name = require_init["instanceName"]
+    resource_group = require_init["resourceGroup"]
+    device_name = f"dev-{generate_random_string(8, force_lower=True)}"
+    endpoint_name = f"mqtt-{generate_random_string(8)}"
+    asset_name = f"mqtt-{generate_random_string(8, force_lower=True)}"
+    dataset_name_1 = f"dataset{generate_random_string(6, force_lower=True)}"
+
+    # Create Device
+    result = run(
+        f"az iot ops ns device create --name {device_name} --instance {instance_name} "
+        f"-g {resource_group}"
+    )
+    tracked_resources.append(result["id"])
+
+    # Create device endpoint
+    run(
+        f"az iot ops ns device endpoint inbound add mqtt --name {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} --device {device_name} "
+        f"--endpoint-address 'aio-broker:18883'"
+    )
+
+    # Create MQTT asset
+    asset_mqtt = run(
+        f"az iot ops ns asset mqtt create --name {asset_name} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}"
+    )
+    tracked_resources.append(asset_mqtt["id"])
+
+    # 1. CREATE DATASET
+    dataset_data_source = "factory/temperature"
+    dataset_destinations = "topic=telemetry/mqtt/temperature qos=Qos1 retain=Keep ttl=3600"
+
+    # Add MQTT asset dataset (NOTE: MQTT datasets support BrokerStateStore and MQTT destinations only, no events)
+    dataset_result = run(
+        f"az iot ops ns asset mqtt dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
+        f"--data-source {dataset_data_source} "
+        f"--destination {dataset_destinations}"
+    )
+
+    assert_dataset_properties(
+        dataset_result,
+        name=dataset_name_1,
+        data_source=dataset_data_source,
+        asset_type="mqtt",
+    )
+
+    # 2. LIST DATASETS
+    datasets_list = run(
+        f"az iot ops ns asset mqtt dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+
+    dataset_names = [dataset["name"] for dataset in datasets_list]
+    assert dataset_name_1 in dataset_names
+    assert len(datasets_list) >= 1
+
+    # 3. SHOW DATASET
+    dataset_show = run(
+        f"az iot ops ns asset mqtt dataset show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
+    )
+
+    assert_dataset_properties(
+        dataset_show,
+        name=dataset_name_1,
+        data_source=dataset_data_source,
+        asset_type="mqtt",
+    )
+
+    # 4. UPDATE DATASET
+    updated_destinations = "topic=telemetry/mqtt/temperature_v2 qos=Qos0 retain=Never ttl=1800"
+
+    updated_dataset = run(
+        f"az iot ops ns asset mqtt dataset update --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
+        f"--destination {updated_destinations}"
+    )
+
+    assert_dataset_properties(
+        updated_dataset,
+        name=dataset_name_1,
+        asset_type="mqtt",
+    )
+
+    # 5. TEST DATASET REPLACE FUNCTIONALITY
+    # Replace dataset with --replace flag
+    replaced_data_source = "factory/temperature/replaced"
+    broker_destinations = "key=mqtt-data-cache"
+
+    replaced_dataset = run(
+        f"az iot ops ns asset mqtt dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1} "
+        f"--data-source {replaced_data_source} --dest {broker_destinations} "
+        f"--replace"
+    )
+
+    assert_dataset_properties(
+        replaced_dataset,
+        name=dataset_name_1,
+        asset_type="mqtt",
+    )
+
+    # 6. SHOW REPLACED DATASET
+    replaced_dataset_show = run(
+        f"az iot ops ns asset mqtt dataset show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
+    )
+
+    assert_dataset_properties(
+        replaced_dataset_show,
+        name=dataset_name_1,
+        data_source=replaced_data_source,
+        asset_type="mqtt",
+    )
+
+    # 7. CREATE ADDITIONAL DATASET
+    dataset_name_2 = f"dataset2{generate_random_string(6, force_lower=True)}"
+    dataset_2_destinations = "topic=telemetry/mqtt/pressure qos=Qos1 retain=Keep ttl=7200"
+
+    dataset_2_result = run(
+        f"az iot ops ns asset mqtt dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_2} "
+        f"--data-source factory/pressure "
+        f"--destination {dataset_2_destinations}"
+    )
+
+    assert_dataset_properties(
+        dataset_2_result,
+        name=dataset_name_2,
+        data_source="factory/pressure",
+        asset_type="mqtt",
+    )
+
+    # 8. REMOVE DATASET
+    run(
+        f"az iot ops ns asset mqtt dataset remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name_1}"
+    )
+
+    # Verify dataset removal
+    datasets_list_after_remove = run(
+        f"az iot ops ns asset mqtt dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+
+    remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
+    assert dataset_name_1 not in remaining_dataset_names

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -16,6 +16,7 @@ from azext_edge.edge.commands_namespaces import (
     add_namespace_opcua_asset_dataset,
     add_namespace_rest_asset_dataset,
     add_namespace_sse_asset_dataset,
+    add_namespace_mqtt_asset_dataset,
     list_namespace_asset_datasets,
     remove_namespace_asset_dataset,
     show_namespace_asset_dataset,
@@ -23,6 +24,7 @@ from azext_edge.edge.commands_namespaces import (
     update_namespace_opcua_asset_dataset,
     update_namespace_rest_asset_dataset,
     update_namespace_sse_asset_dataset,
+    update_namespace_mqtt_asset_dataset,
     add_namespace_custom_asset_dataset_point,
     add_namespace_opcua_asset_dataset_point,
     list_namespace_asset_dataset_points,
@@ -101,6 +103,8 @@ def generate_dataset(dataset_name: Optional[str] = None, num_data_points: int = 
     }),
     # SSE asset dataset with minimal config
     ("sse", add_namespace_sse_asset_dataset, {}),
+    # MQTT asset dataset with minimal config
+    ("mqtt", add_namespace_mqtt_asset_dataset, {}),
 ])
 @pytest.mark.parametrize("destination_params", [
     {},  # No destinations
@@ -749,6 +753,8 @@ def test_show_namespace_asset_dataset(
     }),
     # SSE asset dataset with minimal config
     ("sse", update_namespace_sse_asset_dataset, {}),
+    # MQTT asset dataset with minimal config
+    ("mqtt", update_namespace_mqtt_asset_dataset, {}),
 ])
 def test_update_namespace_asset_dataset(
     mocked_cmd,

--- a/azext_edge/tests/edge/adr/test_namespace_assets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_int.py
@@ -327,11 +327,13 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
     endpoint_name_media = f"media-{generate_random_string(8)}"
     endpoint_name_rest = f"rest-{generate_random_string(8)}"
     endpoint_name_sse = f"sse-{generate_random_string(8)}"
+    endpoint_name_mqtt = f"mqtt-{generate_random_string(8)}"
     asset_name_onvif = f"onvif-{generate_random_string(8, force_lower=True)}"
     asset_name_opcua = f"opcua-{generate_random_string(8, force_lower=True)}"
     asset_name_media = f"media-{generate_random_string(8, force_lower=True)}"
     asset_name_rest = f"rest-{generate_random_string(8, force_lower=True)}"
     asset_name_sse = f"sse-{generate_random_string(8, force_lower=True)}"
+    asset_name_mqtt = f"mqtt-{generate_random_string(8, force_lower=True)}"
 
     # Tags and attributes
     common_tags = {"env": "test", "purpose": "automation"}
@@ -351,12 +353,16 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
         (endpoint_name_media, "media"),
         (endpoint_name_rest, "rest"),
         (endpoint_name_sse, "sse"),
+        (endpoint_name_mqtt, "mqtt"),
     ]:
         command = (
             f"az iot ops ns device endpoint inbound add {endpoint_type} --name {endpoint_name} "
             f"--instance {instance_name} -g {resource_group} --device {device_name} "
-            "--endpoint-address 'http://192.168.1.100:8000/onvif/device_service'"
         )
+        if endpoint_type == "mqtt":
+            command += "--endpoint-address 'aio-broker:18883'"
+        else:
+            command += "--endpoint-address 'http://192.168.1.100:8000/onvif/device_service'"
         if endpoint_type == "custom":
             command += " --endpoint-type custom"
         run(command)
@@ -508,6 +514,36 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
         custom_location=custom_location,
     )
 
+    # 6. Create MQTT asset with maximum inputs
+    asset_mqtt = run(
+        f"az iot ops ns asset mqtt create --name {asset_name_mqtt} --instance {instance_name} "
+        f"-g {resource_group} --device {device_name} --endpoint {endpoint_name_mqtt} "
+        "--description \"In-cluster MQTT Stream\" --display-name \"Factory MQTT Subscriber\" "
+        "--model \"MQTT-SUB-100\" --manufacturer \"BrokerCorp\" --serial-number \"MQTT-12345\" "
+        "--documentation-uri \"https://example.com/docs/mqtt\" "
+        "--external-asset-id \"EXT-MQTT-01\" --hardware-revision \"v1.0\" "
+        f"--attribute {' '.join(common_attrs)} --tags {' '.join([f'{k}={v}' for k, v in common_tags.items()])}"
+    )
+    tracked_resources.append(asset_mqtt["id"])
+
+    assert_asset_properties(
+        asset_mqtt,
+        name=asset_name_mqtt,
+        device=device_name,
+        endpoint=endpoint_name_mqtt,
+        description="In-cluster MQTT Stream",
+        display_name="Factory MQTT Subscriber",
+        model="MQTT-SUB-100",
+        manufacturer="BrokerCorp",
+        serial_number="MQTT-12345",
+        documentation_uri="https://example.com/docs/mqtt",
+        external_asset_id="EXT-MQTT-01",
+        attributes=common_attrs,
+        tags=common_tags,
+        hardware_revision="v1.0",
+        custom_location=custom_location,
+    )
+
     # 1. Update ONVIF asset
     updated_onvif = run(
         f"az iot ops ns asset onvif update --name {asset_name_onvif} --instance {instance_name} "
@@ -574,6 +610,17 @@ def test_namespace_asset_1p_types(require_init, tracked_resources: List[str]):
         updated_sse,
         name=asset_name_sse,
         description="Updated SSE Event Source",
+    )
+
+    # 6. Update MQTT asset
+    updated_mqtt = run(
+        f"az iot ops ns asset mqtt update --name {asset_name_mqtt} --instance {instance_name} "
+        f"-g {resource_group} --description \"Updated MQTT Stream\""
+    )
+    assert_asset_properties(
+        updated_mqtt,
+        name=asset_name_mqtt,
+        description="Updated MQTT Stream",
     )
 
 

--- a/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_unit.py
@@ -18,6 +18,7 @@ from azext_edge.edge.commands_namespaces import (
     create_namespace_opcua_asset,
     create_namespace_rest_asset,
     create_namespace_sse_asset,
+    create_namespace_mqtt_asset,
     show_namespace_asset,
     delete_namespace_asset,
     update_namespace_custom_asset,
@@ -26,6 +27,7 @@ from azext_edge.edge.commands_namespaces import (
     update_namespace_opcua_asset,
     update_namespace_rest_asset,
     update_namespace_sse_asset,
+    update_namespace_mqtt_asset,
     query_namespace_assets
 )
 from azext_edge.edge.providers.adr.namespace_assets import _process_configs
@@ -153,6 +155,7 @@ def add_device_get_call(
     ["opcua", {}],
     ["rest", {}],
     ["sse", {}],
+    ["mqtt", {}],
     # CUSTOM
     [
         "custom",
@@ -235,6 +238,20 @@ def add_device_get_call(
             "default_dataset_destinations": ["key=sse-data-cache"],
             "default_event_destinations": ["topic=/contoso/sse/alerts", "retain=Keep", "qos=Qos1", "ttl=3600"]
         }
+    ],
+    # MQTT (In-cluster MQTT broker)
+    [
+        "mqtt",
+        {
+            "default_dataset_destinations": ["topic=/contoso/mqtt/data", "retain=Keep", "qos=Qos1", "ttl=3600"]
+        }
+    ],
+    # MQTT with BrokerStateStore destinations
+    [
+        "mqtt",
+        {
+            "default_dataset_destinations": ["key=mqtt-data-cache"]
+        }
     ]
 ])
 def test_create_namespace_asset(
@@ -301,6 +318,7 @@ def test_create_namespace_asset(
         "opcua": create_namespace_opcua_asset,
         "rest": create_namespace_rest_asset,
         "sse": create_namespace_sse_asset,
+        "mqtt": create_namespace_mqtt_asset,
     }
     result = type_to_command[asset_type](
         cmd=mocked_cmd,
@@ -345,7 +363,8 @@ def test_create_namespace_asset(
     ["onvif", create_namespace_onvif_asset],
     ["opcua", create_namespace_opcua_asset],
     ["rest", create_namespace_rest_asset],
-    ["sse", create_namespace_sse_asset]
+    ["sse", create_namespace_sse_asset],
+    ["mqtt", create_namespace_mqtt_asset]
 ])
 def test_create_namespace_asset_error(
     mocked_cmd,
@@ -381,7 +400,8 @@ def test_create_namespace_asset_error(
         "onvif": DeviceEndpointType.MEDIA.value,
         "opcua": DeviceEndpointType.ONVIF.value,
         "rest": DeviceEndpointType.OPCUA.value,
-        "sse": DeviceEndpointType.MEDIA.value
+        "sse": DeviceEndpointType.MEDIA.value,
+        "mqtt": DeviceEndpointType.REST.value
     }
     mock_device_record["properties"]["endpoints"]["inbound"] = {
         device_endpoint_name: {"endpointType": incorrect_types[asset_type]}
@@ -670,6 +690,13 @@ def test_show_namespace_asset(
             "default_dataset_destinations": ["topic=/contoso/sse/updated-data", "retain=Keep", "qos=Qos1", "ttl=1800"],
             "default_event_destinations": ["topic=/contoso/sse/updated-events", "retain=Never", "qos=Qos0", "ttl=3600"]
         }
+    ],
+    # MQTT (In-cluster MQTT broker)
+    [
+        "mqtt",
+        {
+            "default_dataset_destinations": ["topic=/contoso/mqtt/updated-data", "retain=Keep", "qos=Qos1", "ttl=1800"]
+        }
     ]
 ])
 @pytest.mark.parametrize("original_properties", [
@@ -796,6 +823,7 @@ def test_update_namespace_asset(
         "opcua": update_namespace_opcua_asset,
         "rest": update_namespace_rest_asset,
         "sse": update_namespace_sse_asset,
+        "mqtt": update_namespace_mqtt_asset,
     }
 
     # Execute the update command

--- a/azext_edge/tests/edge/adr/test_namespace_devices_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_int.py
@@ -32,6 +32,7 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     endpoint_name_custom = f"custom-{generate_random_string(8)}"
     endpoint_name_rest = f"rest-{generate_random_string(8)}"
     endpoint_name_sse = f"sse-{generate_random_string(8)}"
+    endpoint_name_mqtt = f"mqtt-{generate_random_string(8)}"
 
     # Create 1st device with minimal inputs
     result = run(
@@ -309,18 +310,38 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
         version="1.1",
     )
 
+    # Add MQTT endpoint (no authentication, in-cluster broker only)
+    mqtt_endpoint_address = "aio-broker:18883"
+    result = run(
+        f"az iot ops ns device endpoint inbound add mqtt --device {device_name_2} "
+        f"--instance {instance_name} -g {resource_group} --name {endpoint_name_mqtt} "
+        f"--endpoint-address {mqtt_endpoint_address} "
+        f"--version 0.3.4"
+    )
+    assert_namespace_device_endpoint_props(
+        result,
+        endpoint_name=endpoint_name_mqtt,
+        endpoint_type=DeviceEndpointType.MQTT.value,
+        endpoint_address=mqtt_endpoint_address,
+        accept_invalid_hostnames=True,
+        accept_invalid_certificates=True,
+        authentication_method="Anonymous",
+        version="0.3.4",
+    )
+
     # List (all) endpoints
     result = run(
         f"az iot ops ns device endpoint list --device {device_name_2} "
         f"--instance {instance_name} -g {resource_group}"
     )
-    assert len(result["inbound"]) == 6
+    assert len(result["inbound"]) == 7
     assert endpoint_name_onvif in result["inbound"]
     assert endpoint_name_media in result["inbound"]
     assert endpoint_name_opcua in result["inbound"]
     assert endpoint_name_custom in result["inbound"]
     assert endpoint_name_rest in result["inbound"]
     assert endpoint_name_sse in result["inbound"]
+    assert endpoint_name_mqtt in result["inbound"]
 
     # List inbound endpoints option a
     result_1 = run(
@@ -333,7 +354,7 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
         f"az iot ops ns device endpoint inbound list --device {device_name_2} "
         f"--instance {instance_name} -g {resource_group}"
     )
-    assert len(result_1) == len(result_2) == 6
+    assert len(result_1) == len(result_2) == 7
     assert result_1 == result_2
     assert endpoint_name_onvif in result_1
     assert endpoint_name_media in result_1
@@ -341,6 +362,7 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     assert endpoint_name_custom in result_1
     assert endpoint_name_rest in result_1
     assert endpoint_name_sse in result_1
+    assert endpoint_name_mqtt in result_1
 
     # List inbound endpoints with specific type
     result = run(
@@ -351,11 +373,12 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     assert endpoint_name_media in result
     assert endpoint_name_custom not in result
 
-    # Remove endpoints (including the certificate authenticated REST endpoint and SSE endpoint)
+    # Remove endpoints (REST cert-auth, SSE username-auth, MQTT anonymous)
     result = run(
         f"az iot ops ns device endpoint inbound remove --device {device_name_2} "
         f"--instance {instance_name} -g {resource_group} "
-        f"--endpoint {endpoint_name_onvif} {endpoint_name_media} {endpoint_name_rest} {endpoint_name_sse} -y"
+        f"--endpoint {endpoint_name_onvif} {endpoint_name_media} {endpoint_name_rest} "
+        f"{endpoint_name_sse} {endpoint_name_mqtt} -y"
     )
     # Filter out None values (removed endpoints) to get only active endpoints
     active_endpoints = {k: v for k, v in result.items() if v is not None}
@@ -369,6 +392,8 @@ def test_namespace_device_lifecycle_operations(require_init, tracked_resources: 
     assert result[endpoint_name_rest] is None
     assert endpoint_name_sse in result
     assert result[endpoint_name_sse] is None
+    assert endpoint_name_mqtt in result
+    assert result[endpoint_name_mqtt] is None
     # Remaining endpoints should be present with their configurations
     assert endpoint_name_opcua in active_endpoints
     assert endpoint_name_custom in active_endpoints

--- a/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
@@ -26,7 +26,8 @@ from azext_edge.edge.commands_namespaces import (
     add_inbound_onvif_device_endpoint,
     add_inbound_opcua_device_endpoint,
     add_inbound_rest_device_endpoint,
-    add_inbound_sse_device_endpoint
+    add_inbound_sse_device_endpoint,
+    add_inbound_mqtt_device_endpoint
 )
 from azext_edge.edge.providers.adr.common import ADRAuthModes
 from azext_edge.edge.providers.adr.namespace_devices import DeviceEndpointType
@@ -1756,6 +1757,7 @@ def test_add_inbound_opcua_device_endpoint(
     (DeviceEndpointType.OPCUA.value, add_inbound_opcua_device_endpoint),
     (DeviceEndpointType.REST.value, add_inbound_rest_device_endpoint),
     (DeviceEndpointType.SSE.value, add_inbound_sse_device_endpoint),
+    (DeviceEndpointType.MQTT.value, add_inbound_mqtt_device_endpoint),
     ("custom", add_inbound_custom_device_endpoint)
 ])
 def test_add_inbound_device_endpoint_error(
@@ -2185,6 +2187,148 @@ def test_add_inbound_sse_device_endpoint(
     patch_body = json.loads(mocked_responses.calls[1].request.body)
     endpoint_patch = patch_body["properties"]["endpoints"]["inbound"][endpoint_name]
     assert endpoint_patch["endpointType"] == DeviceEndpointType.SSE.value
+    assert endpoint_patch["version"] == endpoint_version
+    assert endpoint_patch["address"] == endpoint_address
+    assert endpoint_patch["authentication"]["method"] == expected_endpoint["authentication"]["method"]
+    assert endpoint_patch["authentication"] == expected_endpoint["authentication"]
+
+
+@pytest.mark.parametrize("response_status", [200, 400])
+@pytest.mark.parametrize("endpoint_version", [None, "0.3.4"])
+@pytest.mark.parametrize("endpoints_present, replace", [
+    (False, False),  # Endpoint does not exist, do not replace
+    (True, False),   # Endpoint exists, do not replace
+    (True, True)     # Endpoint exists, replace it
+])
+def test_add_inbound_mqtt_device_endpoint(
+    mocked_cmd,
+    mocked_responses: responses,
+    response_status: int,
+    endpoint_version: Optional[str],
+    endpoints_present: bool,
+    replace: bool,
+    mocked_get_namespace_for_instance
+):
+    # Setup test data
+    device_name = generate_random_string()
+    instance_name = f"test-inst-{generate_random_string()}"
+    instance_resource_group = f"inst-rg-{generate_random_string()}"
+    endpoint_name = f"mqtt-endpoint-{generate_random_string()}"
+    endpoint_address = "aio-broker:18883"
+
+    # Mock namespace information returned by get_namespace_for_instance
+    namespace_name = mocked_get_namespace_for_instance.return_value["name"]
+    resource_group_name = mocked_get_namespace_for_instance.return_value["resource_group"]
+
+    # Create original device record with no endpoints
+    original_device = get_namespace_device_record(
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    original_device["properties"]["endpoints"] = {
+        "inbound": generate_device_inbound_endpoint() if endpoints_present else {}
+    }
+    if replace:
+        original_device["properties"]["endpoints"]["inbound"].update(
+            generate_device_inbound_endpoint(endpoint_name=endpoint_name)
+        )
+
+    # Create expected endpoint structure (MQTT has no authentication)
+    expected_endpoint = {
+        "endpointType": DeviceEndpointType.MQTT.value,
+        "address": endpoint_address,
+        "version": endpoint_version,
+        "authentication": {
+            "method": ADRAuthModes.anonymous.value
+        }
+    }
+
+    # Create updated device record for PATCH response
+    updated_device = deepcopy(original_device)
+    updated_device["properties"]["endpoints"] = {
+        "inbound": {endpoint_name: expected_endpoint}
+    }
+
+    # Mock the GET call to get the original device
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_namespace_device_mgmt_uri(
+            namespace_name=namespace_name,
+            resource_group_name=resource_group_name,
+            device_name=device_name
+        ),
+        json=original_device,
+        status=200,
+        content_type="application/json",
+    )
+
+    # Mock the PATCH call to update the endpoints
+    mocked_responses.add(
+        method=responses.PATCH,
+        url=get_namespace_device_mgmt_uri(
+            namespace_name=namespace_name,
+            resource_group_name=resource_group_name,
+            device_name=device_name
+        ),
+        json=updated_device if response_status == 200 else {"error": "Bad Request"},
+        status=response_status,
+        content_type="application/json",
+    )
+
+    if response_status == 200:
+        # Mock the GET call to show_namespace_device after adding endpoint
+        mocked_responses.add(
+            method=responses.GET,
+            url=get_namespace_device_mgmt_uri(
+                namespace_name=namespace_name,
+                resource_group_name=resource_group_name,
+                device_name=device_name
+            ),
+            json=updated_device,
+            status=200,
+            content_type="application/json",
+        )
+    else:
+        # Execute test based on status code
+        with pytest.raises(Exception):
+            add_inbound_mqtt_device_endpoint(
+                cmd=mocked_cmd,
+                device_name=device_name,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                endpoint_name=endpoint_name,
+                endpoint_address=endpoint_address,
+                endpoint_version=endpoint_version,
+                replace=replace,
+                wait_sec=0
+            )
+        return
+
+    # Test add_inbound_mqtt_device_endpoint for success case
+    result = add_inbound_mqtt_device_endpoint(
+        cmd=mocked_cmd,
+        device_name=device_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        endpoint_name=endpoint_name,
+        endpoint_address=endpoint_address,
+        endpoint_version=endpoint_version,
+        replace=replace,
+        wait_sec=0
+    )
+    assert result == updated_device["properties"]["endpoints"]["inbound"]
+
+    # Verify that both GET and PATCH calls were made
+    assert len(mocked_responses.calls) == 3
+    assert mocked_responses.calls[0].request.method == "GET"
+    assert mocked_responses.calls[1].request.method == "PATCH"
+    assert mocked_responses.calls[2].request.method == "GET"
+
+    # Verify request body contains expected endpoint
+    patch_body = json.loads(mocked_responses.calls[1].request.body)
+    endpoint_patch = patch_body["properties"]["endpoints"]["inbound"][endpoint_name]
+    assert endpoint_patch["endpointType"] == DeviceEndpointType.MQTT.value
     assert endpoint_patch["version"] == endpoint_version
     assert endpoint_patch["address"] == endpoint_address
     assert endpoint_patch["authentication"]["method"] == expected_endpoint["authentication"]["method"]


### PR DESCRIPTION
- Added comprehensive MQTT connector support following the same pattern as SSE connector, including device endpoints, assets, and datasets with MQTT-specific configuration (anonymous authentication, in-cluster broker, MQTT v5)
- Refactored helper function to address PR feedback by moving _format_enum_list
- Added missing help documentation for MQTT dataset list/remove/show commands and ensured complete help text coverage across all MQTT commands

Testing Done

-  Ran live endpoints successfully - tested all MQTT device endpoint, asset, and dataset commands against real Azure IoT Operations instance
-  Ran integration tests locally successfully - all MQTT integration tests pass (device lifecycle, asset operations, dataset management)
-  Linting check and unit test ran successfully -
