### PR TITLE
fix(ns-asset): optional data-source, add type-ref param

### DIFF
--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -2356,7 +2356,7 @@ def add_namespace_opcua_asset_management_group(
     instance_name: str,
     instance_resource_group: str,
     group_name: str,
-    data_source: str,
+    data_source: Optional[str] = None,
     default_topic: Optional[str] = None,
     default_timeout: Optional[int] = None,
     # mgmt_custom_configuration: Optional[str] = None,
@@ -2384,7 +2384,7 @@ def add_namespace_onvif_asset_management_group(
     instance_name: str,
     instance_resource_group: str,
     group_name: str,
-    data_source: str,
+    data_source: Optional[str] = None,
     default_topic: Optional[str] = None,
     default_timeout: Optional[int] = None,
     # mgmt_custom_configuration: Optional[str] = None,
@@ -2578,6 +2578,7 @@ def add_namespace_opcua_asset_management_group_action(
     # custom_configuration: Optional[str] = None,
     timeout: Optional[int] = None,
     topic: Optional[str] = None,
+    type_ref: Optional[str] = None,
     replace: Optional[bool] = False,
     **kwargs
 ) -> dict:
@@ -2593,6 +2594,7 @@ def add_namespace_opcua_asset_management_group_action(
         # custom_configuration=custom_configuration,
         timeout=timeout,
         topic=topic,
+        type_ref=type_ref,
         replace=replace,
         **kwargs
     )

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -2414,9 +2414,9 @@ def load_iotops_adr_help():
         - name: Add a basic management group to an OPC UA asset.
           text: >
             az iot ops ns asset opcua mgmt-group add --asset myopcuaasset --instance myInstance -g myInstanceResourceGroup
-            --name myManagementGroup --data-source mydatasource
+            --name myManagementGroup
 
-        - name: Add a management group with default topic and timeout.
+        - name: Add a management group with data source, default topic and timeout.
           text: >
             az iot ops ns asset opcua mgmt-group add --asset myopcuaasset --instance myInstance -g myInstanceResourceGroup
             --name myManagementGroup --default-topic factory/opcua/management/responses --default-timeout 30
@@ -2517,6 +2517,12 @@ def load_iotops_adr_help():
             az iot ops ns asset opcua mgmt-action add --asset myopcuaasset --instance myInstance -g myInstanceResourceGroup
             --group myManagementGroup --name myAction --target-uri /opcua/device_service?OPCUAProfile=Profile1
             --action-type Call --timeout 30
+
+        - name: Add an action with a type reference.
+          text: >
+            az iot ops ns asset opcua mgmt-action add --asset myopcuaasset --instance myInstance -g myInstanceResourceGroup
+            --group myManagementGroup --name myAction --target-uri /opcua/device_service?OPCUAProfile=Profile1
+            --type-ref ns=2;i=1234
 
         - name: Replace an existing action with the same name.
           text: >

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -1268,7 +1268,7 @@ class NamespaceAssets(Queryable):
         instance_resource_group: str,
         asset_type: str,
         group_name: str,
-        data_source: str,
+        data_source: Optional[str] = None,
         default_topic: Optional[str] = None,
         default_timeout: Optional[int] = None,
         type_ref: Optional[str] = None,

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -1551,6 +1551,13 @@ def load_adr_arguments(self, _):
                 arg_type=get_three_state_flag(),
             )
 
+    with self.argument_context("iot ops ns asset opcua mgmt-action") as context:
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="URI or type definition ID for the action.",
+        )
+
     with self.argument_context("iot ops ns asset custom dataset") as context:
         context.argument(
             "dataset_custom_configuration",

--- a/azext_edge/tests/edge/adr/namespace_helpers.py
+++ b/azext_edge/tests/edge/adr/namespace_helpers.py
@@ -68,6 +68,8 @@ def assert_management_group_action_properties(result, **expected):
         assert result["timeoutInSeconds"] == expected["timeout"]
     if "topic" in expected:
         assert result["topic"] == expected["topic"]
+    if "type_ref" in expected:
+        assert result["typeRef"] == expected["type_ref"]
     if "custom_configuration" in expected:
         assert result["actionConfiguration"] == expected["custom_configuration"]
 

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
@@ -276,21 +276,19 @@ def test_namespace_opcua_asset_management_group_lifecycle_operations(require_ini
     )
     tracked_resources.append(asset_opcua["id"])
 
-    # 1. CREATE MANAGEMENT GROUP WITH FULL OPCUA CONFIGURATION
+    # 1. CREATE MANAGEMENT GROUP WITH ONLY REQUIRED PARAMS (no data-source)
     default_topic = "factory/opcua/management/responses"
     default_timeout = 45
-    data_source = f"nsu=opcuaNamespace;i={randint(1, 999)}"
 
     mgmt_group_result = run(
         f"az iot ops ns asset opcua mgmt-group add --asset {asset_name} --instance {instance_name} "
         f"-g {resource_group} --name {mgmt_group_name} --default-topic '{default_topic}' "
-        f"--default-timeout {default_timeout} --data-source '{data_source}'"
+        f"--default-timeout {default_timeout}"
     )
 
     assert_management_group_properties(
         mgmt_group_result,
         name=mgmt_group_name,
-        data_source=data_source,
         default_topic=default_topic,
         default_timeout=default_timeout,
     )
@@ -331,12 +329,11 @@ def test_namespace_opcua_asset_management_group_lifecycle_operations(require_ini
     assert_management_group_properties(
         updated_mgmt_group,
         name=mgmt_group_name,
-        data_source=data_source,
         default_topic=updated_default_topic,
         default_timeout=updated_default_timeout,
     )
 
-    # 5. CREATE MANAGEMENT GROUP WITH REPLACE
+    # 5. CREATE MANAGEMENT GROUP WITH REPLACE (with optional data-source)
     replaced_default_topic = "factory/opcua/management/replaced_responses"
     replaced_data_source = f"nsu=replacedNamespace;i={randint(1, 999)}"
     replaced_mgmt_group = run(
@@ -357,12 +354,13 @@ def test_namespace_opcua_asset_management_group_lifecycle_operations(require_ini
     action_type = "Call"
     action_timeout = 30
     action_topic = "factory/opcua/actions/production"
+    action_type_ref = "ns=2;i=1234"
 
     action_result = run(
         f"az iot ops ns asset opcua mgmt-action add --asset {asset_name} --instance {instance_name} "
         f"-g {resource_group} --group {mgmt_group_name} --name {action_name} "
         f"--target-uri {action_target_uri} --action-type {action_type} --timeout {action_timeout} "
-        f"--topic {action_topic}"
+        f"--topic {action_topic} --type-ref '{action_type_ref}'"
     )
 
     assert_management_group_action_properties(
@@ -371,7 +369,8 @@ def test_namespace_opcua_asset_management_group_lifecycle_operations(require_ini
         target_uri=action_target_uri,
         action_type=action_type,
         timeout=action_timeout,
-        topic=action_topic
+        topic=action_topic,
+        type_ref=action_type_ref
     )
 
     # 7. LIST MANAGEMENT GROUP ACTIONS


### PR DESCRIPTION
When deploying a management group, the `--data-source` / `--ds` property is required - but it should be optional:  
[az iot ops ns asset opcua mgmt-group | Microsoft Learn](https://learn.microsoft.com/en-us/cli/azure/iot/ops/ns/asset/opcua/mgmt-group?view=azure-cli-latest)

When deploying an action, a `--type-ref` property is missing - this should be an optional parameter:
[az iot ops ns asset opcua mgmt-action | Microsoft Learn](https://learn.microsoft.com/en-us/cli/azure/iot/ops/ns/asset/opcua/mgmt-action?view=azure-cli-latest)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
