### PR TITLE
feat: adds optional rp registration mechanism.

### DIFF
--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -4,11 +4,15 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import Optional, Set
+from typing import TYPE_CHECKING, Optional, Set
 
 from knack.log import get_logger
 
 from ...util.az_client import get_resource_client
+
+if TYPE_CHECKING:
+    from ...util.az_client import ResourceManagementClient
+
 
 logger = get_logger(__name__)
 
@@ -61,7 +65,7 @@ def register_providers(subscription_id: str, resource_provider: Optional[str] = 
     return failed_optional
 
 
-def _register_rp(resource_client, providers: dict, namespace: str, optional: bool) -> bool:
+def _register_rp(resource_client: "ResourceManagementClient", providers: dict, namespace: str, optional: bool) -> bool:
     """
     Register a single RP if needed.
 

--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -36,6 +36,28 @@ RP_NAMESPACE_OPTIONAL_SET = frozenset(
 )
 
 
+def _needs_registration(state: str) -> bool:
+    return state.lower() not in ("registered", "registering")
+
+
+def _try_register(resource_client: "ResourceManagementClient", namespace: str, optional: bool) -> bool:
+    """
+    Attempt to register a single RP.
+
+    Returns:
+        True if successful, False if optional and failed.
+    """
+    try:
+        logger.debug("Registering RP %s.", namespace)
+        resource_client.providers.register(namespace)
+        return True
+    except Exception as e:
+        if optional:
+            logger.debug("Optional RP %s registration failed: %s. Continuing.", namespace, e)
+            return False
+        raise
+
+
 def register_providers(subscription_id: str, resource_provider: Optional[str] = None) -> Set[str]:
     """
     Register resource providers for IoT Operations.
@@ -51,39 +73,18 @@ def register_providers(subscription_id: str, resource_provider: Optional[str] = 
     providers = {p["namespace"]: p.get("registrationState", "") for p in resource_client.providers.list()}
 
     if resource_provider:
-        _register_rp(resource_client, providers, resource_provider, optional=False)
+        if _needs_registration(providers.get(resource_provider, "")):
+            _try_register(resource_client, resource_provider, optional=False)
         return set()
 
     for rp in RP_NAMESPACE_SET:
-        _register_rp(resource_client, providers, rp, optional=False)
+        if _needs_registration(providers.get(rp, "")):
+            _try_register(resource_client, rp, optional=False)
 
     failed_optional: Set[str] = set()
     for rp in RP_NAMESPACE_OPTIONAL_SET:
-        if not _register_rp(resource_client, providers, rp, optional=True):
-            failed_optional.add(rp)
+        if _needs_registration(providers.get(rp, "")):
+            if not _try_register(resource_client, rp, optional=True):
+                failed_optional.add(rp)
 
     return failed_optional
-
-
-def _register_rp(resource_client: "ResourceManagementClient", providers: dict, namespace: str, optional: bool) -> bool:
-    """
-    Register a single RP if needed.
-
-    Returns:
-        True if successful or already registered, False if optional and failed.
-    """
-    state = providers.get(namespace, "").lower()
-
-    if state in ("registered", "registering"):
-        logger.debug("RP %s state: %s. Skipping.", namespace, state)
-        return True
-
-    try:
-        logger.debug("Registering RP %s.", namespace)
-        resource_client.providers.register(namespace)
-        return True
-    except Exception as e:
-        if optional:
-            logger.debug("Optional RP %s registration failed: %s. Continuing.", namespace, e)
-            return False
-        raise

--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -4,7 +4,8 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import Optional
+from typing import Optional, Set
+
 from knack.log import get_logger
 
 from ...util.az_client import get_resource_client
@@ -13,25 +14,72 @@ logger = get_logger(__name__)
 
 
 ADR_PROVIDER = "Microsoft.DeviceRegistry"
+
+# Required RPs - registration failure will block deployment
 RP_NAMESPACE_SET = frozenset(
     [
         "Microsoft.IoTOperations",
         "Microsoft.SecretSyncController",
         ADR_PROVIDER,
+    ]
+)
+
+# Optional RPs - registration failure is logged but won't block deployment
+RP_NAMESPACE_OPTIONAL_SET = frozenset(
+    [
         "Microsoft.ResourceHealth",
     ]
 )
 
 
-def register_providers(subscription_id: str, resource_provider: Optional[str] = None):
+def register_providers(subscription_id: str, resource_provider: Optional[str] = None) -> Set[str]:
+    """
+    Register resource providers for IoT Operations.
+
+    Args:
+        subscription_id: Azure subscription ID.
+        resource_provider: Specific RP to register. If None, registers all default RPs.
+
+    Returns:
+        Set of optional RPs that failed to register.
+    """
     resource_client = get_resource_client(subscription_id=subscription_id)
-    providers_list = resource_client.providers.list()
-    required_providers = [resource_provider] if resource_provider else RP_NAMESPACE_SET
-    for provider in providers_list:
-        if "namespace" in provider and provider["namespace"] in required_providers:
-            registration_state = provider.get("registrationState", "")
-            if registration_state.lower() in ("registered", "registering"):
-                logger.debug("RP %s state: %s. Skipping.", provider["namespace"], registration_state)
-                continue
-            logger.debug("Registering RP %s.", provider["namespace"])
-            resource_client.providers.register(provider["namespace"])
+    providers = {p["namespace"]: p.get("registrationState", "") for p in resource_client.providers.list()}
+
+    if resource_provider:
+        _register_rp(resource_client, providers, resource_provider, optional=False)
+        return set()
+
+    for rp in RP_NAMESPACE_SET:
+        _register_rp(resource_client, providers, rp, optional=False)
+
+    failed_optional: Set[str] = set()
+    for rp in RP_NAMESPACE_OPTIONAL_SET:
+        if not _register_rp(resource_client, providers, rp, optional=True):
+            failed_optional.add(rp)
+
+    return failed_optional
+
+
+def _register_rp(resource_client, providers: dict, namespace: str, optional: bool) -> bool:
+    """
+    Register a single RP if needed.
+
+    Returns:
+        True if successful or already registered, False if optional and failed.
+    """
+    state = providers.get(namespace, "").lower()
+
+    if state in ("registered", "registering"):
+        logger.debug("RP %s state: %s. Skipping.", namespace, state)
+        return True
+
+    try:
+        logger.debug("Registering RP %s.", namespace)
+        resource_client.providers.register(namespace)
+        return True
+    except Exception as e:
+        if optional:
+            logger.debug("Optional RP %s registration failed: %s. Continuing.", namespace, e)
+            return False
+        raise

--- a/azext_edge/edge/providers/orchestration/rp_namespace.py
+++ b/azext_edge/edge/providers/orchestration/rp_namespace.py
@@ -18,6 +18,7 @@ logger = get_logger(__name__)
 
 
 ADR_PROVIDER = "Microsoft.DeviceRegistry"
+HEALTH_PROVIDER = "Microsoft.ResourceHealth"
 
 # Required RPs - registration failure will block deployment
 RP_NAMESPACE_SET = frozenset(
@@ -31,7 +32,7 @@ RP_NAMESPACE_SET = frozenset(
 # Optional RPs - registration failure is logged but won't block deployment
 RP_NAMESPACE_OPTIONAL_SET = frozenset(
     [
-        "Microsoft.ResourceHealth",
+        HEALTH_PROVIDER,
     ]
 )
 

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -46,6 +46,7 @@ from .common import (
 from .permissions import ROLE_DEF_FORMAT_STR, PermissionManager, PrincipalType
 from .resource_map import IoTOperationsResourceMap
 from .resources.custom_locations import CustomLocations
+from .rp_namespace import HEALTH_PROVIDER, register_providers
 from .targets import InitTargets, InstancePhase
 
 logger = get_logger(__name__)
@@ -357,7 +358,6 @@ class WorkManager:
 
     def _do_work(self):
         from .host import verify_cli_client_connections
-        from .rp_namespace import register_providers
 
         try:
             # Ensure connection to ARM if needed. Show remediation error message otherwise.
@@ -378,7 +378,7 @@ class WorkManager:
 
                 # WorkStepKey.ENUMERATE_PRE_FLIGHT
                 # Skip health check if ResourceHealth RP registration failed
-                if "Microsoft.ResourceHealth" not in failed_optional_rps:
+                if HEALTH_PROVIDER not in failed_optional_rps:
                     self._eval_cluster_health()
                 if self._check_cluster:
                     cluster_check_kwargs = self._build_cluster_check_kwargs()

--- a/azext_edge/edge/providers/orchestration/work.py
+++ b/azext_edge/edge/providers/orchestration/work.py
@@ -369,7 +369,7 @@ class WorkManager:
             if self._pre_flight:
                 # WorkStepKey.REG_RP
                 self._render_display(category=WorkCategoryKey.PRE_FLIGHT, active_step=WorkStepKey.REG_RP)
-                register_providers(self.subscription_id)
+                failed_optional_rps = register_providers(self.subscription_id)
                 self._complete_step(
                     category=WorkCategoryKey.PRE_FLIGHT,
                     completed_step=WorkStepKey.REG_RP,
@@ -377,7 +377,9 @@ class WorkManager:
                 )
 
                 # WorkStepKey.ENUMERATE_PRE_FLIGHT
-                self._eval_cluster_health()
+                # Skip health check if ResourceHealth RP registration failed
+                if "Microsoft.ResourceHealth" not in failed_optional_rps:
+                    self._eval_cluster_health()
                 if self._check_cluster:
                     cluster_check_kwargs = self._build_cluster_check_kwargs()
                     # TODO - load_config_context should be moved down to functions that directly call it
@@ -691,10 +693,15 @@ class WorkManager:
             )
 
     def _eval_cluster_health(self):
-        if self._resource_map.connected_cluster.available:
+        connected_cluster = self._resource_map.connected_cluster
+        if connected_cluster.available:
             return
 
-        properties: dict = self._resource_map.connected_cluster.health_state.get("properties", {})
+        health_state = connected_cluster.health_state
+        if not health_state:
+            return
+
+        properties: dict = health_state.get("properties", {})
         summary = properties.get("summary", "No additional details available.")
         reason_type = properties.get("reasonType", "")
 

--- a/azext_edge/tests/edge/orchestration/test_base_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_base_unit.py
@@ -336,27 +336,20 @@ class TestRegisterProviders:
 
         mocked_resource_client.assert_any_call(subscription_id=test_sub)
 
-    def test_mixed_registration_states(self, mocked_resource_client, rp_constants):
+    def test_mixed_registration_states(self, mocked_resource_client):
         """Only RPs not in Registered/Registering state trigger registration."""
         from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
 
-        providers = {}
-        required_list = list(rp_constants["required"])
-        if len(required_list) >= 2:
-            providers[required_list[0]] = "Registered"
-            providers[required_list[1]] = "NotRegistered"
-            for rp in required_list[2:]:
-                providers[rp] = "Registering"
-        for rp in rp_constants["optional"]:
-            providers[rp] = "NotRegistered"
+        providers = {
+            "Microsoft.IoTOperations": "Registered",
+            "Microsoft.SecretSyncController": "NotRegistered",
+            "Microsoft.DeviceRegistry": "Registering",
+            "Microsoft.ResourceHealth": "NotRegistered",
+        }
 
         self._setup_client(mocked_resource_client, providers)
-
         result = register_providers(ZEROED_SUB)
 
         registered_rps = self._get_registered_rps(mocked_resource_client)
-        expected_to_register = {
-            rp for rp, state in providers.items() if state.lower() not in ("registered", "registering")
-        }
-        assert registered_rps == expected_to_register
+        assert registered_rps == {"Microsoft.SecretSyncController", "Microsoft.ResourceHealth"}
         assert result == set()

--- a/azext_edge/tests/edge/orchestration/test_base_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_base_unit.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 from azure.cli.core.azclierror import ValidationError
+from azure.core.exceptions import HttpResponseError
 
 from azext_edge.edge.providers.orchestration.connected_cluster import ConnectedCluster
 
@@ -217,9 +218,9 @@ class TestRegisterProviders:
         from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
 
         self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], "NotRegistered"))
-        mocked_resource_client().providers.register.side_effect = Exception("Permission denied")
+        mocked_resource_client().providers.register.side_effect = HttpResponseError("Permission denied")
 
-        with pytest.raises(Exception, match="Permission denied"):
+        with pytest.raises(HttpResponseError, match="Permission denied"):
             register_providers(ZEROED_SUB)
 
     def test_optional_rp_failure_returns_failed_set(self, mocked_resource_client, rp_constants):
@@ -229,7 +230,7 @@ class TestRegisterProviders:
 
         def fail_optional_only(namespace):
             if namespace in rp_constants["optional"]:
-                raise Exception("Permission denied")
+                raise HttpResponseError("Permission denied")
 
         mocked_resource_client().providers.register.side_effect = fail_optional_only
 
@@ -259,7 +260,7 @@ class TestRegisterProviders:
 
         def fail_optional_only(namespace):
             if namespace in rp_constants["optional"]:
-                raise Exception("Permission denied")
+                raise HttpResponseError("Permission denied")
 
         mocked_resource_client().providers.register.side_effect = fail_optional_only
 
@@ -296,9 +297,9 @@ class TestRegisterProviders:
 
         target_rp = "Microsoft.DeviceRegistry"
         self._setup_client(mocked_resource_client, {target_rp: "NotRegistered"})
-        mocked_resource_client().providers.register.side_effect = Exception("Permission denied")
+        mocked_resource_client().providers.register.side_effect = HttpResponseError("Permission denied")
 
-        with pytest.raises(Exception, match="Permission denied"):
+        with pytest.raises(HttpResponseError, match="Permission denied"):
             register_providers(ZEROED_SUB, resource_provider=target_rp)
 
     def test_single_rp_missing_attempts_registration(self, mocked_resource_client):

--- a/azext_edge/tests/edge/orchestration/test_base_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_base_unit.py
@@ -354,3 +354,23 @@ class TestRegisterProviders:
         registered_rps = self._get_registered_rps(mocked_resource_client)
         assert registered_rps == {"Microsoft.SecretSyncController", "Microsoft.ResourceHealth"}
         assert result == set()
+
+
+class TestNeedsRegistration:
+    @pytest.mark.parametrize("state,expected", [
+        ("Registered", False),
+        ("registered", False),
+        ("REGISTERED", False),
+        ("Registering", False),
+        ("registering", False),
+        ("REGISTERING", False),
+        ("NotRegistered", True),
+        ("Unregistered", True),
+        ("", True),
+        ("Failed", True),
+        ("Unknown", True),
+    ])
+    def test_needs_registration_states(self, state, expected):
+        from azext_edge.edge.providers.orchestration.rp_namespace import _needs_registration
+
+        assert _needs_registration(state) == expected

--- a/azext_edge/tests/edge/orchestration/test_base_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_base_unit.py
@@ -159,48 +159,204 @@ def test_verify_custom_location_namespace(
     )
 
 
-@pytest.mark.parametrize(
-    "registration_state, should_register",
-    [
-        ("Registered", False),
-        ("Registering", False),
-        ("NotRegistered", True),
-        ("Unregistered", True),  # Edge case - any other state triggers registration
-    ],
-)
-@pytest.mark.parametrize("input_rp", [None, "Microsoft.DeviceRegistry"])
-def test_register_providers(mocker, registration_state, should_register, input_rp):
-    mocked_get_resource_client: Mock = mocker.patch(
-        "azext_edge.edge.providers.orchestration.rp_namespace.get_resource_client"
-    )
-    from azext_edge.edge.providers.orchestration.rp_namespace import (
-        RP_NAMESPACE_SET,
-        register_providers,
-    )
+class TestRegisterProviders:
+    @pytest.fixture
+    def mocked_resource_client(self, mocker) -> Mock:
+        return mocker.patch("azext_edge.edge.providers.orchestration.rp_namespace.get_resource_client")
 
-    iot_ops_rps = [
-        "Microsoft.IoTOperations",
-        "Microsoft.DeviceRegistry",
-        "Microsoft.SecretSyncController",
-        "Microsoft.ResourceHealth",
-    ]
-    if input_rp:
-        iot_ops_rps = [input_rp]
+    @pytest.fixture
+    def rp_constants(self):
+        from azext_edge.edge.providers.orchestration.rp_namespace import (
+            RP_NAMESPACE_SET,
+            RP_NAMESPACE_OPTIONAL_SET,
+        )
 
-    mocked_get_resource_client().providers.list.return_value = [
-        {"namespace": namespace, "registrationState": registration_state} for namespace in iot_ops_rps
-    ]
+        return {
+            "required": RP_NAMESPACE_SET,
+            "optional": RP_NAMESPACE_OPTIONAL_SET,
+            "all": RP_NAMESPACE_SET | RP_NAMESPACE_OPTIONAL_SET,
+        }
 
-    for rp in iot_ops_rps:
-        assert rp in RP_NAMESPACE_SET
-    assert len(iot_ops_rps) == (1 if input_rp else len(RP_NAMESPACE_SET))
+    def _build_providers(self, namespaces, state: str) -> dict:
+        return {ns: state for ns in namespaces}
 
-    register_providers(ZEROED_SUB)
+    def _setup_client(self, mocked_resource_client, providers: dict):
+        mocked_resource_client().providers.list.return_value = [
+            {"namespace": ns, "registrationState": state} for ns, state in providers.items()
+        ]
 
-    mocked_get_resource_client().providers.list.assert_called_once()
-    if should_register:
-        assert mocked_get_resource_client().providers.register.call_count == len(iot_ops_rps)
-        for rp in iot_ops_rps:
-            mocked_get_resource_client().providers.register.assert_any_call(rp)
-    else:
-        mocked_get_resource_client().providers.register.assert_not_called()
+    def _get_registered_rps(self, mocked_resource_client) -> set:
+        return {call.args[0] for call in mocked_resource_client().providers.register.call_args_list}
+
+    @pytest.mark.parametrize("state", ["Registered", "registered", "Registering", "registering"])
+    def test_skips_already_registered(self, mocked_resource_client, rp_constants, state):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], state))
+
+        result = register_providers(ZEROED_SUB)
+
+        mocked_resource_client().providers.list.assert_called_once()
+        mocked_resource_client().providers.register.assert_not_called()
+        assert result == set()
+
+    @pytest.mark.parametrize("state", ["NotRegistered", "Unregistered", ""])
+    def test_registers_unregistered_rps(self, mocked_resource_client, rp_constants, state):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], state))
+
+        result = register_providers(ZEROED_SUB)
+
+        assert mocked_resource_client().providers.register.call_count == len(rp_constants["all"])
+        registered_rps = self._get_registered_rps(mocked_resource_client)
+        assert registered_rps == rp_constants["all"]
+        assert result == set()
+
+    def test_required_rp_failure_raises(self, mocked_resource_client, rp_constants):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], "NotRegistered"))
+        mocked_resource_client().providers.register.side_effect = Exception("Permission denied")
+
+        with pytest.raises(Exception, match="Permission denied"):
+            register_providers(ZEROED_SUB)
+
+    def test_optional_rp_failure_returns_failed_set(self, mocked_resource_client, rp_constants):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], "NotRegistered"))
+
+        def fail_optional_only(namespace):
+            if namespace in rp_constants["optional"]:
+                raise Exception("Permission denied")
+
+        mocked_resource_client().providers.register.side_effect = fail_optional_only
+
+        result = register_providers(ZEROED_SUB)
+
+        registered_rps = self._get_registered_rps(mocked_resource_client)
+        assert registered_rps == rp_constants["all"]
+        assert result == rp_constants["optional"]
+        assert result.isdisjoint(rp_constants["required"])
+
+    def test_missing_rps_attempt_registration(self, mocked_resource_client, rp_constants):
+        """RPs not in the providers list get empty state, triggering registration."""
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, {})
+
+        result = register_providers(ZEROED_SUB)
+
+        registered_rps = self._get_registered_rps(mocked_resource_client)
+        assert registered_rps == rp_constants["all"]
+        assert result == set()
+
+    def test_missing_optional_rp_failure_returns_failed(self, mocked_resource_client, rp_constants):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["required"], "Registered"))
+
+        def fail_optional_only(namespace):
+            if namespace in rp_constants["optional"]:
+                raise Exception("Permission denied")
+
+        mocked_resource_client().providers.register.side_effect = fail_optional_only
+
+        result = register_providers(ZEROED_SUB)
+
+        registered_rps = self._get_registered_rps(mocked_resource_client)
+        assert registered_rps == rp_constants["optional"]
+        assert result == rp_constants["optional"]
+
+    def test_single_rp_only_registers_that_rp(self, mocked_resource_client):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        target_rp = "Microsoft.DeviceRegistry"
+        self._setup_client(mocked_resource_client, {target_rp: "NotRegistered"})
+
+        result = register_providers(ZEROED_SUB, resource_provider=target_rp)
+
+        mocked_resource_client().providers.register.assert_called_once_with(target_rp)
+        assert result == set()
+
+    def test_single_rp_skips_if_registered(self, mocked_resource_client):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        target_rp = "Microsoft.DeviceRegistry"
+        self._setup_client(mocked_resource_client, {target_rp: "Registered"})
+
+        result = register_providers(ZEROED_SUB, resource_provider=target_rp)
+
+        mocked_resource_client().providers.register.assert_not_called()
+        assert result == set()
+
+    def test_single_rp_failure_raises(self, mocked_resource_client):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        target_rp = "Microsoft.DeviceRegistry"
+        self._setup_client(mocked_resource_client, {target_rp: "NotRegistered"})
+        mocked_resource_client().providers.register.side_effect = Exception("Permission denied")
+
+        with pytest.raises(Exception, match="Permission denied"):
+            register_providers(ZEROED_SUB, resource_provider=target_rp)
+
+    def test_single_rp_missing_attempts_registration(self, mocked_resource_client):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        target_rp = "Microsoft.DeviceRegistry"
+        self._setup_client(mocked_resource_client, {})
+
+        result = register_providers(ZEROED_SUB, resource_provider=target_rp)
+
+        mocked_resource_client().providers.register.assert_called_once_with(target_rp)
+        assert result == set()
+
+    def test_required_rps_registered_before_optional(self, mocked_resource_client, rp_constants):
+        """Required RPs are processed first to fail fast if they can't be registered."""
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], "NotRegistered"))
+        call_order = []
+        mocked_resource_client().providers.register.side_effect = lambda ns: call_order.append(ns)
+
+        register_providers(ZEROED_SUB)
+
+        required_indices = [call_order.index(rp) for rp in rp_constants["required"]]
+        optional_indices = [call_order.index(rp) for rp in rp_constants["optional"]]
+        assert max(required_indices) < min(optional_indices)
+
+    def test_subscription_id_passed_to_client(self, mocked_resource_client, rp_constants):
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        self._setup_client(mocked_resource_client, self._build_providers(rp_constants["all"], "Registered"))
+        test_sub = "test-subscription-id-12345"
+
+        register_providers(test_sub)
+
+        mocked_resource_client.assert_any_call(subscription_id=test_sub)
+
+    def test_mixed_registration_states(self, mocked_resource_client, rp_constants):
+        """Only RPs not in Registered/Registering state trigger registration."""
+        from azext_edge.edge.providers.orchestration.rp_namespace import register_providers
+
+        providers = {}
+        required_list = list(rp_constants["required"])
+        if len(required_list) >= 2:
+            providers[required_list[0]] = "Registered"
+            providers[required_list[1]] = "NotRegistered"
+            for rp in required_list[2:]:
+                providers[rp] = "Registering"
+        for rp in rp_constants["optional"]:
+            providers[rp] = "NotRegistered"
+
+        self._setup_client(mocked_resource_client, providers)
+
+        result = register_providers(ZEROED_SUB)
+
+        registered_rps = self._get_registered_rps(mocked_resource_client)
+        expected_to_register = {
+            rp for rp, state in providers.items() if state.lower() not in ("registered", "registering")
+        }
+        assert registered_rps == expected_to_register
+        assert result == set()

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -33,12 +33,12 @@ from azure.cli.core.azclierror import (
 )
 
 from azext_edge.edge.common import (
+    DEFAULT_ARTIFACT_REGISTRY,
     DEFAULT_BROKER,
     DEFAULT_BROKER_AUTHN,
     DEFAULT_BROKER_LISTENER,
     DEFAULT_DATAFLOW_ENDPOINT,
     DEFAULT_DATAFLOW_PROFILE,
-    DEFAULT_ARTIFACT_REGISTRY,
 )
 from azext_edge.edge.providers.base import DEFAULT_NAMESPACE
 from azext_edge.edge.providers.orchestration.common import (
@@ -50,7 +50,10 @@ from azext_edge.edge.providers.orchestration.common import (
     OPS_EXTENSION_DEPS,
 )
 from azext_edge.edge.providers.orchestration.permissions import ROLE_DEF_FORMAT_STR
-from azext_edge.edge.providers.orchestration.rp_namespace import RP_NAMESPACE_SET
+from azext_edge.edge.providers.orchestration.rp_namespace import (
+    RP_NAMESPACE_OPTIONAL_SET,
+    RP_NAMESPACE_SET,
+)
 from azext_edge.edge.providers.orchestration.targets import (
     InstancePhase,
     get_default_cl_name,
@@ -414,7 +417,10 @@ def build_target_scenario(
         },
         "customLocation": {"name": None},
         "providerNamespace": {
-            "value": [{"namespace": namespace, "registrationState": "Registered"} for namespace in RP_NAMESPACE_SET]
+            "value": [
+                {"namespace": namespace, "registrationState": "Registered"}
+                for namespace in RP_NAMESPACE_SET.union(RP_NAMESPACE_OPTIONAL_SET)
+            ]
         },
         "trust": {"userTrust": None, "settings": None},
         "enableFaultTolerance": None,


### PR DESCRIPTION
* Applies to Microsoft.ResourceHealth.
* Idea is to support a set of optional RP(s) during pre-flight that will not terminate the deployment workflow if they cannot be registered.
* This also enables conditional checks that only apply if the backing RP is registered.
* IT run with the changeset: https://github.com/Azure/azure-iot-ops-cli-extension/actions/runs/20804355491