### PR TITLE
build: increment kubernetes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "rich>=13.6,<14.0",
-    "kubernetes>=29.0,<32.0",
+    "kubernetes>=35.0,<36.0",
     "azure-identity>=1.14.1,<1.18.0",
     "protobuf~=4.25.0",
     "opentelemetry-proto~=1.20.0",


### PR DESCRIPTION
* urllib3 2.6.0 removed HTTPResponse.getheaders() and HTTPResponse.getheader() leading to exceptions in cluster side operations.
* kubernetes 35 has an explicit !=2.6.0 rule to avoid it. The next patch version of urllib3 re-added the deprecated attributes, for now.
* Support for urllib3 >= 2.6.0 is important to avoid vulnerabilities https://nvd.nist.gov/vuln/detail/CVE-2025-66471, https://nvd.nist.gov/vuln/detail/CVE-2025-66418