### PR TITLE
feat(adr): derive endpoint version from connector template

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -12,4 +12,3 @@ EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)
 AIO_RELEASE = "2602"
-DEFAULT_REGISTRY_HOST = "mcr.microsoft.com"

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -12,3 +12,4 @@ EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)
 AIO_RELEASE = "2602"
+DEFAULT_REGISTRY_HOST = "mcr.microsoft.com"

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -225,6 +225,7 @@ def add_inbound_custom_device_endpoint(
         username_reference=username_reference,
         trust_list=trust_list,
         replace=replace,
+        is_custom_command=True,
         **kwargs
     )
 

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -20,7 +20,7 @@ from ...util.az_client import (
 from ...util.common import parse_kvp_nargs, should_continue_prompt
 from ...util.id_tools import parse_resource_id
 from ...util.queryable import Queryable
-from ..orchestration.resources.connector_templates import get_endpoint_version_from_template
+from ..orchestration.resources.connector_templates import ConnectorTemplates
 
 if TYPE_CHECKING:
     from ...vendor.clients.deviceregistrymgmt.operations import (
@@ -325,8 +325,8 @@ class NamespaceDevices(Queryable):
 
         # Set version from connector template if not provided by user
         if endpoint_version is None:
-            endpoint_version = get_endpoint_version_from_template(
-                cmd=self.cmd,
+            connector_templates = ConnectorTemplates(cmd=self.cmd)
+            endpoint_version = connector_templates.get_endpoint_version_for_type(
                 instance_name=instance_name,
                 instance_resource_group=instance_resource_group,
                 endpoint_type=endpoint_type,

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -66,21 +66,98 @@ class DeviceEndpointType(ListableEnum):
         return mapped_types.get(keyword.lower(), "custom" if return_custom_keyword else keyword)
 
 
-def get_default_endpoint_version(endpoint_type: str) -> Optional[str]:
+def get_endpoint_version_from_template(
+    cmd,
+    instance_name: str,
+    instance_resource_group: str,
+    endpoint_type: str,
+    is_custom_command: bool = False,
+) -> Optional[str]:
     """
-    Returns the default version for a given endpoint type.
+    Returns the endpoint version from a connector template if one exists for the endpoint type.
 
-    Returns None if no default version is defined (ONVIF, Media, OPC-UA, custom types).
+    Looks up connector templates for the specified instance and returns the version
+    from the matching template's deviceInboundEndpointTypes. Returns None if no
+    matching template exists (e.g., for 3rd-party connectors without templates).
+
+    For 1P commands (opcua, rest, mqtt, etc.), only MCR templates are considered.
+    For custom commands (is_custom_command=True), only non-MCR (3P) templates are considered.
+
+    Args:
+        cmd: Azure CLI command context.
+        instance_name: IoT Operations instance name.
+        instance_resource_group: Resource group containing the instance.
+        endpoint_type: The device endpoint type (e.g., "Microsoft.OpcUa").
+        is_custom_command: If True, this is the 'custom' command which should look for 3P templates.
+                           If False, this is a 1P command (rest, opcua, etc.) which should look for MCR templates.
+
+    Returns:
+        The endpoint version string if found in a connector template, None otherwise.
     """
-    version_map = {
-        DeviceEndpointType.REST.value: "1.0",
-        DeviceEndpointType.MQTT.value: "5",
-        DeviceEndpointType.SSE.value: "1.1",
-        DeviceEndpointType.MEDIA.value: None,
-        DeviceEndpointType.ONVIF.value: None,
-        DeviceEndpointType.OPCUA.value: None,
-    }
-    return version_map.get(endpoint_type, None)
+    MCR_PREFIX = "mcr.microsoft.com"
+
+    # Custom command always looks for 3P templates, 1P commands look for MCR templates
+    look_for_mcr = not is_custom_command
+
+    try:
+        from azure.cli.core.commands.client_factory import get_subscription_id
+        from ...util.az_client import get_iotops_mgmt_client
+
+        iotops_client = get_iotops_mgmt_client(
+            subscription_id=get_subscription_id(cli_ctx=cmd.cli_ctx),
+        )
+
+        connector_templates = list(
+            iotops_client.akri_connector_template.list_by_instance_resource(
+                resource_group_name=instance_resource_group,
+                instance_name=instance_name,
+            )
+        )
+
+        for template in connector_templates:
+            template_name = template.get("name")
+            properties = template.get("properties", {})
+            connector_metadata_ref = properties.get("connectorMetadataRef", "")
+            device_endpoint_types = properties.get("deviceInboundEndpointTypes", [])
+
+            # Filter templates based on whether we're looking for 1P (MCR) or 3P (non-MCR)
+            is_mcr_template = connector_metadata_ref.startswith(MCR_PREFIX)
+            if look_for_mcr and not is_mcr_template:
+                continue
+            if not look_for_mcr and is_mcr_template:
+                continue
+
+            for endpoint_type_info in device_endpoint_types:
+                et = endpoint_type_info.get("endpointType")
+
+                # Match endpoint type (case-insensitive)
+                if et and et.lower() == endpoint_type.lower():
+                    # First check if version is in the endpoint type info
+                    ev = endpoint_type_info.get("version")
+
+                    # If not, get version from tagDigestSettings.tag
+                    if not ev:
+                        runtime_config = properties.get("runtimeConfiguration", {})
+                        managed_config = runtime_config.get("managedConfigurationSettings", {})
+                        image_config = managed_config.get("imageConfigurationSettings", {})
+                        tag_settings = image_config.get("tagDigestSettings", {})
+                        ev = tag_settings.get("tag")
+
+                    logger.info(
+                        f"Found endpoint version '{ev}' from connector template "
+                        f"'{template_name}' for endpoint type '{endpoint_type}'"
+                    )
+                    return ev
+
+        logger.info(
+            f"No connector template found for endpoint type '{endpoint_type}'. "
+            "Endpoint version will be None."
+        )
+        return None
+
+    except Exception as e:
+        logger.warning(f"Failed to retrieve connector templates: {e}. Endpoint version will be None.")
+        return None
 
 
 class NamespaceDevices(Queryable):
@@ -334,13 +411,20 @@ class NamespaceDevices(Queryable):
         username_reference: Optional[str] = None,
         trust_list: Optional[str] = None,
         replace: Optional[bool] = False,
+        is_custom_command: bool = False,
         **kwargs
     ):
         from .helpers import process_additional_configuration, process_authentication
 
-        # Set default version if not provided by user
+        # Set version from connector template if not provided by user
         if endpoint_version is None:
-            endpoint_version = get_default_endpoint_version(endpoint_type)
+            endpoint_version = get_endpoint_version_from_template(
+                cmd=self.cmd,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                endpoint_type=endpoint_type,
+                is_custom_command=is_custom_command,
+            )
 
         # get the original inbound endpoints
         device = self.show(

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -20,6 +20,7 @@ from ...util.az_client import (
 from ...util.common import parse_kvp_nargs, should_continue_prompt
 from ...util.id_tools import parse_resource_id
 from ...util.queryable import Queryable
+from ..orchestration.resources.connector_templates import get_endpoint_version_from_template
 
 if TYPE_CHECKING:
     from ...vendor.clients.deviceregistrymgmt.operations import (
@@ -64,100 +65,6 @@ class DeviceEndpointType(ListableEnum):
             "mqtt": cls.MQTT.value
         }
         return mapped_types.get(keyword.lower(), "custom" if return_custom_keyword else keyword)
-
-
-def get_endpoint_version_from_template(
-    cmd,
-    instance_name: str,
-    instance_resource_group: str,
-    endpoint_type: str,
-    is_custom_command: bool = False,
-) -> Optional[str]:
-    """
-    Returns the endpoint version from a connector template if one exists for the endpoint type.
-
-    Looks up connector templates for the specified instance and returns the version
-    from the matching template's deviceInboundEndpointTypes. Returns None if no
-    matching template exists (e.g., for 3rd-party connectors without templates).
-
-    For 1P commands (opcua, rest, mqtt, etc.), only MCR templates are considered.
-    For custom commands (is_custom_command=True), only non-MCR (3P) templates are considered.
-
-    Args:
-        cmd: Azure CLI command context.
-        instance_name: IoT Operations instance name.
-        instance_resource_group: Resource group containing the instance.
-        endpoint_type: The device endpoint type (e.g., "Microsoft.OpcUa").
-        is_custom_command: If True, this is the 'custom' command which should look for 3P templates.
-                           If False, this is a 1P command (rest, opcua, etc.) which should look for MCR templates.
-
-    Returns:
-        The endpoint version string if found in a connector template, None otherwise.
-    """
-    MCR_PREFIX = "mcr.microsoft.com"
-
-    # Custom command always looks for 3P templates, 1P commands look for MCR templates
-    look_for_mcr = not is_custom_command
-
-    try:
-        from azure.cli.core.commands.client_factory import get_subscription_id
-        from ...util.az_client import get_iotops_mgmt_client
-
-        iotops_client = get_iotops_mgmt_client(
-            subscription_id=get_subscription_id(cli_ctx=cmd.cli_ctx),
-        )
-
-        connector_templates = list(
-            iotops_client.akri_connector_template.list_by_instance_resource(
-                resource_group_name=instance_resource_group,
-                instance_name=instance_name,
-            )
-        )
-
-        for template in connector_templates:
-            template_name = template.get("name")
-            properties = template.get("properties", {})
-            connector_metadata_ref = properties.get("connectorMetadataRef", "")
-            device_endpoint_types = properties.get("deviceInboundEndpointTypes", [])
-
-            # Filter templates based on whether we're looking for 1P (MCR) or 3P (non-MCR)
-            is_mcr_template = connector_metadata_ref.startswith(MCR_PREFIX)
-            if look_for_mcr and not is_mcr_template:
-                continue
-            if not look_for_mcr and is_mcr_template:
-                continue
-
-            for endpoint_type_info in device_endpoint_types:
-                et = endpoint_type_info.get("endpointType")
-
-                # Match endpoint type (case-insensitive)
-                if et and et.lower() == endpoint_type.lower():
-                    # First check if version is in the endpoint type info
-                    ev = endpoint_type_info.get("version")
-
-                    # If not, get version from tagDigestSettings.tag
-                    if not ev:
-                        runtime_config = properties.get("runtimeConfiguration", {})
-                        managed_config = runtime_config.get("managedConfigurationSettings", {})
-                        image_config = managed_config.get("imageConfigurationSettings", {})
-                        tag_settings = image_config.get("tagDigestSettings", {})
-                        ev = tag_settings.get("tag")
-
-                    logger.info(
-                        f"Found endpoint version '{ev}' from connector template "
-                        f"'{template_name}' for endpoint type '{endpoint_type}'"
-                    )
-                    return ev
-
-        logger.info(
-            f"No connector template found for endpoint type '{endpoint_type}'. "
-            "Endpoint version will be None."
-        )
-        return None
-
-    except Exception as e:
-        logger.warning(f"Failed to retrieve connector templates: {e}. Endpoint version will be None.")
-        return None
 
 
 class NamespaceDevices(Queryable):

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -713,8 +713,10 @@ def load_adr_arguments(self, _):
         context.argument(
             "endpoint_version",
             options_list=["--version"],
-            help="Endpoint version.",
-            deprecate_info=context.deprecate(hide=True),
+            help="Endpoint version. If not provided, the version is automatically retrieved from the "
+            "connector template matching this endpoint type (if one exists). The endpoint version is required "
+            "for connector pods to be created - without it, devices will not have associated connector pods "
+            "even if a connector template is deployed.",
         )
         # TODO: add description of how to use these in the wiki
         context.argument(
@@ -788,7 +790,9 @@ def load_adr_arguments(self, _):
         context.argument(
             "endpoint_version",
             options_list=["--version"],
-            help="Endpoint version.",
+            help="Endpoint version. For custom (3rd-party) connectors, the version is required if you want "
+            "connector pods to be created. If a connector template exists for this endpoint type, the version "
+            "will be automatically retrieved from the template when not provided.",
         )
         context.argument(
             "endpoint_type",

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -9,6 +9,7 @@ from enum import Enum
 # Urls
 ARM_ENDPOINT = "https://management.azure.com/"
 MCR_ENDPOINT = "https://mcr.microsoft.com/"
+DEFAULT_REGISTRY_HOST = "mcr.microsoft.com"
 
 # App IDs
 CUSTOM_LOCATIONS_RP_APP_ID = "bc313c14-388c-4e7d-a58e-70017303ee3b"

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -55,98 +55,6 @@ VALID_IMAGE_PULL_POLICIES = ["Always", "IfNotPresent", "Never"]
 VALID_ALLOCATION_POLICIES = ["Bucketized"]
 
 
-def get_endpoint_version_from_template(
-    cmd,
-    instance_name: str,
-    instance_resource_group: str,
-    endpoint_type: str,
-    is_custom_command: bool = False,
-) -> Optional[str]:
-    """
-    Returns the endpoint version from a connector template if one exists for the endpoint type.
-
-    Looks up connector templates for the specified instance and returns the version
-    from the matching template's deviceInboundEndpointTypes. Returns None if no
-    matching template exists (e.g., for 3rd-party connectors without templates).
-
-    For 1P commands (opcua, rest, mqtt, etc.), only MCR templates are considered.
-    For custom commands (is_custom_command=True), only non-MCR (3P) templates are considered.
-
-    Args:
-        cmd: Azure CLI command context.
-        instance_name: IoT Operations instance name.
-        instance_resource_group: Resource group containing the instance.
-        endpoint_type: The device endpoint type (e.g., "Microsoft.OpcUa").
-        is_custom_command: If True, this is the 'custom' command which should look for 3P templates.
-                           If False, this is a 1P command (rest, opcua, etc.) which should look for MCR templates.
-
-    Returns:
-        The endpoint version string if found in a connector template, None otherwise.
-    """
-    from azure.cli.core.commands.client_factory import get_subscription_id
-    from ....util.az_client import get_iotops_mgmt_client
-
-    # Custom command always looks for 3P templates, 1P commands look for MCR templates
-    look_for_mcr = not is_custom_command
-
-    try:
-        iotops_client = get_iotops_mgmt_client(
-            subscription_id=get_subscription_id(cli_ctx=cmd.cli_ctx),
-        )
-
-        connector_templates = list(
-            iotops_client.akri_connector_template.list_by_instance_resource(
-                resource_group_name=instance_resource_group,
-                instance_name=instance_name,
-            )
-        )
-
-        for template in connector_templates:
-            template_name = template.get("name")
-            properties = template.get("properties", {})
-            connector_metadata_ref = properties.get("connectorMetadataRef", "")
-            device_endpoint_types = properties.get("deviceInboundEndpointTypes", [])
-
-            # Filter templates based on whether we're looking for 1P (MCR) or 3P (non-MCR)
-            is_mcr_template = connector_metadata_ref.startswith(DEFAULT_REGISTRY_HOST)
-            if look_for_mcr and not is_mcr_template:
-                continue
-            if not look_for_mcr and is_mcr_template:
-                continue
-
-            for endpoint_type_info in device_endpoint_types:
-                et = endpoint_type_info.get("endpointType")
-
-                # Match endpoint type (case-insensitive)
-                if et and et.lower() == endpoint_type.lower():
-                    # First check if version is in the endpoint type info
-                    ev = endpoint_type_info.get("version")
-
-                    # If not, get version from tagDigestSettings.tag
-                    if not ev:
-                        runtime_config = properties.get("runtimeConfiguration", {})
-                        managed_config = runtime_config.get("managedConfigurationSettings", {})
-                        image_config = managed_config.get("imageConfigurationSettings", {})
-                        tag_settings = image_config.get("tagDigestSettings", {})
-                        ev = tag_settings.get("tag")
-
-                    logger.info(
-                        f"Found endpoint version '{ev}' from connector template "
-                        f"'{template_name}' for endpoint type '{endpoint_type}'"
-                    )
-                    return ev
-
-        logger.info(
-            f"No connector template found for endpoint type '{endpoint_type}'. "
-            "Endpoint version will be None."
-        )
-        return None
-
-    except Exception as e:
-        logger.warning(f"Failed to retrieve connector templates: {e}. Endpoint version will be None.")
-        return None
-
-
 class ConnectorTemplates(Queryable):
     """Provider for connector template operations."""
 
@@ -157,6 +65,135 @@ class ConnectorTemplates(Queryable):
         self.ops: "AkriConnectorTemplateOperations" = (
             self.iotops_mgmt_client.akri_connector_template
         )
+
+    def get_endpoint_version_for_type(
+        self,
+        instance_name: str,
+        instance_resource_group: str,
+        endpoint_type: str,
+        is_custom_command: bool = False,
+    ) -> Optional[str]:
+        """
+        Returns the endpoint version from a connector template if one exists for the endpoint type.
+
+        Looks up connector templates for the specified instance and returns the version
+        from the matching template's deviceInboundEndpointTypes. If multiple templates
+        match the endpoint type, the one with the latest version is selected.
+
+        For 1P commands (opcua, rest, mqtt, etc.), only MCR templates are considered.
+        For custom commands (is_custom_command=True), only non-MCR (3P) templates are considered.
+
+        Args:
+            instance_name: IoT Operations instance name.
+            instance_resource_group: Resource group containing the instance.
+            endpoint_type: The device endpoint type (e.g., "Microsoft.OpcUa").
+            is_custom_command: If True, this is the 'custom' command which should look for 3P templates.
+                               If False, this is a 1P command (rest, opcua, etc.) which should look for MCR templates.
+
+        Returns:
+            The endpoint version string if found in a connector template, None otherwise.
+        """
+        from ....util.machinery import scoped_semver_import
+
+        # Custom command always looks for 3P templates, 1P commands look for MCR templates
+        look_for_mcr = not is_custom_command
+
+        try:
+            connector_templates = list(
+                self.ops.list_by_instance_resource(
+                    resource_group_name=instance_resource_group,
+                    instance_name=instance_name,
+                )
+            )
+
+            # Collect all matching templates with their versions
+            # Each entry: (tag_version for comparison, endpoint_type_version to return, template_name)
+            matching_templates = []
+
+            for template in connector_templates:
+                template_name = template.get("name")
+                properties = template.get("properties", {})
+                connector_metadata_ref = properties.get("connectorMetadataRef", "")
+                device_endpoint_types = properties.get("deviceInboundEndpointTypes", [])
+
+                # Filter templates based on whether we're looking for 1P (MCR) or 3P (non-MCR)
+                is_mcr_template = connector_metadata_ref.startswith(DEFAULT_REGISTRY_HOST)
+                if look_for_mcr and not is_mcr_template:
+                    continue
+                if not look_for_mcr and is_mcr_template:
+                    continue
+
+                # Get tag version from tagDigestSettings.tag (for comparison)
+                runtime_config = properties.get("runtimeConfiguration", {})
+                managed_config = runtime_config.get("managedConfigurationSettings", {})
+                image_config = managed_config.get("imageConfigurationSettings", {})
+                tag_settings = image_config.get("tagDigestSettings", {})
+                tag_version = tag_settings.get("tag")
+
+                if not tag_version:
+                    continue
+
+                for endpoint_type_info in device_endpoint_types:
+                    et = endpoint_type_info.get("endpointType")
+                    endpoint_type_version = endpoint_type_info.get("version")
+
+                    # Match endpoint type (case-insensitive)
+                    if et and et.lower() == endpoint_type.lower():
+                        matching_templates.append((tag_version, endpoint_type_version, template_name))
+
+            if not matching_templates:
+                logger.info(
+                    f"No connector template found for endpoint type '{endpoint_type}'. "
+                    "Endpoint version will be None."
+                )
+                return None
+
+            # If only one matching template, return its endpoint type version
+            if len(matching_templates) == 1:
+                tag_version, endpoint_type_version, template_name = matching_templates[0]
+                logger.info(
+                    f"Found endpoint version '{endpoint_type_version}' from connector template "
+                    f"'{template_name}' (tag: {tag_version}) for endpoint type '{endpoint_type}'"
+                )
+                return endpoint_type_version
+
+            # Multiple matching templates - compare using tag version to find the latest
+            semver = scoped_semver_import()
+            latest_tag_version = None
+            latest_endpoint_type_version = None
+            latest_template_name = None
+
+            for tag_version, endpoint_type_version, template_name in matching_templates:
+                try:
+                    parsed_version = semver.parse(tag_version)
+                    if latest_tag_version is None:
+                        latest_tag_version = tag_version
+                        latest_endpoint_type_version = endpoint_type_version
+                        latest_template_name = template_name
+                    elif parsed_version > semver.parse(latest_tag_version):
+                        latest_tag_version = tag_version
+                        latest_endpoint_type_version = endpoint_type_version
+                        latest_template_name = template_name
+                except (ValueError, AttributeError):
+                    # If version can't be parsed, use as fallback
+                    logger.debug(
+                        f"Could not parse tag version '{tag_version}' from template '{template_name}' for comparison"
+                    )
+                    if latest_tag_version is None:
+                        latest_tag_version = tag_version
+                        latest_endpoint_type_version = endpoint_type_version
+                        latest_template_name = template_name
+
+            logger.info(
+                f"Found {len(matching_templates)} matching templates for endpoint type '{endpoint_type}'. "
+                f"Selected endpoint version '{latest_endpoint_type_version}' from template "
+                f"'{latest_template_name}' (tag: {latest_tag_version}, latest)."
+            )
+            return latest_endpoint_type_version
+
+        except Exception as e:
+            logger.warning(f"Failed to retrieve connector templates: {e}. Endpoint version will be None.")
+            return None
 
     def create(
         self,

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -32,6 +32,7 @@ from azure.cli.core.azclierror import (
 from knack.log import get_logger
 from rich.console import Console
 
+from .....constants import DEFAULT_REGISTRY_HOST
 from ....util import assemble_nargs_to_dict
 from ....util.common import should_continue_prompt
 from ....util.az_client import wait_for_terminal_state
@@ -52,6 +53,98 @@ DEFAULT_LOG_LEVEL = "info"
 # Valid enum values
 VALID_IMAGE_PULL_POLICIES = ["Always", "IfNotPresent", "Never"]
 VALID_ALLOCATION_POLICIES = ["Bucketized"]
+
+
+def get_endpoint_version_from_template(
+    cmd,
+    instance_name: str,
+    instance_resource_group: str,
+    endpoint_type: str,
+    is_custom_command: bool = False,
+) -> Optional[str]:
+    """
+    Returns the endpoint version from a connector template if one exists for the endpoint type.
+
+    Looks up connector templates for the specified instance and returns the version
+    from the matching template's deviceInboundEndpointTypes. Returns None if no
+    matching template exists (e.g., for 3rd-party connectors without templates).
+
+    For 1P commands (opcua, rest, mqtt, etc.), only MCR templates are considered.
+    For custom commands (is_custom_command=True), only non-MCR (3P) templates are considered.
+
+    Args:
+        cmd: Azure CLI command context.
+        instance_name: IoT Operations instance name.
+        instance_resource_group: Resource group containing the instance.
+        endpoint_type: The device endpoint type (e.g., "Microsoft.OpcUa").
+        is_custom_command: If True, this is the 'custom' command which should look for 3P templates.
+                           If False, this is a 1P command (rest, opcua, etc.) which should look for MCR templates.
+
+    Returns:
+        The endpoint version string if found in a connector template, None otherwise.
+    """
+    from azure.cli.core.commands.client_factory import get_subscription_id
+    from ....util.az_client import get_iotops_mgmt_client
+
+    # Custom command always looks for 3P templates, 1P commands look for MCR templates
+    look_for_mcr = not is_custom_command
+
+    try:
+        iotops_client = get_iotops_mgmt_client(
+            subscription_id=get_subscription_id(cli_ctx=cmd.cli_ctx),
+        )
+
+        connector_templates = list(
+            iotops_client.akri_connector_template.list_by_instance_resource(
+                resource_group_name=instance_resource_group,
+                instance_name=instance_name,
+            )
+        )
+
+        for template in connector_templates:
+            template_name = template.get("name")
+            properties = template.get("properties", {})
+            connector_metadata_ref = properties.get("connectorMetadataRef", "")
+            device_endpoint_types = properties.get("deviceInboundEndpointTypes", [])
+
+            # Filter templates based on whether we're looking for 1P (MCR) or 3P (non-MCR)
+            is_mcr_template = connector_metadata_ref.startswith(DEFAULT_REGISTRY_HOST)
+            if look_for_mcr and not is_mcr_template:
+                continue
+            if not look_for_mcr and is_mcr_template:
+                continue
+
+            for endpoint_type_info in device_endpoint_types:
+                et = endpoint_type_info.get("endpointType")
+
+                # Match endpoint type (case-insensitive)
+                if et and et.lower() == endpoint_type.lower():
+                    # First check if version is in the endpoint type info
+                    ev = endpoint_type_info.get("version")
+
+                    # If not, get version from tagDigestSettings.tag
+                    if not ev:
+                        runtime_config = properties.get("runtimeConfiguration", {})
+                        managed_config = runtime_config.get("managedConfigurationSettings", {})
+                        image_config = managed_config.get("imageConfigurationSettings", {})
+                        tag_settings = image_config.get("tagDigestSettings", {})
+                        ev = tag_settings.get("tag")
+
+                    logger.info(
+                        f"Found endpoint version '{ev}' from connector template "
+                        f"'{template_name}' for endpoint type '{endpoint_type}'"
+                    )
+                    return ev
+
+        logger.info(
+            f"No connector template found for endpoint type '{endpoint_type}'. "
+            "Endpoint version will be None."
+        )
+        return None
+
+    except Exception as e:
+        logger.warning(f"Failed to retrieve connector templates: {e}. Endpoint version will be None.")
+        return None
 
 
 class ConnectorTemplates(Queryable):

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -32,7 +32,7 @@ from azure.cli.core.azclierror import (
 from knack.log import get_logger
 from rich.console import Console
 
-from .....constants import DEFAULT_REGISTRY_HOST
+from ..common import DEFAULT_REGISTRY_HOST
 from ....util import assemble_nargs_to_dict
 from ....util.common import should_continue_prompt
 from ....util.az_client import wait_for_terminal_state

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -22,6 +22,7 @@ from rich.progress import (
 )
 from rich.table import Table, box
 
+from ....constants import DEFAULT_REGISTRY_HOST
 from ...util import parse_kvp_nargs, should_continue_prompt
 from ...util.machinery import scoped_semver_import
 from .common import (
@@ -48,7 +49,6 @@ logger = get_logger(__name__)
 console = Console()
 
 
-DEFAULT_REGISTRY_HOST = "mcr.microsoft.com"
 IOT_OPS_DELAY = 30  # seconds
 
 

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -22,7 +22,7 @@ from rich.progress import (
 )
 from rich.table import Table, box
 
-from ....constants import DEFAULT_REGISTRY_HOST
+from .common import DEFAULT_REGISTRY_HOST
 from ...util import parse_kvp_nargs, should_continue_prompt
 from ...util.machinery import scoped_semver_import
 from .common import (

--- a/azext_edge/tests/edge/adr/conftest.py
+++ b/azext_edge/tests/edge/adr/conftest.py
@@ -101,14 +101,16 @@ def mocked_get_namespace_for_instance(mocker):
 @pytest.fixture()
 def mocked_get_endpoint_version_from_template(mocker):
     """
-    Mock get_endpoint_version_from_template to return None by default.
-    This prevents the function from making API calls during unit tests.
+    Mock ConnectorTemplates to return None from get_endpoint_version_for_type by default.
+    This prevents the class from making API calls during unit tests.
     """
     mock = mocker.patch(
-        "azext_edge.edge.providers.adr.namespace_devices.get_endpoint_version_from_template",
-        return_value=None
+        "azext_edge.edge.providers.adr.namespace_devices.ConnectorTemplates"
     )
-    yield mock
+    # Configure the mock instance's get_endpoint_version_for_type method
+    mock.return_value.get_endpoint_version_for_type.return_value = None
+    # Yield the method mock so tests can configure return values
+    yield mock.return_value.get_endpoint_version_for_type
 
 
 def get_asset_id(

--- a/azext_edge/tests/edge/adr/conftest.py
+++ b/azext_edge/tests/edge/adr/conftest.py
@@ -98,6 +98,19 @@ def mocked_get_namespace_for_instance(mocker):
     yield mock
 
 
+@pytest.fixture()
+def mocked_get_endpoint_version_from_template(mocker):
+    """
+    Mock get_endpoint_version_from_template to return None by default.
+    This prevents the function from making API calls during unit tests.
+    """
+    mock = mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_devices.get_endpoint_version_from_template",
+        return_value=None
+    )
+    yield mock
+
+
 def get_asset_id(
     asset_name: Optional[str] = None,
     asset_resource_group: Optional[str] = None,

--- a/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_devices_unit.py
@@ -957,7 +957,8 @@ def test_add_inbound_custom_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -1157,7 +1158,8 @@ def test_add_inbound_media_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -1324,7 +1326,8 @@ def test_add_inbound_onvif_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -1527,7 +1530,8 @@ def test_add_inbound_opcua_device_endpoint(
     response_status: int,
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -1851,7 +1855,8 @@ def test_add_inbound_rest_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -1879,8 +1884,13 @@ def test_add_inbound_rest_device_endpoint(
         )
 
     # Create expected endpoint structure
-    # REST endpoints get default version "1.0" when None
-    expected_version = endpoint_version if endpoint_version is not None else "1.0"
+    # Simulate connector template returning version when user doesn't provide one
+    template_version = "1.0"  # REST connector template default
+    if endpoint_version is None:
+        mocked_get_endpoint_version_from_template.return_value = template_version
+        expected_version = template_version
+    else:
+        expected_version = endpoint_version
     expected_endpoint = {
         "endpointType": DeviceEndpointType.REST.value,
         "address": endpoint_address,
@@ -2037,7 +2047,8 @@ def test_add_inbound_sse_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -2065,8 +2076,13 @@ def test_add_inbound_sse_device_endpoint(
         )
 
     # Create expected endpoint structure
-    # Apply default version if endpoint_version is None
-    expected_version = endpoint_version if endpoint_version is not None else "1.1"
+    # Simulate connector template returning version when user doesn't provide one
+    template_version = "1.1"  # SSE connector template default
+    if endpoint_version is None:
+        mocked_get_endpoint_version_from_template.return_value = template_version
+        expected_version = template_version
+    else:
+        expected_version = endpoint_version
     expected_endpoint = {
         "endpointType": DeviceEndpointType.SSE.value,
         "address": endpoint_address,
@@ -2211,7 +2227,8 @@ def test_add_inbound_mqtt_device_endpoint(
     endpoint_version: Optional[str],
     endpoints_present: bool,
     replace: bool,
-    mocked_get_namespace_for_instance
+    mocked_get_namespace_for_instance,
+    mocked_get_endpoint_version_from_template
 ):
     # Setup test data
     device_name = generate_random_string()
@@ -2239,8 +2256,13 @@ def test_add_inbound_mqtt_device_endpoint(
         )
 
     # Create expected endpoint structure (MQTT has no authentication)
-    # Apply default version if endpoint_version is None (MQTT default: 5)
-    expected_version = endpoint_version if endpoint_version is not None else "5"
+    # Simulate connector template returning version when user doesn't provide one
+    template_version = "5"  # MQTT connector template default
+    if endpoint_version is None:
+        mocked_get_endpoint_version_from_template.return_value = template_version
+        expected_version = template_version
+    else:
+        expected_version = endpoint_version
     expected_endpoint = {
         "endpointType": DeviceEndpointType.MQTT.value,
         "address": endpoint_address,


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
