### PR TITLE
feat: add resource health availability check for init/create.

### DIFF
--- a/.github/actions/build-int-test-matrix/action.yml
+++ b/.github/actions/build-int-test-matrix/action.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 name: Build Test Matrix
 description: Build matrix of test scenarios from YAML config
 

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1798,6 +1798,13 @@ def load_iotops_help():
                         rotationPollIntervalInSeconds=120
                         validatingAdmissionPolicies.applyPolicies=false
 
+                      The default config settings for cert-manager are:
+                        AgentOperationTimeoutInMinutes=20
+                        global.telemetry.enabled=true
+
+                      To skip pre-flight validation checks (such as cluster health), set the environment
+                      variable AIO_CLI_INIT_PREFLIGHT_DISABLED=true.
+
         examples:
         - name: Usage with minimum input. This form will deploy the IoT Operations foundation layer.
           text: >
@@ -1831,7 +1838,10 @@ def load_iotops_help():
           queues.
 
           To enable edge to cloud resource hydration please use the
-          `az iot ops rsync enable` command post instance creation.
+          `az iot ops enable-rsync` command post instance creation.
+
+          To skip pre-flight validation checks (such as cluster health), set the environment
+          variable AIO_CLI_INIT_PREFLIGHT_DISABLED=true.
 
         examples:
         - name: Create the target instance with minimum input.

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -1802,9 +1802,6 @@ def load_iotops_help():
                         AgentOperationTimeoutInMinutes=20
                         global.telemetry.enabled=true
 
-                      To skip pre-flight validation checks (such as cluster health), set the environment
-                      variable AIO_CLI_INIT_PREFLIGHT_DISABLED=true.
-
         examples:
         - name: Usage with minimum input. This form will deploy the IoT Operations foundation layer.
           text: >
@@ -1839,9 +1836,6 @@ def load_iotops_help():
 
           To enable edge to cloud resource hydration please use the
           `az iot ops enable-rsync` command post instance creation.
-
-          To skip pre-flight validation checks (such as cluster health), set the environment
-          variable AIO_CLI_INIT_PREFLIGHT_DISABLED=true.
 
         examples:
         - name: Create the target instance with minimum input.

--- a/azext_edge/edge/commands_edge.py
+++ b/azext_edge/edge/commands_edge.py
@@ -102,6 +102,7 @@ def init(
     context_name: Optional[str] = None,
     check_cluster: Optional[bool] = None,
     no_progress: Optional[bool] = None,
+    no_preflight: Optional[bool] = None,
     ensure_latest: Optional[bool] = None,
     user_trust: Optional[bool] = None,
     ssc_config: Optional[List[str]] = None,
@@ -117,7 +118,7 @@ def init(
     work_manager = WorkManager(cmd)
     result_payload = work_manager.execute_ops_init(
         show_progress=not no_progress,
-        pre_flight=not feature_config.is_enabled(FeatureFlag.PREFLIGHT_DISABLED),
+        pre_flight=not (no_preflight or feature_config.is_enabled(FeatureFlag.PREFLIGHT_DISABLED)),
         cluster_name=cluster_name,
         context_name=context_name,
         resource_group_name=resource_group_name,
@@ -171,6 +172,7 @@ def create_instance(
     tags: Optional[dict] = None,
     skip_sr_ra: Optional[bool] = None,
     no_progress: Optional[bool] = None,
+    no_preflight: Optional[bool] = None,
     **kwargs,
 ) -> Union[Dict[str, Any], None]:
     from .providers.orchestration.work import WorkManager
@@ -184,7 +186,7 @@ def create_instance(
     work_manager = WorkManager(cmd)
     result_payload = work_manager.execute_ops_init(
         show_progress=not no_progress,
-        pre_flight=not feature_config.is_enabled(FeatureFlag.PREFLIGHT_DISABLED),
+        pre_flight=not (no_preflight or feature_config.is_enabled(FeatureFlag.PREFLIGHT_DISABLED)),
         apply_foundation=False,
         cluster_name=cluster_name,
         resource_group_name=resource_group_name,

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1403,6 +1403,12 @@ def load_iotops_arguments(self, _):
                 options_list=["--cluster"],
                 help="Target cluster name for IoT Operations deployment.",
             )
+            context.argument(
+                "no_preflight",
+                options_list=["--no-preflight"],
+                arg_type=get_three_state_flag(),
+                help="Disable pre-flight checks such as resource provider registration and cluster health validation.",
+            )
 
     for cmd_space in ["iot ops create", "iot ops update"]:
         with self.argument_context(cmd_space) as context:

--- a/azext_edge/edge/providers/orchestration/connected_cluster.py
+++ b/azext_edge/edge/providers/orchestration/connected_cluster.py
@@ -4,9 +4,15 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
+
+from azure.core.exceptions import HttpResponseError
+from knack.log import get_logger
+
+from ...util.az_client import get_health_mgmt_client
 from ...util.resource_graph import ResourceGraph
 
+logger = get_logger(__name__)
 
 QUERIES = {
     "get_custom_location_for_namespace": """
@@ -72,6 +78,7 @@ class ConnectedCluster:
         self.resource_group_name = resource_group_name
         self.resource_graph = ResourceGraph(cmd=cmd, subscriptions=[self.subscription_id])
         self._resource_state = None
+        self._health_state = None
 
         # TODO - @digimaun - temp necessary due to circular import
         from ..orchestration.resources import ConnectedClusters
@@ -91,13 +98,35 @@ class ConnectedCluster:
         return self._resource_state
 
     @property
+    def health_state(self) -> Optional[dict]:
+        if not self._health_state:
+            try:
+                # Consider if health_client should be cached
+                health_client = get_health_mgmt_client(subscription_id=self.subscription_id)
+                self._health_state = health_client.availability_statuses.get_by_resource(self.resource_id)
+            except HttpResponseError as e:
+                logger.debug(f"Failed to retrieve resource health state: {e}")
+                return None
+        return self._health_state
+
+    @property
     def location(self) -> str:
         return self.resource["location"]
 
     @property
     def connected(self) -> bool:
         properties = self.resource.get("properties", {})
-        return "connectivityStatus" in properties and properties["connectivityStatus"].lower() == "connected"
+        connectivity_status: str = properties.get("connectivityStatus", "Unknown")
+        return connectivity_status.lower() == "connected"
+
+    @property
+    def available(self) -> bool:
+        health = self.health_state
+        if not health:
+            return True
+        properties = health.get("properties", {})
+        availability_state: str = properties.get("availabilityState", "Unknown")
+        return availability_state.lower() != "unavailable"
 
     @property
     def extensions(self) -> List[dict]:

--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -29,8 +29,9 @@ def register_providers(subscription_id: str, resource_provider: Optional[str] = 
     required_providers = [resource_provider] if resource_provider else RP_NAMESPACE_SET
     for provider in providers_list:
         if "namespace" in provider and provider["namespace"] in required_providers:
-            if provider["registrationState"] == "Registered":
-                logger.debug("RP %s is already registered.", provider["namespace"])
+            registration_state = provider.get("registrationState", "")
+            if registration_state.lower() in ("registered", "registering"):
+                logger.debug("RP %s state: %s. Skipping.", provider["namespace"], registration_state)
                 continue
             logger.debug("Registering RP %s.", provider["namespace"])
             resource_client.providers.register(provider["namespace"])

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -28,7 +28,6 @@ from azext_edge.edge.providers.orchestration.base import verify_arc_cluster_conf
 from ...util.az_client import (
     DeviceRegistryMgmtApiVersion,
     get_api_error_str,
-    get_health_mgmt_client,
     get_resource_client,
     parse_resource_id,
     wait_for_terminal_state,
@@ -122,7 +121,6 @@ class WorkManager:
         self.subscription_id: str = get_subscription_id(cli_ctx=cmd.cli_ctx)
         self.resource_client = get_resource_client(subscription_id=self.subscription_id)
         self.permission_manager = PermissionManager(subscription_id=self.subscription_id)
-        self.health_client = get_health_mgmt_client(subscription_id=self.subscription_id)
         self.custom_locations = CustomLocations(self.cmd)
 
     def _bootstrap_ux(self, show_progress: bool = False):
@@ -379,10 +377,7 @@ class WorkManager:
                 )
 
                 # WorkStepKey.ENUMERATE_PRE_FLIGHT
-                # TODO @digimaun
-                self.health_client.availability_statuses.get_by_resource(
-                    self._resource_map.connected_cluster.resource_id
-                )
+                self._eval_cluster_health()
                 if self._check_cluster:
                     cluster_check_kwargs = self._build_cluster_check_kwargs()
                     # TODO - load_config_context should be moved down to functions that directly call it
@@ -694,3 +689,23 @@ class WorkManager:
                 f"'az iot ops delete --cluster {self._targets.cluster_name} -g {self._targets.resource_group_name}'\n"
                 "to uninstall the existing deployment prior to running ops create."
             )
+
+    def _eval_cluster_health(self):
+        if self._resource_map.connected_cluster.available:
+            return
+
+        properties: dict = self._resource_map.connected_cluster.health_state.get("properties", {})
+        summary = properties.get("summary", "No additional details available.")
+        reason_type = properties.get("reasonType", "")
+
+        error_msg = (
+            f"The connected cluster '{self._targets.cluster_name}' is currently unavailable.\n\nSummary: {summary}"
+        )
+        if reason_type:
+            error_msg += f"\nReason: {reason_type}"
+
+        error_msg += (
+            "\n\nPlease resolve the cluster health issues before deploying Azure IoT Operations.\n"
+            "For more information, check the Azure portal Resource Health blade for this cluster."
+        )
+        raise ValidationError(error_msg)

--- a/azext_edge/tests/edge/orchestration/test_base_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_base_unit.py
@@ -160,14 +160,16 @@ def test_verify_custom_location_namespace(
 
 
 @pytest.mark.parametrize(
-    "registration_state",
+    "registration_state, should_register",
     [
-        "Registered",
-        "NotRegistered",
+        ("Registered", False),
+        ("Registering", False),
+        ("NotRegistered", True),
+        ("Unregistered", True),  # Edge case - any other state triggers registration
     ],
 )
 @pytest.mark.parametrize("input_rp", [None, "Microsoft.DeviceRegistry"])
-def test_register_providers(mocker, registration_state, input_rp):
+def test_register_providers(mocker, registration_state, should_register, input_rp):
     mocked_get_resource_client: Mock = mocker.patch(
         "azext_edge.edge.providers.orchestration.rp_namespace.get_resource_client"
     )
@@ -184,6 +186,7 @@ def test_register_providers(mocker, registration_state, input_rp):
     ]
     if input_rp:
         iot_ops_rps = [input_rp]
+
     mocked_get_resource_client().providers.list.return_value = [
         {"namespace": namespace, "registrationState": registration_state} for namespace in iot_ops_rps
     ]
@@ -193,7 +196,11 @@ def test_register_providers(mocker, registration_state, input_rp):
     assert len(iot_ops_rps) == (1 if input_rp else len(RP_NAMESPACE_SET))
 
     register_providers(ZEROED_SUB)
+
     mocked_get_resource_client().providers.list.assert_called_once()
-    if registration_state == "NotRegistered":
+    if should_register:
+        assert mocked_get_resource_client().providers.register.call_count == len(iot_ops_rps)
         for rp in iot_ops_rps:
             mocked_get_resource_client().providers.register.assert_any_call(rp)
+    else:
+        mocked_get_resource_client().providers.register.assert_not_called()

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -419,7 +419,7 @@ def build_target_scenario(
         "trust": {"userTrust": None, "settings": None},
         "enableFaultTolerance": None,
         "check_cluster": None,
-        "ensureLatest": None,
+        "ensure_latest": None,
         "schemaRegistry": {
             "id": generate_resource_id(
                 resource_group_name=resource_group_name,
@@ -439,7 +439,8 @@ def build_target_scenario(
         },
         "dataflow": {"profileInstances": None},
         "broker": {},
-        "noProgress": True,
+        "no_progress": True,
+        "no_preflight": None,
         "raises": raises,
         "omitHttpMethods": omit_http_methods,
         "apiControl": {
@@ -558,6 +559,10 @@ def assert_exception(expected_exc_meta: ExceptionMeta, call_func: Callable, call
                 }
             },
         ),
+        # Test --no-preflight skips pre-flight checks
+        build_target_scenario(
+            no_preflight=True,
+        ),
     ],
 )
 def test_iot_ops_init(
@@ -581,13 +586,12 @@ def test_iot_ops_init(
     if target_scenario["trust"]["userTrust"]:
         init_call_kwargs["user_trust"] = target_scenario["trust"]["userTrust"]
 
-    if target_scenario["noProgress"]:
-        init_call_kwargs["no_progress"] = target_scenario["noProgress"]
-    if target_scenario["ensureLatest"]:
-        init_call_kwargs["ensure_latest"] = target_scenario["ensureLatest"]
+    optional_flags = ["no_progress", "ensure_latest", "check_cluster", "no_preflight"]
+    for key in optional_flags:
+        if target_scenario.get(key):
+            init_call_kwargs[key] = target_scenario[key]
 
-    if target_scenario["check_cluster"]:
-        init_call_kwargs["check_cluster"] = target_scenario["check_cluster"]
+    preflight_calls = int(not bool(target_scenario.get("no_preflight")))
 
     exc_meta: Optional[ExceptionMeta] = target_scenario.get("raises")
     if exc_meta:
@@ -598,9 +602,9 @@ def test_iot_ops_init(
     init_result = init(**init_call_kwargs)  # pylint: disable=assignment-from-no-return
     expected_call_count_map = {
         CallKey.CONNECT_RESOURCE_MANAGER: 1,
-        CallKey.GET_RESOURCE_PROVIDERS: 1,
+        CallKey.GET_RESOURCE_PROVIDERS: preflight_calls,
         CallKey.GET_CLUSTER: 1,
-        CallKey.GET_RESOURCE_HEALTH: 1,
+        CallKey.GET_RESOURCE_HEALTH: preflight_calls,
         CallKey.DEPLOY_INIT_WHATIF: 1,
         CallKey.DEPLOY_INIT: 1,
     }
@@ -609,7 +613,7 @@ def test_iot_ops_init(
     assert_cluster_prechecks(mock_prechecks, target_scenario)
 
     # TODO - @digimaun
-    if target_scenario["noProgress"]:
+    if target_scenario["no_progress"]:
         assert init_result is None
 
 
@@ -889,8 +893,11 @@ def test_iot_ops_create(
     if instance_features:
         create_call_kwargs["instance_features"] = instance_features
 
-    if target_scenario["noProgress"]:
-        create_call_kwargs["no_progress"] = target_scenario["noProgress"]
+    for key in ["no_progress", "no_preflight"]:
+        if target_scenario.get(key):
+            create_call_kwargs[key] = target_scenario[key]
+
+    preflight_calls = int(not bool(target_scenario.get("no_preflight")))
 
     # TODO: Simplify existing arg plumbing to this style for simplification
     for key in ["persist_max_size", "persist_pvc_sc", "persist_mode"]:
@@ -898,6 +905,7 @@ def test_iot_ops_create(
             create_call_kwargs[key] = target_scenario[key]
 
     skip_sr_ra = target_scenario.get("skip_sr_ra")
+    sr_ra_calls = int(not bool(skip_sr_ra))
     create_call_kwargs["skip_sr_ra"] = skip_sr_ra
 
     exc_meta: Optional[ExceptionMeta] = target_scenario.get("raises")
@@ -910,15 +918,15 @@ def test_iot_ops_create(
 
     expected_call_count_map = {
         CallKey.CONNECT_RESOURCE_MANAGER: 1,
-        CallKey.GET_RESOURCE_PROVIDERS: 1,
+        CallKey.GET_RESOURCE_PROVIDERS: preflight_calls,
         CallKey.GET_CLUSTER: 1,
-        CallKey.GET_RESOURCE_HEALTH: 1,
+        CallKey.GET_RESOURCE_HEALTH: preflight_calls,
         CallKey.GET_SCHEMA_REGISTRY: 1,
         CallKey.GET_ADR_NAMESPACE: 1,
         CallKey.GET_CLUSTER_EXTENSIONS: 2,
         CallKey.GET_EXISTING_DEPLOYMENTS: 1,
-        CallKey.GET_SCHEMA_REGISTRY_RA: 0 if skip_sr_ra else 1,
-        CallKey.PUT_SCHEMA_REGISTRY_RA: 0 if skip_sr_ra else 1,
+        CallKey.GET_SCHEMA_REGISTRY_RA: sr_ra_calls,
+        CallKey.PUT_SCHEMA_REGISTRY_RA: sr_ra_calls,
         CallKey.CREATE_CUSTOM_LOCATION: 2,
         CallKey.DEPLOY_CREATE_EXT: 1,
         CallKey.DEPLOY_CREATE_INSTANCE: 1,
@@ -929,7 +937,7 @@ def test_iot_ops_create(
     assert_logger(mocked_logger, target_scenario)
 
     # TODO - @digimaun
-    if target_scenario["noProgress"]:
+    if target_scenario["no_progress"]:
         assert create_result is None
 
 

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -550,7 +550,7 @@ def assert_exception(expected_exc_meta: ExceptionMeta, call_func: Callable, call
                 }
             },
         ),
-        # Resource Health API failure (403) - should pass (graceful degradation)
+        # Resource Health API failure (403) - should pass
         build_target_scenario(
             apiControl={
                 CallKey.GET_RESOURCE_HEALTH: {
@@ -559,7 +559,6 @@ def assert_exception(expected_exc_meta: ExceptionMeta, call_func: Callable, call
                 }
             },
         ),
-        # Test --no-preflight skips pre-flight checks
         build_target_scenario(
             no_preflight=True,
         ),

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -178,7 +178,8 @@ class ServiceGenerator:
             if "/providers/Microsoft.ResourceHealth/availabilityStatuses/current" in request_kpis.path_url:
                 assert request_kpis.params["api-version"] == ExpectedAPIVersion.RESOURCE_HEALTH.value
                 self.call_map[CallKey.GET_RESOURCE_HEALTH].append(request_kpis)
-                return (200, STANDARD_HEADERS, json.dumps({"properties": {"availabilityState": "Available"}}))
+                api_control = self.scenario["apiControl"][CallKey.GET_RESOURCE_HEALTH]
+                return (api_control["code"], STANDARD_HEADERS, json.dumps(api_control["body"]))
 
     def _handle_init(self, request_kpis: RequestKPIs):
         url_deployment_seg = r"/providers/Microsoft\.Resources/deployments/aziotops\.enablement\.[a-zA-Z0-9\.-]+"
@@ -448,6 +449,7 @@ def build_target_scenario(
             CallKey.GET_EXISTING_DEPLOYMENTS: {"code": 200, "body": {"data": []}},
             CallKey.GET_SCHEMA_REGISTRY: {"code": 200, "body": {}},
             CallKey.GET_ADR_NAMESPACE: {"code": 200, "body": {}},
+            CallKey.GET_RESOURCE_HEALTH: {"code": 200, "body": {"properties": {"availabilityState": "Available"}}},
         },
     }
     if "cluster_properties" in kwargs:
@@ -514,6 +516,47 @@ def assert_exception(expected_exc_meta: ExceptionMeta, call_func: Callable, call
         ),
         build_target_scenario(
             check_cluster=True,
+        ),
+        build_target_scenario(
+            apiControl={
+                CallKey.GET_RESOURCE_HEALTH: {
+                    "code": 200,
+                    "body": {
+                        "properties": {
+                            "availabilityState": "Unavailable",
+                            "summary": "The cluster is experiencing issues.",
+                            "reasonType": "PlatformInitiated",
+                        }
+                    },
+                }
+            },
+            raises=ExceptionMeta(
+                exc_type=ValidationError,
+                exc_msg=[
+                    "is currently unavailable",
+                    "The cluster is experiencing issues.",
+                    "PlatformInitiated",
+                ],
+            ),
+            omit_http_methods=frozenset([responses.PUT, responses.POST]),
+        ),
+        # Cluster health unknown - should pass
+        build_target_scenario(
+            apiControl={
+                CallKey.GET_RESOURCE_HEALTH: {
+                    "code": 200,
+                    "body": {"properties": {"availabilityState": "Unknown"}},
+                }
+            },
+        ),
+        # Resource Health API failure (403) - should pass (graceful degradation)
+        build_target_scenario(
+            apiControl={
+                CallKey.GET_RESOURCE_HEALTH: {
+                    "code": 403,
+                    "body": {"error": {"code": "AuthorizationFailed", "message": "Access denied."}},
+                }
+            },
         ),
     ],
 )
@@ -782,6 +825,25 @@ def assert_cluster_prechecks(mock_prechecks: Dict[str, Mock], target_scenario: d
         ),
         build_target_scenario(
             skip_sr_ra=True,
+        ),
+        build_target_scenario(
+            apiControl={
+                CallKey.GET_RESOURCE_HEALTH: {
+                    "code": 200,
+                    "body": {
+                        "properties": {
+                            "availabilityState": "Unavailable",
+                            "summary": "The cluster is experiencing issues.",
+                            "reasonType": "PlatformInitiated",
+                        }
+                    },
+                }
+            },
+            raises=ExceptionMeta(
+                exc_type=ValidationError,
+                exc_msg="is currently unavailable",
+            ),
+            omit_http_methods=frozenset([responses.PUT, responses.POST]),
         ),
     ],
 )

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -849,6 +849,9 @@ def assert_cluster_prechecks(mock_prechecks: Dict[str, Mock], target_scenario: d
             ),
             omit_http_methods=frozenset([responses.PUT, responses.POST]),
         ),
+        build_target_scenario(
+            no_preflight=True,
+        ),
     ],
 )
 def test_iot_ops_create(


### PR DESCRIPTION
- The availabilityState can be Available, Unavailable, Unknown, or Degraded. This change set currently only considers "Unavailable" as a blocking validation error. Main idea being to block when there is for sure a problem.
- Other availability states, or http errors attempting to fetch the availability state are handled silently/non-blocking.
- Summary and reasonType (if exists) will be shown with the ValidationError.
- Re-introduce `--no-preflight` for `ops init` and `ops create`. Takes priority over respective env var.
- RP registration won't be attempted if state is registering.