### PR TITLE
fix(upgrade): prevent any upgrade migration changes if installed ops is incompatible

### DIFF
--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -35,6 +35,7 @@ from .common import (
     MIN_INSTANCE_VERSION_FOR_CM_MIGRATE,
     MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE,
     MIN_INSTANCE_VERSION_V2,
+    PROVISIONING_STATE_SUCCESS,
     ConfigSyncModeType,
 )
 from .migration import SecretSyncMigrationManager
@@ -399,7 +400,7 @@ def format_extension_row(ext: "ExtensionUpgradeState") -> Tuple[str, str, str]:
     """
     try:
         status_indicator = ""
-        if ext.provisioning_state and ext.provisioning_state.lower() != "succeeded":
+        if ext.provisioning_state and ext.provisioning_state.lower() != PROVISIONING_STATE_SUCCESS.lower():
             status_indicator = f" [yellow]({ext.provisioning_state})[/yellow]"
 
         if ext.operation_type == ExtensionOperation.DELETE:
@@ -645,7 +646,7 @@ class ConfigOverride:
         self.version = version
         self.train = train
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return not any([self.config, self.config_sync_mode, self.version, self.train])
 
 
@@ -790,12 +791,23 @@ class ClusterUpgradeState:
     def _refresh_upgrade_state(self) -> List["ExtensionUpgradeState"]:
         ext_queue: List["ExtensionUpgradeState"] = []
 
-        if not self.extensions_map.get(EXTENSION_TYPE_OPS):
+        ops_extension = self.extensions_map.get(EXTENSION_TYPE_OPS)
+        if not ops_extension:
             raise ValidationError(
                 "The cluster backing the instance has an invalid state. IoT Operations extension not detected."
             )
 
-        # Check what operations we need
+        # Build IoT Operations extension state first and validate upgrade compatibility.
+        ops_moniker = EXTENSION_TYPE_TO_MONIKER_MAP[EXTENSION_TYPE_OPS]
+        ops_upgrade_state = ExtensionUpgradeState(
+            extension=ops_extension,
+            desired_version_map=self.init_version_map.get(ops_moniker, {}),
+            desired_config=self.desired_config_map.get(ops_moniker),
+            override=self.override_map.get(ops_moniker),
+            force=self.force,
+        )
+        ops_upgrade_state.validate_upgrade()
+
         should_delete_platform = self._should_delete_platform()
         should_create_certmanager = self._should_create_certmanager(deleting_platform=should_delete_platform)
 
@@ -840,6 +852,11 @@ class ClusterUpgradeState:
 
             # Skip certmanager if we're creating it (already handled above)
             if ext_type == EXTENSION_TYPE_CM and should_create_certmanager:
+                continue
+
+            # Use pre-built ops_upgrade_state for IoT Operations extension
+            if ext_type == EXTENSION_TYPE_OPS:
+                ext_queue.append(ops_upgrade_state)
                 continue
 
             if extension:
@@ -888,7 +905,7 @@ class ClusterUpgradeState:
         if not ops_extension:
             return False
 
-        ops_override = self.override_map.get(EXTENSION_MONIKER_OPS, ConfigOverride())
+        ops_override = self.override_map.get(EXTENSION_MONIKER_OPS) or ConfigOverride()
 
         # Priority: override > init_version_map > current version
         target_version = (
@@ -1011,6 +1028,18 @@ class ExtensionUpgradeState:
             payload["properties"]["configurationSettings"] = config_settings
 
         return payload
+
+    def validate_upgrade(self) -> None:
+        """Validate the upgrade path for this extension.
+
+        Should be called early to ensure upgrade compatibility before
+        computing dependent operations (e.g., platform deletion, certmanager creation).
+
+        Raises:
+            ValidationError: If the upgrade is not valid (e.g., downgrade, incompatible versions).
+        """
+        if self._has_delta_in_version() or self._has_non_success_state():
+            self._validate_version_upgrade()
 
     def _should_migrate_mqtt_config(self) -> bool:
         if not self.extension:
@@ -1135,7 +1164,7 @@ class ExtensionUpgradeState:
         """
         Determines if the extension has a non-success provisioning state.
         """
-        return self.provisioning_state.lower() not in {"succeeded"}
+        return self.provisioning_state.lower() != PROVISIONING_STATE_SUCCESS.lower()
 
     def _validate_version_upgrade(self):
         # Skip validation for CREATE/DELETE operations

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -1352,17 +1352,6 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             },
         ),
         (
-            UpgradeScenario("No CM Install: No effect when target version < MIN_INSTANCE_VERSION_FOR_CM_MIGRATE")
-            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
-            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
-            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.2.0")
-            .set_user_kwargs(ops_version="1.2.82", no_cm_install=True),
-            {
-                # Target version doesn't trigger migration, so no_cm_install has no effect
-                EXTENSION_TYPE_OPS: build_extension_props(EXTENSION_TYPE_OPS, version="1.2.82"),
-            },
-        ),
-        (
             UpgradeScenario("No CM Install: Works with other migrations (registry, secretsync)")
             .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
             .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
@@ -1371,20 +1360,6 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_auxiliary_kwargs(default_registry_exists=False, secretsync_migration_needed=True),
             {
                 # No CM creation, but other migrations still happen
-                EXTENSION_TYPE_OPS: build_extension_props(
-                    EXTENSION_TYPE_OPS, version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE
-                ),
-            },
-        ),
-        (
-            UpgradeScenario("No CM Install: False explicitly allows cert-manager creation")
-            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
-            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
-            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.2.0")
-            .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE, no_cm_install=False),
-            {
-                # no_cm_install=False (explicit) should create CM normally
-                EXTENSION_TYPE_CM: build_extension_props(EXTENSION_TYPE_CM, version=BUILT_IN_VALUE),
                 EXTENSION_TYPE_OPS: build_extension_props(
                     EXTENSION_TYPE_OPS, version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE
                 ),
@@ -1808,6 +1783,57 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_auxiliary_kwargs(has_default_spc_only=True),
             {
                 EXTENSION_TYPE_OPS: build_extension_props(EXTENSION_TYPE_OPS, version="1.2.82"),
+            },
+        ),
+        # ========== Early Validation - IoT Ops validation blocks migration operations ==========
+        (
+            UpgradeScenario("Early Validation: IoT Ops downgrade blocks platform migration")
+            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
+            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
+            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE)
+            .set_user_kwargs(ops_version="1.2.0")  # Downgrade from MIN_INSTANCE_VERSION_FOR_CM_MIGRATE
+            .expecting_validation_error(r"is a downgrade which is not supported"),
+            {},  # No operations should happen
+        ),
+        (
+            UpgradeScenario("Early Validation: IoT Ops minor version gap blocks platform migration")
+            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
+            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
+            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.1.59")  # Meets min v1 requirement
+            .set_user_kwargs(ops_version="1.5.0")
+            .expecting_validation_error(r"incompatible \(more than 2 minor versions ahead\)"),
+            {},  # No operations should happen
+        ),
+        (
+            UpgradeScenario("Early Validation: IoT Ops preview train blocks platform migration")
+            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
+            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
+            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.2.0", ext_train="preview")
+            .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE)
+            .expecting_validation_error(r"Upgrades to or from non-stable release trains are not supported"),
+            {},  # No operations should happen
+        ),
+        (
+            UpgradeScenario("Early Validation: IoT Ops min v2 requirement blocks platform migration")
+            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
+            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
+            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.0.0")
+            .set_user_kwargs(ops_version="1.2.36")  # Current 1.0.0 is below min v1 version (1.1.59) required for v2 upgrade
+            .expecting_validation_error(r"min compatible upgrade version.*1\.1\.59"),
+            {},  # No operations should happen
+        ),
+        (
+            UpgradeScenario("Early Validation: Force bypasses validation and allows migration")
+            .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
+            .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
+            .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.0.0")
+            .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE, force=True),  # Force bypasses validation
+            {
+                # Platform deleted, CM created, IoT Ops upgraded - all operations proceed with force
+                EXTENSION_TYPE_CM: build_extension_props(EXTENSION_TYPE_CM, version=BUILT_IN_VALUE),
+                EXTENSION_TYPE_OPS: build_extension_props(
+                    EXTENSION_TYPE_OPS, version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE
+                ),
             },
         ),
     ],
@@ -2238,25 +2264,29 @@ def assert_displays(
 
                 # These errors occur early (before table render), only 1 progress init
                 early_errors = [
-                    "Cluster is not connected",
-                    "requires the IoT Operations extension",
-                    "requires an ADR namespace",  # This happens during analyze_cluster
+                    "is not connected",
+                    "IoT Operations extension not detected",
+                    "requires an ADR namespace",
                 ]
 
-                # These errors occur late (after table render), 2 progress inits
-                late_errors = [
+                ops_validation_patterns = [
                     "is a downgrade",
                     "incompatible",
                     "min compatible upgrade version",
                     "non-stable release trains",
                 ]
+                is_ops_validation_error = EXTENSION_MONIKER_OPS in error_msg and any(
+                    pattern in error_msg for pattern in ops_validation_patterns
+                )
 
                 if any(phrase in error_msg for phrase in early_errors):
                     progress_count = 1
-                elif any(phrase in error_msg for phrase in late_errors):
-                    progress_count = 2
-                else:
+                elif is_ops_validation_error:
+                    # IoT Operations validation errors are early (gatekeeper for entire upgrade)
                     progress_count = 1
+                else:
+                    # Other validation errors (e.g., certManager downgrade) are late
+                    progress_count = 2
             elif isinstance(error_value, HttpResponseError):
                 # HTTP errors occur during apply_upgrades, after table render
                 progress_count = 2

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -1793,7 +1793,7 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE)
             .set_user_kwargs(ops_version="1.2.0")  # Downgrade from MIN_INSTANCE_VERSION_FOR_CM_MIGRATE
             .expecting_validation_error(r"is a downgrade which is not supported"),
-            {},  # No operations should happen
+            {},
         ),
         (
             UpgradeScenario("Early Validation: IoT Ops minor version gap blocks platform migration")
@@ -1802,7 +1802,7 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.1.59")  # Meets min v1 requirement
             .set_user_kwargs(ops_version="1.5.0")
             .expecting_validation_error(r"incompatible \(more than 2 minor versions ahead\)"),
-            {},  # No operations should happen
+            {},
         ),
         (
             UpgradeScenario("Early Validation: IoT Ops preview train blocks platform migration")
@@ -1811,7 +1811,7 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.2.0", ext_train="preview")
             .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE)
             .expecting_validation_error(r"Upgrades to or from non-stable release trains are not supported"),
-            {},  # No operations should happen
+            {},
         ),
         (
             UpgradeScenario("Early Validation: IoT Ops min v2 requirement blocks platform migration")
@@ -1820,14 +1820,14 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.0.0")
             .set_user_kwargs(ops_version="1.2.36")  # Current is below min v1 version (1.1.59) required for v2 upgrade
             .expecting_validation_error(r"min compatible upgrade version.*1\.1\.59"),
-            {},  # No operations should happen
+            {},
         ),
         (
             UpgradeScenario("Early Validation: Force bypasses validation and allows migration")
             .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
             .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.0.0")
-            .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE, force=True),  # Force bypasses validation
+            .set_user_kwargs(ops_version=MIN_INSTANCE_VERSION_FOR_CM_MIGRATE, force=True),
             {
                 # Platform deleted, CM created, IoT Ops upgraded - all operations proceed with force
                 EXTENSION_TYPE_CM: build_extension_props(EXTENSION_TYPE_CM, version=BUILT_IN_VALUE),

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -1818,7 +1818,7 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
             .set_extension(ext_type=EXTENSION_TYPE_PLATFORM, ext_vers="1.0.0")
             .set_extension(ext_type=EXTENSION_TYPE_CM, remove=True)
             .set_extension(ext_type=EXTENSION_TYPE_OPS, ext_vers="1.0.0")
-            .set_user_kwargs(ops_version="1.2.36")  # Current 1.0.0 is below min v1 version (1.1.59) required for v2 upgrade
+            .set_user_kwargs(ops_version="1.2.36")  # Current is below min v1 version (1.1.59) required for v2 upgrade
             .expecting_validation_error(r"min compatible upgrade version.*1\.1\.59"),
             {},  # No operations should happen
         ),


### PR DESCRIPTION
- Modified `_refresh_upgrade_state()` to validate IoT Operations extension upgrade compatibility before computing platform deletion and certmanager creation operations.
- New public method on `ExtensionUpgradeState` that can be called to check upgrade compatibility early.
- Added test cases.