### PR TITLE
feat(mgmt-actions): add Rich workflow progress display to enable/disable

### DIFF
--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -20,6 +20,7 @@ from ...util.az_client import (
 from ...util.id_tools import parse_resource_id as parse_resource_id_dict
 from ...util.common import should_continue_prompt
 from ...util.queryable import Queryable
+from ...util.workflow_display import StepState, WorkflowDisplay, render_summary
 from .common import (
     CUSTOM_LOCATIONS_API_VERSION,
     EG_TOPICSPACES_PUBLISHER_ROLE_ID,
@@ -146,49 +147,72 @@ def _log_disable_summary(
     sub_exists: bool,
     eg_ctx: Optional["EgNamespaceContext"],
 ) -> None:
-    """Log a summary of resources that will be removed by disable().
+    """Render a Rich summary of resources that will be removed by disable().
 
     Only lists resources confirmed to exist during the discovery phase.
-    Emits via logger.warning so it appears on stderr alongside the confirmation prompt.
+    Printed to stderr via render_summary() alongside the confirmation prompt.
+    Resource names are logged at info level for debugging — they are deterministic
+    hashes that don't aid the confirmation decision.
     """
-    graph_name = get_mgmt_actions_resource_name("req", instance_resource_id)
-    resp_name = get_mgmt_actions_resource_name("resp", instance_resource_id)
-    ep_name = get_mgmt_actions_resource_name("eg", instance_resource_id)
-    ts_name = get_mgmt_actions_resource_name("ops", instance_resource_id)
-    pub_name = get_mgmt_actions_resource_name("pub", instance_resource_id)
-    sub_name = get_mgmt_actions_resource_name("sub", instance_resource_id)
-
-    aio_resources = []
+    aio_items: List[str] = []
     if dataflow_profile_name:
-        aio_resources.extend([f"dataflow graph '{graph_name}'", f"response dataflow '{resp_name}'"])
+        aio_items.append("Response dataflow")
+        aio_items.append("Dataflow graph")
     elif resp_profile_name:
-        aio_resources.append(f"orphaned response dataflow '{resp_name}'")
+        aio_items.append("Response dataflow (orphaned)")
     if ep_exists:
-        aio_resources.append(f"EG endpoint '{ep_name}'")
+        aio_items.append("EG dataflow endpoint")
 
-    eg_resources = []
-    if ts_exists:
-        eg_resources.append(f"topic space '{ts_name}'")
-    if pub_exists:
-        eg_resources.append(f"permission binding '{pub_name}'")
-    if sub_exists:
-        eg_resources.append(f"permission binding '{sub_name}'")
-
-    has_work = any([aio_resources, has_adr_entry, eg_resources])
-
-    logger.warning("The following resources will be removed:")
-    if aio_resources:
-        logger.warning("  AIO: %s", ", ".join(aio_resources))
+    adr_items: List[str] = []
     if has_adr_entry:
-        logger.warning(
-            "  ADR: management endpoint entry for instance '%s' on namespace '%s'",
-            instance_name, adr_namespace_name,
-        )
-    if eg_resources:
-        logger.warning("  EG:  %s on namespace '%s'", ", ".join(eg_resources), eg_ctx.namespace_name)
-    if not has_work:
-        logger.warning("  No management actions resources found.")
-    logger.warning("  Note: Role assignments are NOT removed.")
+        adr_items.append("Management endpoint")
+
+    eg_items: List[str] = []
+    if pub_exists:
+        eg_items.append("Permission binding (publisher)")
+    if sub_exists:
+        eg_items.append("Permission binding (subscriber)")
+    if ts_exists:
+        eg_items.append("Topic space")
+
+    eg_ns_label = f"Event Grid Namespace ({eg_ctx.namespace_name})" if eg_ctx else "Event Grid Namespace"
+
+    sections: Dict[str, List[str]] = {
+        f"IoT Operations Instance ({instance_name})": aio_items,
+        f"Device Registry Namespace ({adr_namespace_name})": adr_items,
+        eg_ns_label: eg_items,
+    }
+
+    total = sum(len(items) for items in sections.values())
+
+    render_summary(
+        title=f"Resources to remove ({total})",
+        sections=sections,
+        footer="Note: Role assignments are NOT removed.",
+    )
+
+    # Log resource names at info level for debugging / portal cross-reference
+    logger.info("Resource names targeted for removal:")
+    if aio_items:
+        for label in aio_items:
+            purpose_map = {
+                "Response dataflow": "resp", "Response dataflow (orphaned)": "resp",
+                "Dataflow graph": "req", "EG dataflow endpoint": "eg",
+            }
+            purpose = purpose_map.get(label)
+            if purpose:
+                logger.info("  %s: %s", label, get_mgmt_actions_resource_name(purpose, instance_resource_id))
+    if adr_items:
+        logger.info("  Management endpoint: (ADR namespace '%s')", adr_namespace_name)
+    if eg_items:
+        for label in eg_items:
+            purpose_map = {
+                "Permission binding (publisher)": "pub", "Permission binding (subscriber)": "sub",
+                "Topic space": "ops",
+            }
+            purpose = purpose_map.get(label)
+            if purpose:
+                logger.info("  %s: %s", label, get_mgmt_actions_resource_name(purpose, instance_resource_id))
 
 
 class EgNamespaceContext(NamedTuple):
@@ -243,105 +267,188 @@ class MgmtActions(Queryable):
         from ...util.machinery import scoped_semver_import
 
         semver = scoped_semver_import()
+        no_progress = kwargs.pop("no_progress", None)
 
-        # Resolve instance
-        instance = self.iotops_mgmt_client.instance.get(
-            instance_name=name,
-            resource_group_name=resource_group_name,
-        )
-        instance_resource_id: str = instance["id"]
+        # --- Phase 1: Analyzing (transient — vanishes before configuring phase) ---
+        analyzing_cats = {"Analyzing": ["Instance & version check", "EG namespace validation", "UAMI resolution"]}
+        with WorkflowDisplay(
+            "Management Actions Enablement", analyzing_cats, no_progress=no_progress,
+        ) as display:
+            display.update_step("Analyzing", "Instance & version check", StepState.ACTIVE)
 
-        # Validate instance version
-        instance_version = instance.get("properties", {}).get("version", "")
-        if not instance_version or (semver.parse(instance_version) < semver.parse(MIN_INSTANCE_VERSION_MGMT_ACTIONS)):
-            raise ValidationError(
-                f"Instance '{name}' version '{instance_version}' does not meet the minimum "
-                f"required version '{MIN_INSTANCE_VERSION_MGMT_ACTIONS}' for management actions."
+            # Resolve instance
+            instance = self.iotops_mgmt_client.instance.get(
+                instance_name=name,
+                resource_group_name=resource_group_name,
             )
+            instance_resource_id: str = instance["id"]
 
-        # Validate EG namespace (format, existence, topic spaces, MQTT hostname)
-        eg_ctx = self._validate_eg_namespace(eg_resource_id)
+            # Validate instance version
+            instance_version = instance.get("properties", {}).get("version", "")
+            if not instance_version or (
+                semver.parse(instance_version) < semver.parse(MIN_INSTANCE_VERSION_MGMT_ACTIONS)
+            ):
+                raise ValidationError(
+                    f"Instance '{name}' version '{instance_version}' does not meet the minimum "
+                    f"required version '{MIN_INSTANCE_VERSION_MGMT_ACTIONS}' for management actions."
+                )
+            display.update_step("Analyzing", "Instance & version check", StepState.COMPLETE, "done")
 
-        # Extract extendedLocation from instance (needed for AIO child resources)
-        extended_location: Dict = instance["extendedLocation"]
+            # Validate EG namespace (format, existence, topic spaces, MQTT hostname)
+            display.update_step("Analyzing", "EG namespace validation", StepState.ACTIVE)
+            eg_ctx = self._validate_eg_namespace(eg_resource_id)
+            display.update_step("Analyzing", "EG namespace validation", StepState.COMPLETE, "done")
 
-        # Resolve UAMI once (used by EG dataflow endpoint + identity resolution)
-        mi_resource = self._resolve_user_assigned_mi(mi_user_assigned) if mi_user_assigned else None
+            # Extract extendedLocation from instance (needed for AIO child resources)
+            extended_location: Dict = instance["extendedLocation"]
 
-        # Event Grid infrastructure setup
-        topic_space_result = self._setup_eg_topic_space(
-            eg_ctx=eg_ctx,
-            instance_name=name,
-            instance_resource_id=instance_resource_id,
-            **kwargs,
-        )
+            # Resolve UAMI once (used by EG dataflow endpoint + identity resolution)
+            display.update_step("Analyzing", "UAMI resolution", StepState.ACTIVE)
+            mi_resource = self._resolve_user_assigned_mi(mi_user_assigned) if mi_user_assigned else None
+            if mi_resource:
+                display.update_step("Analyzing", "UAMI resolution", StepState.COMPLETE, "done")
+            else:
+                display.update_step("Analyzing", "UAMI resolution", StepState.SKIPPED, "not needed")
 
-        permission_bindings_result = self._setup_eg_permission_bindings(
-            eg_ctx=eg_ctx,
-            instance_resource_id=instance_resource_id,
-            topic_space_name=topic_space_result["name"],
-            eg_client_group=eg_client_group,
-            **kwargs,
-        )
+        # --- Phase 2: Configuring (persistent — display remains with elapsed time) ---
+        # Derive ADR namespace name for display (zero-cost parse, no API call)
+        adr_ns_ref = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId", "")
+        adr_ns_display = parse_resource_id_dict(adr_ns_ref).get("name", "") if adr_ns_ref else ""
 
-        # EG dataflow endpoint
-        dataflow_endpoint_result = self._setup_eg_dataflow_endpoint(
-            eg_ctx=eg_ctx,
-            instance_name=name,
-            instance_resource_id=instance_resource_id,
-            resource_group_name=resource_group_name,
-            extended_location=extended_location,
-            mi_resource=mi_resource,
-            **kwargs,
-        )
+        cat_eg = f"Event Grid Namespace ({eg_ctx.namespace_name})"
+        cat_adr = f"Device Registry Namespace ({adr_ns_display})" if adr_ns_display else "Device Registry Namespace"
+        cat_aio = f"IoT Operations Instance ({name})"
+        cat_roles = "Role Assignments"
 
-        # ADR namespace — enable system MI + configure management endpoint
-        adr_result = self._setup_adr_management_endpoint(
-            instance=instance,
-            eg_ctx=eg_ctx,
-            **kwargs,
-        )
-
-        # Dataflow graph (uses default registry endpoint provisioned with instance)
-        resolved_profile = dataflow_profile or MGMT_ACTIONS_DEFAULT_DATAFLOW_PROFILE
-        resolved_registry_endpoint = registry_endpoint or MGMT_ACTIONS_DEFAULT_REGISTRY_ENDPOINT
-
-        dataflow_graph_result = self._setup_dataflow_graph(
-            instance_name=name,
-            instance_resource_id=instance_resource_id,
-            resource_group_name=resource_group_name,
-            extended_location=extended_location,
-            eg_dataflow_endpoint_name=dataflow_endpoint_result["name"],
-            dataflow_profile_name=resolved_profile,
-            registry_endpoint_name=resolved_registry_endpoint,
-            **kwargs,
-        )
-
-        # Response dataflow (edge→cloud: local MQTT → EG)
-        response_dataflow_result = self._setup_response_dataflow(
-            instance_name=name,
-            instance_resource_id=instance_resource_id,
-            resource_group_name=resource_group_name,
-            extended_location=extended_location,
-            eg_dataflow_endpoint_name=dataflow_endpoint_result["name"],
-            dataflow_profile_name=resolved_profile,
-            **kwargs,
-        )
-
-        # Role assignments — ADR namespace MI + dataflow auth identity → EG namespace
-        role_assignments_result = None
+        config_cats: Dict[str, List[str]] = {
+            cat_eg: ["Topic space", "Permission bindings"],
+            cat_adr: ["Managed identity", "Management endpoint"],
+            cat_aio: ["EG dataflow endpoint", "Dataflow graph", "Response dataflow"],
+        }
         if not skip_role_assignments:
-            dataflow_auth_principal_id = self._resolve_dataflow_auth_identity(
-                instance=instance,
-                mi_resource=mi_resource,
-            )
-            role_assignments_result = self._setup_role_assignments(
+            config_cats[cat_roles] = ["ADR namespace roles", "Dataflow identity roles"]
+
+        with WorkflowDisplay(
+            "Management Actions Enablement", config_cats, transient=False, no_progress=no_progress,
+        ) as display:
+            # Event Grid infrastructure setup
+            display.update_step(cat_eg, "Topic space", StepState.ACTIVE)
+            topic_space_result = self._setup_eg_topic_space(
                 eg_ctx=eg_ctx,
-                adr_principal_id=adr_result["identity"]["principalId"],
-                dataflow_auth_principal_id=dataflow_auth_principal_id,
-                adr_role_ids=adr_role_ids,
-                ops_role_ids=ops_role_ids,
+                instance_name=name,
+                instance_resource_id=instance_resource_id,
+                **kwargs,
             )
+            if topic_space_result.get("existed"):
+                display.update_step(cat_eg, "Topic space", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_eg, "Topic space", StepState.COMPLETE, "created")
+
+            display.update_step(cat_eg, "Permission bindings", StepState.ACTIVE)
+            permission_bindings_result = self._setup_eg_permission_bindings(
+                eg_ctx=eg_ctx,
+                instance_resource_id=instance_resource_id,
+                topic_space_name=topic_space_result["name"],
+                eg_client_group=eg_client_group,
+                **kwargs,
+            )
+            if permission_bindings_result.get("existed"):
+                display.update_step(cat_eg, "Permission bindings", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_eg, "Permission bindings", StepState.COMPLETE, "created")
+
+            # ADR namespace — enable system MI + configure management endpoint
+            display.update_step(cat_adr, "Managed identity", StepState.ACTIVE)
+            display.update_step(cat_adr, "Management endpoint", StepState.ACTIVE)
+            adr_result = self._setup_adr_management_endpoint(
+                instance=instance,
+                eg_ctx=eg_ctx,
+                **kwargs,
+            )
+            if adr_result.get("identity_existed"):
+                display.update_step(cat_adr, "Managed identity", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_adr, "Managed identity", StepState.COMPLETE, "enabled")
+            if adr_result.get("endpoint_existed"):
+                display.update_step(cat_adr, "Management endpoint", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_adr, "Management endpoint", StepState.COMPLETE, "created")
+
+            # EG dataflow endpoint
+            display.update_step(cat_aio, "EG dataflow endpoint", StepState.ACTIVE)
+            dataflow_endpoint_result = self._setup_eg_dataflow_endpoint(
+                eg_ctx=eg_ctx,
+                instance_name=name,
+                instance_resource_id=instance_resource_id,
+                resource_group_name=resource_group_name,
+                extended_location=extended_location,
+                mi_resource=mi_resource,
+                **kwargs,
+            )
+            if dataflow_endpoint_result.get("existed"):
+                display.update_step(cat_aio, "EG dataflow endpoint", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_aio, "EG dataflow endpoint", StepState.COMPLETE, "created")
+
+            # Dataflow graph (uses default registry endpoint provisioned with instance)
+            resolved_profile = dataflow_profile or MGMT_ACTIONS_DEFAULT_DATAFLOW_PROFILE
+            resolved_registry_endpoint = registry_endpoint or MGMT_ACTIONS_DEFAULT_REGISTRY_ENDPOINT
+
+            display.update_step(cat_aio, "Dataflow graph", StepState.ACTIVE)
+            dataflow_graph_result = self._setup_dataflow_graph(
+                instance_name=name,
+                instance_resource_id=instance_resource_id,
+                resource_group_name=resource_group_name,
+                extended_location=extended_location,
+                eg_dataflow_endpoint_name=dataflow_endpoint_result["name"],
+                dataflow_profile_name=resolved_profile,
+                registry_endpoint_name=resolved_registry_endpoint,
+                **kwargs,
+            )
+            if dataflow_graph_result.get("existed"):
+                display.update_step(cat_aio, "Dataflow graph", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_aio, "Dataflow graph", StepState.COMPLETE, "created")
+
+            # Response dataflow (edge→cloud: local MQTT → EG)
+            display.update_step(cat_aio, "Response dataflow", StepState.ACTIVE)
+            response_dataflow_result = self._setup_response_dataflow(
+                instance_name=name,
+                instance_resource_id=instance_resource_id,
+                resource_group_name=resource_group_name,
+                extended_location=extended_location,
+                eg_dataflow_endpoint_name=dataflow_endpoint_result["name"],
+                dataflow_profile_name=resolved_profile,
+                **kwargs,
+            )
+            if response_dataflow_result.get("existed"):
+                display.update_step(cat_aio, "Response dataflow", StepState.SKIPPED, "exists")
+            else:
+                display.update_step(cat_aio, "Response dataflow", StepState.COMPLETE, "created")
+
+            # Role assignments — ADR namespace MI + dataflow auth identity → EG namespace
+            role_assignments_result = None
+            if not skip_role_assignments:
+                display.update_step(cat_roles, "ADR namespace roles", StepState.ACTIVE)
+                display.update_step(cat_roles, "Dataflow identity roles", StepState.ACTIVE)
+                dataflow_auth_principal_id = self._resolve_dataflow_auth_identity(
+                    instance=instance,
+                    mi_resource=mi_resource,
+                )
+                role_assignments_result = self._setup_role_assignments(
+                    eg_ctx=eg_ctx,
+                    adr_principal_id=adr_result["identity"]["principalId"],
+                    dataflow_auth_principal_id=dataflow_auth_principal_id,
+                    adr_role_ids=adr_role_ids,
+                    ops_role_ids=ops_role_ids,
+                )
+                display.update_step(cat_roles, "ADR namespace roles", StepState.COMPLETE, "done")
+                display.update_step(cat_roles, "Dataflow identity roles", StepState.COMPLETE, "done")
+
+        # Extract our custom location's endpoint for the consumer-facing return
+        our_endpoint = adr_result.get("managementEndpoints", {}).get(
+            instance["extendedLocation"]["name"], {}
+        )
 
         result: Dict = {
             "instance": {
@@ -358,9 +465,22 @@ class MgmtActions(Queryable):
                     "mqttHostname": eg_ctx.mqtt_hostname,
                 },
                 "topicSpace": topic_space_result,
-                "permissionBindings": permission_bindings_result,
+                "permissionBindings": {
+                    "publisher": permission_bindings_result["publisher"],
+                    "subscriber": permission_bindings_result["subscriber"],
+                },
             },
-            "deviceRegistryNamespace": adr_result,
+            "deviceRegistryNamespace": {
+                "name": adr_result["name"],
+                "resourceGroup": adr_result["resourceGroup"],
+                "subscriptionId": adr_result["subscriptionId"],
+                "identity": adr_result.get("identity"),
+                "managementEndpoint": {
+                    "endpointType": our_endpoint.get("endpointType", ""),
+                    "address": our_endpoint.get("address", ""),
+                    "scopeId": our_endpoint.get("scopeId", ""),
+                },
+            },
         }
 
         if role_assignments_result is not None:
@@ -477,23 +597,25 @@ class MgmtActions(Queryable):
         }
 
         # Probe EG permission bindings
-        client_group = ""
+        pub_client_group = ""
         try:
             pub_binding = self.eventgrid_mgmt_client.permission_bindings.get(
                 resource_group_name=eg_resource_group,
                 namespace_name=eg_namespace_name,
                 permission_binding_name=pub_binding_name,
             )
-            client_group = pub_binding.get("properties", {}).get("clientGroupName", "")
+            pub_client_group = pub_binding.get("properties", {}).get("clientGroupName", "")
         except ResourceNotFoundError:
             return {"enabled": False}
 
+        sub_client_group = ""
         try:
-            self.eventgrid_mgmt_client.permission_bindings.get(
+            sub_binding = self.eventgrid_mgmt_client.permission_bindings.get(
                 resource_group_name=eg_resource_group,
                 namespace_name=eg_namespace_name,
                 permission_binding_name=sub_binding_name,
             )
+            sub_client_group = sub_binding.get("properties", {}).get("clientGroupName", "")
         except ResourceNotFoundError:
             return {"enabled": False}
 
@@ -508,9 +630,8 @@ class MgmtActions(Queryable):
                 },
                 "topicSpace": topic_space_result,
                 "permissionBindings": {
-                    "publisherName": pub_binding_name,
-                    "subscriberName": sub_binding_name,
-                    "clientGroup": client_group,
+                    "publisher": {"name": pub_binding_name, "clientGroup": pub_client_group},
+                    "subscriber": {"name": sub_binding_name, "clientGroup": sub_client_group},
                 },
             },
             "deviceRegistryNamespace": {
@@ -538,97 +659,124 @@ class MgmtActions(Queryable):
         EG topic space/permission bindings, and ADR namespace management endpoint entry.
         Role assignments are NOT removed — they may be shared with other resources.
         """
-        # Resolve instance
-        instance = self.iotops_mgmt_client.instance.get(
-            instance_name=name,
-            resource_group_name=resource_group_name,
-        )
-        instance_resource_id: str = instance["id"]
+        no_progress = kwargs.pop("no_progress", None)
 
-        # Derive deterministic resource names
-        resp_name = get_mgmt_actions_resource_name("resp", instance_resource_id)
-        graph_name = get_mgmt_actions_resource_name("req", instance_resource_id)
-        ep_name = get_mgmt_actions_resource_name("eg", instance_resource_id)
-        ts_name = get_mgmt_actions_resource_name("ops", instance_resource_id)
-        pub_name = get_mgmt_actions_resource_name("pub", instance_resource_id)
-        sub_name = get_mgmt_actions_resource_name("sub", instance_resource_id)
+        # --- Phase 1: Discovery (transient — vanishes before prompt) ---
+        analyzing_cats = {
+            "Analyzing": ["Instance & ADR namespace", "Dataflow profile detection", "EG resource probing"],
+        }
+        with WorkflowDisplay(
+            "Management Actions Disablement", analyzing_cats, no_progress=no_progress,
+        ) as display:
+            display.update_step("Analyzing", "Instance & ADR namespace", StepState.ACTIVE)
 
-        # Discover EG namespace from ADR namespace management endpoint
-        adr_namespace_resource_id = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
-        if not adr_namespace_resource_id:
-            logger.warning(
-                "Instance '%s' does not have an ADR namespace reference. "
-                "Management actions may not have been enabled.",
-                name,
-            )
-            return
-
-        parsed_adr = parse_resource_id_dict(adr_namespace_resource_id)
-        adr_resource_group = parsed_adr.get("resource_group", "")
-        adr_namespace_name = parsed_adr.get("name", "")
-
-        try:
-            adr_namespace = self.registry_mgmt_client.namespaces.get(
-                resource_group_name=adr_resource_group,
-                namespace_name=adr_namespace_name,
-            )
-        except ResourceNotFoundError:
-            logger.warning(
-                "ADR namespace '%s' not found. Management actions may not have been enabled.",
-                adr_namespace_name,
-            )
-            return
-
-        custom_location_id: str = instance.get("extendedLocation", {}).get("name", "")
-        existing_endpoints = adr_namespace.get("properties", {}).get("management", {}).get("endpoints", {})
-        mgmt_endpoint = existing_endpoints.get(custom_location_id)
-
-        # Discover EG namespace context from the management endpoint entry
-        eg_ctx = self._discover_eg_context(mgmt_endpoint)
-
-        # --- Discovery phase: probe AIO resources before prompting ---
-        # Auto-detect the dataflow profile containing our graph
-        dataflow_profile_name = self._discover_dataflow_profile(
-            instance_name=name,
-            resource_group_name=resource_group_name,
-            get_resource=lambda profile: self.iotops_mgmt_client.dataflow_graph.get(
-                resource_group_name=resource_group_name,
-                instance_name=name,
-                dataflow_profile_name=profile,
-                dataflow_graph_name=graph_name,
-            ),
-        )
-
-        # If graph gone, check for orphaned response dataflow
-        resp_profile_name: Optional[str] = None
-        if not dataflow_profile_name:
-            resp_profile_name = self._discover_dataflow_profile(
+            # Resolve instance
+            instance = self.iotops_mgmt_client.instance.get(
                 instance_name=name,
                 resource_group_name=resource_group_name,
-                get_resource=lambda profile: self.iotops_mgmt_client.dataflow.get(
+            )
+            instance_resource_id: str = instance["id"]
+
+            # Derive deterministic resource names
+            resp_name = get_mgmt_actions_resource_name("resp", instance_resource_id)
+            graph_name = get_mgmt_actions_resource_name("req", instance_resource_id)
+            ep_name = get_mgmt_actions_resource_name("eg", instance_resource_id)
+            ts_name = get_mgmt_actions_resource_name("ops", instance_resource_id)
+            pub_name = get_mgmt_actions_resource_name("pub", instance_resource_id)
+            sub_name = get_mgmt_actions_resource_name("sub", instance_resource_id)
+
+            # Discover EG namespace from ADR namespace management endpoint
+            adr_namespace_resource_id = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+            if not adr_namespace_resource_id:
+                logger.warning(
+                    "Instance '%s' does not have an ADR namespace reference. "
+                    "Management actions may not have been enabled.",
+                    name,
+                )
+                return
+
+            parsed_adr = parse_resource_id_dict(adr_namespace_resource_id)
+            adr_resource_group = parsed_adr.get("resource_group", "")
+            adr_namespace_name = parsed_adr.get("name", "")
+
+            try:
+                adr_namespace = self.registry_mgmt_client.namespaces.get(
+                    resource_group_name=adr_resource_group,
+                    namespace_name=adr_namespace_name,
+                )
+            except ResourceNotFoundError:
+                logger.warning(
+                    "ADR namespace '%s' not found. Management actions may not have been enabled.",
+                    adr_namespace_name,
+                )
+                return
+
+            custom_location_id: str = instance.get("extendedLocation", {}).get("name", "")
+            existing_endpoints = adr_namespace.get("properties", {}).get("management", {}).get("endpoints", {})
+            mgmt_endpoint = existing_endpoints.get(custom_location_id)
+
+            # Discover EG namespace context from the management endpoint entry
+            eg_ctx = self._discover_eg_context(mgmt_endpoint)
+            display.update_step("Analyzing", "Instance & ADR namespace", StepState.COMPLETE, "found")
+
+            # --- Discovery phase: probe AIO resources before prompting ---
+            display.update_step("Analyzing", "Dataflow profile detection", StepState.ACTIVE)
+
+            # Auto-detect the dataflow profile containing our graph
+            dataflow_profile_name = self._discover_dataflow_profile(
+                instance_name=name,
+                resource_group_name=resource_group_name,
+                get_resource=lambda profile: self.iotops_mgmt_client.dataflow_graph.get(
                     resource_group_name=resource_group_name,
                     instance_name=name,
                     dataflow_profile_name=profile,
-                    dataflow_name=resp_name,
+                    dataflow_graph_name=graph_name,
                 ),
             )
 
-        # Check dataflow endpoint existence
-        ep_exists = True
-        try:
-            self.iotops_mgmt_client.dataflow_endpoint.get(
-                resource_group_name=resource_group_name,
-                instance_name=name,
-                dataflow_endpoint_name=ep_name,
+            # If graph gone, check for orphaned response dataflow
+            resp_profile_name: Optional[str] = None
+            if not dataflow_profile_name:
+                resp_profile_name = self._discover_dataflow_profile(
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                    get_resource=lambda profile: self.iotops_mgmt_client.dataflow.get(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        dataflow_profile_name=profile,
+                        dataflow_name=resp_name,
+                    ),
+                )
+
+            # Check dataflow endpoint existence
+            ep_exists = True
+            try:
+                self.iotops_mgmt_client.dataflow_endpoint.get(
+                    resource_group_name=resource_group_name,
+                    instance_name=name,
+                    dataflow_endpoint_name=ep_name,
+                )
+            except ResourceNotFoundError:
+                ep_exists = False
+
+            if dataflow_profile_name:
+                profile_detail = "found"
+            elif resp_profile_name:
+                profile_detail = "orphaned"
+            else:
+                profile_detail = "not found"
+            display.update_step("Analyzing", "Dataflow profile detection", StepState.COMPLETE, profile_detail)
+
+            # Check EG resource existence (topic space + permission bindings)
+            display.update_step("Analyzing", "EG resource probing", StepState.ACTIVE)
+            ts_exists, pub_exists, sub_exists = self._probe_eg_resources(
+                eg_ctx=eg_ctx, ts_name=ts_name, pub_name=pub_name, sub_name=sub_name,
             )
-        except ResourceNotFoundError:
-            ep_exists = False
+            eg_found_count = sum([ts_exists, pub_exists, sub_exists])
+            eg_probe_detail = f"{eg_found_count} found" if eg_found_count else "none found"
+            display.update_step("Analyzing", "EG resource probing", StepState.COMPLETE, eg_probe_detail)
 
-        # Check EG resource existence (topic space + permission bindings)
-        ts_exists, pub_exists, sub_exists = self._probe_eg_resources(
-            eg_ctx=eg_ctx, ts_name=ts_name, pub_name=pub_name, sub_name=sub_name,
-        )
-
+        # --- Phase 2: Summary + prompt (no display active) ---
         # Print summary of what will be removed (skip when --yes bypasses the prompt)
         if not confirm_yes:
             _log_disable_summary(
@@ -648,8 +796,132 @@ class MgmtActions(Queryable):
         if not should_continue_prompt(confirm_yes=confirm_yes):
             return
 
-        # --- AIO resource teardown (dependents before parents) ---
+        # --- Phase 3: Teardown (persistent — display remains as evidence) ---
+        self._execute_disable_teardown(
+            name=name,
+            resource_group_name=resource_group_name,
+            dataflow_profile_name=dataflow_profile_name,
+            resp_profile_name=resp_profile_name,
+            resp_name=resp_name,
+            graph_name=graph_name,
+            ep_name=ep_name,
+            ep_exists=ep_exists,
+            adr_namespace=adr_namespace,
+            adr_resource_group=adr_resource_group,
+            adr_namespace_name=adr_namespace_name,
+            custom_location_id=custom_location_id,
+            existing_endpoints=existing_endpoints,
+            eg_ctx=eg_ctx,
+            pub_name=pub_name,
+            sub_name=sub_name,
+            pub_exists=pub_exists,
+            sub_exists=sub_exists,
+            ts_name=ts_name,
+            ts_exists=ts_exists,
+            no_progress=no_progress,
+            **kwargs,
+        )
+
+    def _execute_disable_teardown(
+        self,
+        name: str,
+        resource_group_name: str,
+        dataflow_profile_name: Optional[str],
+        resp_profile_name: Optional[str],
+        resp_name: str,
+        graph_name: str,
+        ep_name: str,
+        ep_exists: bool,
+        adr_namespace: Dict,
+        adr_resource_group: str,
+        adr_namespace_name: str,
+        custom_location_id: str,
+        existing_endpoints: Dict,
+        eg_ctx: Optional["EgNamespaceContext"],
+        pub_name: str,
+        sub_name: str,
+        pub_exists: bool,
+        sub_exists: bool,
+        ts_name: str,
+        ts_exists: bool,
+        no_progress: Optional[bool] = None,
+        **kwargs,
+    ) -> None:
+        """Execute the Phase 3 teardown of disable(), deleting discovered resources.
+
+        Orchestrates three domain-specific teardown helpers (AIO, ADR, EG) under a
+        single persistent WorkflowDisplay. All parameters are pre-resolved during
+        discovery (Phase 1).
+        """
+        eg_ns_label = f"Event Grid Namespace ({eg_ctx.namespace_name})" if eg_ctx else "Event Grid Namespace"
+        cat_aio = f"IoT Operations Instance ({name})"
+        cat_adr = f"Device Registry Namespace ({adr_namespace_name})"
+
+        teardown_cats: Dict[str, List[str]] = {
+            cat_aio: ["Response dataflow", "Dataflow graph", "EG dataflow endpoint"],
+            cat_adr: ["Management endpoint"],
+            eg_ns_label: ["Permission bindings", "Topic space"],
+        }
+        with WorkflowDisplay(
+            "Management Actions Disablement", teardown_cats, transient=False, no_progress=no_progress,
+        ) as display:
+            self._teardown_aio_resources(
+                display=display,
+                category=cat_aio,
+                name=name,
+                resource_group_name=resource_group_name,
+                dataflow_profile_name=dataflow_profile_name,
+                resp_profile_name=resp_profile_name,
+                resp_name=resp_name,
+                graph_name=graph_name,
+                ep_name=ep_name,
+                ep_exists=ep_exists,
+                **kwargs,
+            )
+            self._teardown_adr_endpoint(
+                display=display,
+                category=cat_adr,
+                adr_namespace=adr_namespace,
+                adr_resource_group=adr_resource_group,
+                adr_namespace_name=adr_namespace_name,
+                custom_location_id=custom_location_id,
+                existing_endpoints=existing_endpoints,
+                **kwargs,
+            )
+            self._teardown_eg_resources(
+                display=display,
+                category=eg_ns_label,
+                eg_ctx=eg_ctx,
+                pub_name=pub_name,
+                sub_name=sub_name,
+                pub_exists=pub_exists,
+                sub_exists=sub_exists,
+                ts_name=ts_name,
+                ts_exists=ts_exists,
+                **kwargs,
+            )
+
+    def _teardown_aio_resources(
+        self,
+        display: WorkflowDisplay,
+        category: str,
+        name: str,
+        resource_group_name: str,
+        dataflow_profile_name: Optional[str],
+        resp_profile_name: Optional[str],
+        resp_name: str,
+        graph_name: str,
+        ep_name: str,
+        ep_exists: bool,
+        **kwargs,
+    ) -> None:
+        """Delete AIO dataflow resources (response dataflow, graph, EG endpoint).
+
+        Handles three scenarios: both graph+response exist under one profile,
+        only an orphaned response dataflow exists, or neither is found.
+        """
         if dataflow_profile_name:
+            display.update_step(category, "Response dataflow", StepState.ACTIVE)
             _graceful_delete(
                 lambda: self.iotops_mgmt_client.dataflow.begin_delete(
                     resource_group_name=resource_group_name,
@@ -660,7 +932,9 @@ class MgmtActions(Queryable):
                 resource_desc=f"response dataflow '{resp_name}'",
                 **kwargs,
             )
+            display.update_step(category, "Response dataflow", StepState.COMPLETE, "removed")
 
+            display.update_step(category, "Dataflow graph", StepState.ACTIVE)
             _graceful_delete(
                 lambda: self.iotops_mgmt_client.dataflow_graph.begin_delete(
                     resource_group_name=resource_group_name,
@@ -671,7 +945,9 @@ class MgmtActions(Queryable):
                 resource_desc=f"dataflow graph '{graph_name}'",
                 **kwargs,
             )
+            display.update_step(category, "Dataflow graph", StepState.COMPLETE, "removed")
         elif resp_profile_name:
+            display.update_step(category, "Response dataflow", StepState.ACTIVE)
             _graceful_delete(
                 lambda: self.iotops_mgmt_client.dataflow.begin_delete(
                     resource_group_name=resource_group_name,
@@ -682,14 +958,19 @@ class MgmtActions(Queryable):
                 resource_desc=f"orphaned response dataflow '{resp_name}'",
                 **kwargs,
             )
+            display.update_step(category, "Response dataflow", StepState.COMPLETE, "removed")
+            display.update_step(category, "Dataflow graph", StepState.SKIPPED, "not found")
         else:
             logger.info(
                 "Dataflow graph '%s' and response dataflow '%s' not found in any profile — skipping.",
                 graph_name,
                 resp_name,
             )
+            display.update_step(category, "Response dataflow", StepState.SKIPPED, "not found")
+            display.update_step(category, "Dataflow graph", StepState.SKIPPED, "not found")
 
         if ep_exists:
+            display.update_step(category, "EG dataflow endpoint", StepState.ACTIVE)
             _graceful_delete(
                 lambda: self.iotops_mgmt_client.dataflow_endpoint.begin_delete(
                     resource_group_name=resource_group_name,
@@ -699,11 +980,25 @@ class MgmtActions(Queryable):
                 resource_desc=f"dataflow endpoint '{ep_name}'",
                 **kwargs,
             )
+            display.update_step(category, "EG dataflow endpoint", StepState.COMPLETE, "removed")
         else:
             logger.info("Dataflow endpoint '%s' not found — skipping.", ep_name)
+            display.update_step(category, "EG dataflow endpoint", StepState.SKIPPED, "not found")
 
-        # --- ADR namespace: remove management endpoint entry ---
+    def _teardown_adr_endpoint(
+        self,
+        display: WorkflowDisplay,
+        category: str,
+        adr_namespace: Dict,
+        adr_resource_group: str,
+        adr_namespace_name: str,
+        custom_location_id: str,
+        existing_endpoints: Dict,
+        **kwargs,
+    ) -> None:
+        """Remove the management endpoint entry from the ADR namespace."""
         if custom_location_id in existing_endpoints:
+            display.update_step(category, "Management endpoint", StepState.ACTIVE)
             put_payload = _build_adr_put_payload(adr_namespace, endpoint_key_to_remove=custom_location_id)
             poller = self.registry_mgmt_client.namespaces.begin_create_or_replace(
                 resource_group_name=adr_resource_group,
@@ -715,36 +1010,66 @@ class MgmtActions(Queryable):
                 "Removed management endpoint entry for custom location from ADR namespace '%s'.",
                 adr_namespace_name,
             )
+            display.update_step(
+                category, "Management endpoint", StepState.COMPLETE, "removed",
+            )
         else:
             logger.info(
                 "No management endpoint entry found for custom location on ADR namespace '%s' — skipping.",
                 adr_namespace_name,
             )
-
-        # --- EG resource teardown (only if resources were discovered) ---
-        if pub_exists:
-            _graceful_delete(
-                lambda: self.eventgrid_mgmt_client.permission_bindings.begin_delete(
-                    resource_group_name=eg_ctx.resource_group_name,
-                    namespace_name=eg_ctx.namespace_name,
-                    permission_binding_name=pub_name,
-                ),
-                resource_desc=f"permission binding '{pub_name}'",
-                **kwargs,
+            display.update_step(
+                category, "Management endpoint", StepState.SKIPPED, "not found",
             )
 
-        if sub_exists:
-            _graceful_delete(
-                lambda: self.eventgrid_mgmt_client.permission_bindings.begin_delete(
-                    resource_group_name=eg_ctx.resource_group_name,
-                    namespace_name=eg_ctx.namespace_name,
-                    permission_binding_name=sub_name,
-                ),
-                resource_desc=f"permission binding '{sub_name}'",
-                **kwargs,
-            )
+    def _teardown_eg_resources(
+        self,
+        display: WorkflowDisplay,
+        category: str,
+        eg_ctx: Optional["EgNamespaceContext"],
+        pub_name: str,
+        sub_name: str,
+        pub_exists: bool,
+        sub_exists: bool,
+        ts_name: str,
+        ts_exists: bool,
+        **kwargs,
+    ) -> None:
+        """Delete EG permission bindings and topic space."""
+        if not eg_ctx:
+            logger.info("EG namespace not discovered from ADR — skipping EG resource cleanup.")
+            display.update_step(category, "Permission bindings", StepState.SKIPPED, "not found")
+            display.update_step(category, "Topic space", StepState.SKIPPED, "not found")
+            return
+
+        if pub_exists or sub_exists:
+            display.update_step(category, "Permission bindings", StepState.ACTIVE)
+            if pub_exists:
+                _graceful_delete(
+                    lambda: self.eventgrid_mgmt_client.permission_bindings.begin_delete(
+                        resource_group_name=eg_ctx.resource_group_name,
+                        namespace_name=eg_ctx.namespace_name,
+                        permission_binding_name=pub_name,
+                    ),
+                    resource_desc=f"permission binding '{pub_name}'",
+                    **kwargs,
+                )
+            if sub_exists:
+                _graceful_delete(
+                    lambda: self.eventgrid_mgmt_client.permission_bindings.begin_delete(
+                        resource_group_name=eg_ctx.resource_group_name,
+                        namespace_name=eg_ctx.namespace_name,
+                        permission_binding_name=sub_name,
+                    ),
+                    resource_desc=f"permission binding '{sub_name}'",
+                    **kwargs,
+                )
+            display.update_step(category, "Permission bindings", StepState.COMPLETE, "removed")
+        else:
+            display.update_step(category, "Permission bindings", StepState.SKIPPED, "not found")
 
         if ts_exists:
+            display.update_step(category, "Topic space", StepState.ACTIVE)
             _graceful_delete(
                 lambda: self.eventgrid_mgmt_client.topic_spaces.begin_delete(
                     resource_group_name=eg_ctx.resource_group_name,
@@ -754,11 +1079,12 @@ class MgmtActions(Queryable):
                 resource_desc=f"topic space '{ts_name}'",
                 **kwargs,
             )
+            display.update_step(category, "Topic space", StepState.COMPLETE, "removed")
+        else:
+            display.update_step(category, "Topic space", StepState.SKIPPED, "not found")
 
-        if eg_ctx and not any([pub_exists, sub_exists, ts_exists]):
+        if not any([pub_exists, sub_exists, ts_exists]):
             logger.info("No EG resources found on namespace '%s' — skipping.", eg_ctx.namespace_name)
-        elif not eg_ctx:
-            logger.info("EG namespace not discovered from ADR — skipping EG resource cleanup.")
 
     def _probe_eg_resources(
         self,
@@ -1009,6 +1335,7 @@ class MgmtActions(Queryable):
                 "name": topic_space_name,
                 "topicTemplates": topic_templates,
                 "scopeId": instance_name,
+                "existed": True,
             }
         except ResourceNotFoundError:
             pass
@@ -1034,6 +1361,7 @@ class MgmtActions(Queryable):
             "name": topic_space_name,
             "topicTemplates": topic_templates,
             "scopeId": instance_name,
+            "existed": False,
         }
 
     def _setup_eg_permission_bindings(
@@ -1054,6 +1382,7 @@ class MgmtActions(Queryable):
         sub_name = get_mgmt_actions_resource_name("sub", instance_resource_id)
 
         result: Dict = {}
+        all_existed = True
         for binding_name, permission, key in [
             (pub_name, "Publisher", "publisher"),
             (sub_name, "Subscriber", "subscriber"),
@@ -1073,7 +1402,7 @@ class MgmtActions(Queryable):
                 result[key] = {"name": binding_name, "clientGroup": client_group}
                 continue
             except ResourceNotFoundError:
-                pass
+                all_existed = False
 
             # Create the permission binding
             binding_payload = {
@@ -1102,6 +1431,7 @@ class MgmtActions(Queryable):
             )
             result[key] = {"name": binding_name, "clientGroup": client_group}
 
+        result["existed"] = all_existed
         return result
 
     def _setup_eg_dataflow_endpoint(
@@ -1136,7 +1466,7 @@ class MgmtActions(Queryable):
                 instance_name,
             )
             existing_auth = existing.get("properties", {}).get("mqttSettings", {}).get("authentication", {})
-            return {"name": endpoint_name, "authentication": existing_auth}
+            return {"name": endpoint_name, "authentication": existing_auth, "existed": True}
         except ResourceNotFoundError:
             pass
 
@@ -1185,7 +1515,7 @@ class MgmtActions(Queryable):
             instance_name,
         )
 
-        return {"name": endpoint_name, "authentication": authentication}
+        return {"name": endpoint_name, "authentication": authentication, "existed": False}
 
     def _setup_adr_management_endpoint(
         self,
@@ -1263,6 +1593,8 @@ class MgmtActions(Queryable):
                     "principalId": principal_id,
                 },
                 "managementEndpoints": existing_endpoints,
+                "identity_existed": True,
+                "endpoint_existed": True,
             }
 
         # Build the update payload
@@ -1314,6 +1646,8 @@ class MgmtActions(Queryable):
                 "principalId": principal_id,
             },
             "managementEndpoints": updated_endpoints,
+            "identity_existed": identity_already_enabled,
+            "endpoint_existed": endpoint_already_configured,
         }
 
     def _setup_dataflow_graph(
@@ -1348,7 +1682,7 @@ class MgmtActions(Queryable):
                 graph_name,
                 instance_name,
             )
-            return {"name": graph_name}
+            return {"name": graph_name, "existed": True}
         except ResourceNotFoundError:
             pass
 
@@ -1416,7 +1750,7 @@ class MgmtActions(Queryable):
             dataflow_profile_name,
         )
 
-        return {"name": graph_name}
+        return {"name": graph_name, "existed": False}
 
     def _setup_response_dataflow(
         self,
@@ -1449,7 +1783,7 @@ class MgmtActions(Queryable):
                 dataflow_name,
                 instance_name,
             )
-            return {"name": dataflow_name}
+            return {"name": dataflow_name, "existed": True}
         except ResourceNotFoundError:
             pass
 
@@ -1493,7 +1827,7 @@ class MgmtActions(Queryable):
             dataflow_profile_name,
         )
 
-        return {"name": dataflow_name}
+        return {"name": dataflow_name, "existed": False}
 
     def _resolve_user_assigned_mi(self, mi_resource_id: str) -> Dict:
         """Fetch a user-assigned managed identity resource to extract clientId and tenantId.

--- a/azext_edge/edge/util/workflow_display.py
+++ b/azext_edge/edge/util/workflow_display.py
@@ -1,0 +1,283 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""Reusable Rich-based workflow progress display for multi-step CLI operations."""
+
+import threading
+from enum import Enum
+from typing import Dict, List, Optional, Tuple, Union
+
+from rich.console import Console
+from rich.live import Live
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.table import Table
+from rich.text import Text
+
+
+_DISPLAY_WIDTH = 56
+_DOT_CHAR = "."
+
+
+def format_dot_leader(
+    name: str, detail: str, width: int = _DISPLAY_WIDTH, indent: str = "    ", dot_char: str = _DOT_CHAR,
+) -> str:
+    """Format a line with dot-leaders connecting name to right-aligned detail.
+
+    Produces lines like:  ``    Topic space ............... created``
+    Shared between WorkflowDisplay step rendering and static summary tables.
+    """
+    content_width = width - len(indent)
+    dots_needed = content_width - len(name) - len(detail) - 2  # 2 spaces flanking dots
+    dots_needed = max(dots_needed, 2)
+    dots = f" {dot_char * dots_needed} "
+    return f"{indent}{name}{dots}{detail}"
+
+
+def render_summary(
+    title: str,
+    sections: Dict[str, Union[List[Tuple[str, str]], List[str]]],
+    footer: str = "",
+) -> None:
+    """Print a static Rich summary table to stderr.
+
+    Each section is a category header with items listed below it.
+    Items can be tuples ``(name, detail)`` rendered with dot-leaders, or plain
+    strings rendered as simple indented lines.
+    Empty sections are silently skipped.
+
+    Args:
+        title: Bold header line.
+        sections: Ordered dict of {category_name: items}.  Items may be
+            ``[(name, detail), ...]`` for dot-leader layout or ``[label, ...]``
+            for plain hierarchical listing.
+        footer: Optional dim-styled note line at the bottom.
+    """
+    grid = Table.grid(padding=(0, 0))
+    grid.add_column()
+
+    grid.add_row(Text(f" {title}", style="bold"))
+    grid.add_row(Text(""))
+
+    has_items = False
+    for category, items in sections.items():
+        if not items:
+            continue
+        has_items = True
+        grid.add_row(Text(f"  {category}"))
+        for item in items:
+            if isinstance(item, tuple):
+                grid.add_row(Text(format_dot_leader(item[0], item[1])))
+            else:
+                grid.add_row(Text(f"    {item}"))
+        grid.add_row(Text(""))
+
+    if not has_items:
+        grid.add_row(Text("  No resources found.", style="dim"))
+        grid.add_row(Text(""))
+
+    if footer:
+        grid.add_row(Text(f"  {footer}", style="dim"))
+        grid.add_row(Text(""))
+
+    Console(stderr=True).print(grid)
+
+
+class StepState(Enum):
+    """Workflow step lifecycle states."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    COMPLETE = "complete"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+class WorkflowDisplay:
+    """Thread-safe progress display for multi-step CLI workflows.
+
+    Renders categorized steps with dot-leader alignment, caller-supplied status words,
+    and color-coded category headers. All output goes to stderr via Console(stderr=True)
+    to keep stdout clean for JSON return values.
+
+    Supports transient mode (display vanishes on exit) for commands that return JSON,
+    and persistent mode (display remains) for commands that return None. Full suppression
+    via no_progress for CI/CD automation.
+
+    Usage:
+        categories = {"Analyzing": ["Step 1", "Step 2"], "Building": ["Step 3"]}
+        with WorkflowDisplay("My Workflow", categories) as display:
+            display.update_step("Analyzing", "Step 1", StepState.ACTIVE)
+            # ... do work ...
+            display.update_step("Analyzing", "Step 1", StepState.COMPLETE, "done")
+    """
+
+    def __init__(
+        self,
+        title: str,
+        categories: Dict[str, List[str]],
+        transient: bool = True,
+        no_progress: bool = False,
+        refresh_per_second: int = 8,
+    ) -> None:
+        self._title = title
+        self._transient = transient
+        self._no_progress = bool(no_progress)
+        self._refresh_per_second = refresh_per_second
+
+        self._console = Console(stderr=True)
+        self._lock = threading.Lock()
+        self._live: Optional[Live] = None
+        self._progress_bar: Optional[Progress] = None
+        self._task_id: Optional[int] = None
+
+        # Ordered step state: {category: {step_name: [state, detail]}}
+        # Dict insertion order preserved (Python 3.7+)
+        self._steps: Dict[str, Dict[str, list]] = {}
+        for cat, steps in categories.items():
+            self._steps[cat] = {}
+            for step in steps:
+                self._steps[cat][step] = [StepState.PENDING, ""]
+
+    def __enter__(self) -> "WorkflowDisplay":
+        if self._no_progress:
+            return self
+        if not self._transient:
+            self._progress_bar = Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(bar_width=20),
+                TextColumn("Elapsed:"),
+                TimeElapsedColumn(),
+                auto_refresh=False,
+            )
+            self._task_id = self._progress_bar.add_task(description="Working...", total=None)
+        self._live = Live(
+            console=self._console,
+            transient=self._transient,
+            refresh_per_second=self._refresh_per_second,
+        )
+        # Override get_renderable so Live's auto-refresh daemon thread calls _render()
+        # on each cycle, giving us live elapsed time updates without manual live.update()
+        # calls on every state change.
+        self._live.get_renderable = self._render
+        self._live.__enter__()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._progress_bar is not None and self._task_id is not None:
+            self._progress_bar.update(self._task_id, description="Done.")
+            self._progress_bar.stop_task(self._task_id)
+        if self._live is not None:
+            self._live.__exit__(*exc)
+            self._live = None
+
+    def update_step(self, category: str, step: str, state: StepState, detail: str = "") -> None:
+        """Transition a step to a new state with an optional caller-supplied status word.
+
+        The display is domain-agnostic — callers choose contextually appropriate status
+        words like 'created', 'exists', 'removed', 'not found', 'failed: <reason>'.
+        """
+        if self._no_progress:
+            return
+        with self._lock:
+            self._set_step(category, step, state, detail)
+
+    def complete_category(self, category: str) -> None:
+        """Mark all remaining PENDING steps in a category as COMPLETE with 'done'.
+
+        Useful when all steps in a phase succeed and the caller wants to advance the
+        entire category in one call rather than updating each step individually.
+        """
+        if self._no_progress:
+            return
+        with self._lock:
+            if category not in self._steps:
+                raise ValueError(f"Unknown category: {category!r}")
+            for step_entry in self._steps[category].values():
+                if step_entry[0] == StepState.PENDING:
+                    step_entry[0] = StepState.COMPLETE
+                    if not step_entry[1]:
+                        step_entry[1] = "done"
+
+    def _set_step(self, category: str, step: str, state: StepState, detail: str) -> None:
+        """Update a step entry. Must be called under self._lock."""
+        if category not in self._steps:
+            raise ValueError(f"Unknown category: {category!r}")
+        if step not in self._steps[category]:
+            raise ValueError(f"Unknown step {step!r} in category {category!r}")
+        self._steps[category][step] = [state, detail]
+
+    def _render(self) -> Table:
+        """Build the display grid from a snapshot of current state.
+
+        Called by Rich Live's auto-refresh daemon thread on each refresh cycle —
+        acquires lock briefly for the state snapshot, then builds the grid outside
+        the lock to minimize contention with worker threads.
+        """
+        with self._lock:
+            snapshot: Dict[str, Dict[str, Tuple[StepState, str]]] = {
+                cat: {step: (entry[0], entry[1]) for step, entry in steps.items()}
+                for cat, steps in self._steps.items()
+            }
+
+        grid = Table.grid(padding=(0, 0))
+        grid.add_column()
+
+        # Title
+        grid.add_row(Text(f" {self._title}", style="bold"))
+        grid.add_row(Text(""))
+
+        for cat, steps in snapshot.items():
+            cat_style = self._category_style(steps)
+            grid.add_row(Text(f"  {cat}", style=cat_style))
+
+            for step_name, (state, detail) in steps.items():
+                grid.add_row(self._render_step(step_name, state, detail))
+
+            grid.add_row(Text(""))
+
+        # Animated progress footer for non-transient displays
+        if self._progress_bar is not None:
+            grid.add_row(self._progress_bar)
+            grid.add_row(Text(""))
+
+        return grid
+
+    @staticmethod
+    def _category_style(steps: Dict[str, Tuple[StepState, str]]) -> str:
+        """Derive category header color from the aggregate state of its steps."""
+        states = [s for s, _ in steps.values()]
+        if any(s == StepState.FAILED for s in states):
+            return "red"
+        if any(s == StepState.ACTIVE for s in states):
+            return "cyan"
+        if all(s in (StepState.COMPLETE, StepState.SKIPPED) for s in states):
+            return ""
+        if all(s == StepState.PENDING for s in states):
+            return "dim"
+        # Mix of completed/skipped and pending — category is in progress
+        return "cyan"
+
+    def _render_step(self, name: str, state: StepState, detail: str) -> Text:
+        """Render a single step with formatting appropriate to its state."""
+        indent = "    "
+
+        if state == StepState.PENDING:
+            return Text(f"{indent}{name}", style="dim")
+
+        if state == StepState.ACTIVE:
+            return Text(f"{indent}{name} ...", style="cyan")
+
+        # Terminal states: dot leaders connecting step name to right-aligned status word
+        status_word = detail or state.value
+        line = format_dot_leader(name, status_word)
+
+        style_map = {
+            StepState.COMPLETE: "",
+            StepState.SKIPPED: "dark_khaki",
+            StepState.FAILED: "red",
+        }
+        return Text(line, style=style_map.get(state, ""))

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -61,6 +61,17 @@ K8S_EXTENSIONS_API_VERSION = "2023-05-01"
 
 
 # ---------------------------------------------------------------------------
+# Autouse fixture — suppress Rich display for all tests in this module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def suppress_workflow_display(mocker):
+    """Prevent WorkflowDisplay and render_summary from writing to stderr during tests."""
+    mocker.patch("azext_edge.edge.providers.orchestration.mgmt_actions.WorkflowDisplay")
+    mocker.patch("azext_edge.edge.providers.orchestration.mgmt_actions.render_summary")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -2290,7 +2301,9 @@ class TestEnable:
         """Register HTTP mocks for an enable() call.
 
         Registers 16 calls (or 17 with mi_response) in the exact order
-        the enable() method issues them.
+        the enable() method issues them:
+          Instance GET → EG namespace GET → (UAMI GET) → topic space → permission bindings
+          → ADR namespace GET/PATCH → dataflow endpoint → dataflow graph → response dataflow.
         """
         # 1. GET instance
         mocked_responses.add(
@@ -2341,19 +2354,6 @@ class TestEnable:
                 json=_build_permission_binding_response(name, perm, ts_name),
                 status=200,
             )
-        # Dataflow endpoint: GET 404, PUT 200
-        mocked_responses.add(
-            method=responses.GET,
-            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{ep_name}"),
-            json={"error": {"code": "ResourceNotFound"}},
-            status=404,
-        )
-        mocked_responses.add(
-            method=responses.PUT,
-            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{ep_name}"),
-            json={"id": f"/fake/path/dataflowEndpoints/{ep_name}", "name": ep_name},
-            status=200,
-        )
         # ADR namespace: GET, PATCH 200
         mocked_responses.add(
             method=responses.GET,
@@ -2378,6 +2378,19 @@ class TestEnable:
                     },
                 },
             ),
+            status=200,
+        )
+        # Dataflow endpoint: GET 404, PUT 200
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{ep_name}"),
+            json={"error": {"code": "ResourceNotFound"}},
+            status=404,
+        )
+        mocked_responses.add(
+            method=responses.PUT,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{ep_name}"),
+            json={"id": f"/fake/path/dataflowEndpoints/{ep_name}", "name": ep_name},
             status=200,
         )
         # Dataflow graph: GET 404, PUT 200
@@ -2479,6 +2492,10 @@ class TestEnable:
         assert adr["subscriptionId"] == ZEROED_SUBSCRIPTION
         assert adr["identity"]["type"] == "SystemAssigned"
         assert adr["identity"]["principalId"] == f["adr_principal_id"]
+        assert adr["managementEndpoint"]["endpointType"] == MGMT_ACTIONS_ADR_ENDPOINT_TYPE
+        assert adr["managementEndpoint"]["address"] == f["hostname"]
+        assert adr["managementEndpoint"]["scopeId"] == f["instance_name"]
+        assert "managementEndpoints" not in adr
 
         # -- Assert roleAssignments section --
         assert result["roleAssignments"] == mock_role_result
@@ -2564,7 +2581,8 @@ class TestEnable:
         assert result["instance"]["dataflowEndpoint"]["name"] == f["ep_name"]
 
         # Verify the endpoint PUT body contains UserAssignedManagedIdentity auth
-        endpoint_put_call = mocked_responses.calls[10]
+        # Index 12: UAMI GET(2) + topic space(3-4) + bindings(5-8) + ADR(9-10) + ep GET(11) + ep PUT(12)
+        endpoint_put_call = mocked_responses.calls[12]
         endpoint_body = json.loads(endpoint_put_call.request.body)
         auth = endpoint_body["properties"]["mqttSettings"]["authentication"]
         assert auth["method"] == "UserAssignedManagedIdentity"
@@ -3525,7 +3543,13 @@ class TestShow:
         )
         assert result["eventGrid"]["topicSpace"]["scopeId"] == f["instance_name"]
         assert len(result["eventGrid"]["topicSpace"]["topicTemplates"]) == 2
-        assert result["eventGrid"]["permissionBindings"]["clientGroup"] == MGMT_ACTIONS_DEFAULT_EG_CLIENT_GROUP
+        pub_name = get_mgmt_actions_resource_name("pub", f["instance_resource_id"])
+        sub_name = get_mgmt_actions_resource_name("sub", f["instance_resource_id"])
+        pub_bindings = result["eventGrid"]["permissionBindings"]
+        assert pub_bindings["publisher"]["name"] == pub_name
+        assert pub_bindings["publisher"]["clientGroup"] == MGMT_ACTIONS_DEFAULT_EG_CLIENT_GROUP
+        assert pub_bindings["subscriber"]["name"] == sub_name
+        assert pub_bindings["subscriber"]["clientGroup"] == MGMT_ACTIONS_DEFAULT_EG_CLIENT_GROUP
         assert result["deviceRegistryNamespace"]["name"] == f["adr_ns_name"]
         assert result["deviceRegistryNamespace"]["resourceGroup"] == f["rg"]
         assert result["deviceRegistryNamespace"]["subscriptionId"] == ZEROED_SUBSCRIPTION

--- a/azext_edge/tests/utility/test_workflow_display_unit.py
+++ b/azext_edge/tests/utility/test_workflow_display_unit.py
@@ -208,12 +208,11 @@ class TestRendering:
         """Non-transient displays include animated progress bar with elapsed time."""
         mocker.patch("azext_edge.edge.util.workflow_display.Live")
         display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=False)
-        display.__enter__()
-        grid = display._render()
-        output = _render_grid_to_text(grid)
-        assert "Working..." in output
-        assert "Elapsed:" in output
-        display.__exit__(None, None, None)
+        with display:
+            grid = display._render()
+            output = _render_grid_to_text(grid)
+            assert "Working..." in output
+            assert "Elapsed:" in output
 
     def test_complete_detail_defaults_to_state_value(self):
         """When no detail is passed, the status word falls back to state.value."""

--- a/azext_edge/tests/utility/test_workflow_display_unit.py
+++ b/azext_edge/tests/utility/test_workflow_display_unit.py
@@ -1,0 +1,563 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+from azext_edge.edge.util.workflow_display import StepState, WorkflowDisplay, format_dot_leader, render_summary
+
+
+class TestStepState:
+    """StepState enum values."""
+
+    def test_enum_values(self):
+        assert StepState.PENDING.value == "pending"
+        assert StepState.ACTIVE.value == "active"
+        assert StepState.COMPLETE.value == "complete"
+        assert StepState.SKIPPED.value == "skipped"
+        assert StepState.FAILED.value == "failed"
+
+    def test_all_states_present(self):
+        assert len(StepState) == 5
+
+
+SAMPLE_CATEGORIES = {
+    "Analyzing": ["Step A", "Step B"],
+    "Building": ["Step C", "Step D", "Step E"],
+}
+
+
+class TestWorkflowDisplayInit:
+    """Constructor and initial state."""
+
+    def test_initial_state_all_pending(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        for cat_steps in display._steps.values():
+            for entry in cat_steps.values():
+                assert entry[0] == StepState.PENDING
+                assert entry[1] == ""
+
+    def test_categories_preserve_order(self):
+        cats = {"First": ["S1"], "Second": ["S2"], "Third": ["S3"]}
+        display = WorkflowDisplay("Test", cats)
+        assert list(display._steps.keys()) == ["First", "Second", "Third"]
+
+    def test_steps_preserve_order(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        assert list(display._steps["Building"].keys()) == ["Step C", "Step D", "Step E"]
+
+    def test_no_progress_flag_coercion(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES, no_progress=1)
+        assert display._no_progress is True
+
+    def test_console_uses_stderr(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        assert display._console.stderr is True
+
+
+class TestUpdateStep:
+    """State transitions via update_step()."""
+
+    def test_pending_to_active(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Analyzing", "Step A", StepState.ACTIVE)
+        assert display._steps["Analyzing"]["Step A"] == [StepState.ACTIVE, ""]
+
+    def test_active_to_complete_with_detail(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Analyzing", "Step A", StepState.ACTIVE)
+        display.update_step("Analyzing", "Step A", StepState.COMPLETE, "created")
+        assert display._steps["Analyzing"]["Step A"] == [StepState.COMPLETE, "created"]
+
+    def test_skipped_with_detail(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Analyzing", "Step B", StepState.SKIPPED, "not needed")
+        assert display._steps["Analyzing"]["Step B"] == [StepState.SKIPPED, "not needed"]
+
+    def test_failed_with_detail(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Building", "Step C", StepState.FAILED, "failed: timeout")
+        assert display._steps["Building"]["Step C"] == [StepState.FAILED, "failed: timeout"]
+
+    def test_unknown_category_raises(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        with pytest.raises(ValueError, match="Unknown category"):
+            display.update_step("Nonexistent", "Step A", StepState.ACTIVE)
+
+    def test_unknown_step_raises(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        with pytest.raises(ValueError, match="Unknown step"):
+            display.update_step("Analyzing", "Nonexistent", StepState.ACTIVE)
+
+    def test_no_progress_is_noop(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES, no_progress=True)
+        # Should not raise even with invalid args — completely skipped
+        display.update_step("Nonexistent", "Nope", StepState.ACTIVE)
+        # State unchanged
+        assert display._steps["Analyzing"]["Step A"][0] == StepState.PENDING
+
+
+class TestCompleteCategory:
+    """Bulk completion of pending steps."""
+
+    def test_marks_pending_as_complete(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Building", "Step C", StepState.COMPLETE, "created")
+        display.complete_category("Building")
+        assert display._steps["Building"]["Step C"] == [StepState.COMPLETE, "created"]
+        assert display._steps["Building"]["Step D"] == [StepState.COMPLETE, "done"]
+        assert display._steps["Building"]["Step E"] == [StepState.COMPLETE, "done"]
+
+    def test_preserves_non_pending_states(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        display.update_step("Analyzing", "Step A", StepState.SKIPPED, "exists")
+        display.update_step("Analyzing", "Step B", StepState.FAILED, "timeout")
+        display.complete_category("Analyzing")
+        # Non-pending states are untouched
+        assert display._steps["Analyzing"]["Step A"] == [StepState.SKIPPED, "exists"]
+        assert display._steps["Analyzing"]["Step B"] == [StepState.FAILED, "timeout"]
+
+    def test_preserves_existing_detail_on_pending(self):
+        """If a pending step already has a detail string, complete_category keeps it."""
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]})
+        display._steps["Cat"]["S1"] = [StepState.PENDING, "pre-set"]
+        display.complete_category("Cat")
+        assert display._steps["Cat"]["S1"] == [StepState.COMPLETE, "pre-set"]
+
+    def test_unknown_category_raises(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES)
+        with pytest.raises(ValueError, match="Unknown category"):
+            display.complete_category("Nonexistent")
+
+    def test_no_progress_is_noop(self):
+        display = WorkflowDisplay("Test", SAMPLE_CATEGORIES, no_progress=True)
+        display.complete_category("Nonexistent")  # no error
+        assert display._steps["Analyzing"]["Step A"][0] == StepState.PENDING
+
+
+class TestRendering:
+    """Grid rendering correctness."""
+
+    def test_title_in_output(self):
+        display = WorkflowDisplay("My Workflow Title", {"Cat": ["S1"]})
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "My Workflow Title" in output
+
+    def test_category_names_in_output(self):
+        display = WorkflowDisplay("Test", {"First Cat": ["S1"], "Second Cat": ["S2"]})
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "First Cat" in output
+        assert "Second Cat" in output
+
+    def test_pending_step_no_status_word(self):
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "My Step" in output
+        # No dots or status word for pending
+        assert ".." not in output
+
+    def test_active_step_shows_ellipsis(self):
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        display.update_step("Cat", "My Step", StepState.ACTIVE)
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "My Step ..." in output
+
+    def test_complete_step_shows_dot_leaders_and_status(self):
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        display.update_step("Cat", "My Step", StepState.COMPLETE, "created")
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "My Step" in output
+        assert "created" in output
+        assert ".." in output  # dot leaders present
+
+    def test_skipped_step_shows_detail(self):
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        display.update_step("Cat", "My Step", StepState.SKIPPED, "exists")
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "exists" in output
+        assert ".." in output
+
+    def test_failed_step_shows_detail(self):
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        display.update_step("Cat", "My Step", StepState.FAILED, "failed: 403")
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "failed: 403" in output
+
+    def test_no_progress_footer_transient(self):
+        """Transient displays omit the animated progress footer."""
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=True)
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "Elapsed" not in output
+        assert "Working" not in output
+
+    def test_progress_footer_non_transient(self, mocker):
+        """Non-transient displays include animated progress bar with elapsed time."""
+        mocker.patch("azext_edge.edge.util.workflow_display.Live")
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=False)
+        display.__enter__()
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "Working..." in output
+        assert "Elapsed:" in output
+        display.__exit__(None, None, None)
+
+    def test_complete_detail_defaults_to_state_value(self):
+        """When no detail is passed, the status word falls back to state.value."""
+        display = WorkflowDisplay("Test", {"Cat": ["My Step"]})
+        display.update_step("Cat", "My Step", StepState.COMPLETE)
+        grid = display._render()
+        output = _render_grid_to_text(grid)
+        assert "complete" in output  # StepState.COMPLETE.value
+
+
+class TestCategoryStyle:
+    """Category header styling rules."""
+
+    @pytest.mark.parametrize(
+        "steps, expected_style",
+        [
+            # All pending → dim
+            ({"S1": (StepState.PENDING, ""), "S2": (StepState.PENDING, "")}, "dim"),
+            # Any active → cyan
+            ({"S1": (StepState.COMPLETE, "done"), "S2": (StepState.ACTIVE, "")}, "cyan"),
+            # All complete → default
+            ({"S1": (StepState.COMPLETE, "done"), "S2": (StepState.COMPLETE, "done")}, ""),
+            # All skipped → default
+            ({"S1": (StepState.SKIPPED, "exists")}, ""),
+            # Mix of complete and skipped → default
+            ({"S1": (StepState.COMPLETE, "done"), "S2": (StepState.SKIPPED, "exists")}, ""),
+            # Any failed → red (takes priority over active)
+            ({"S1": (StepState.FAILED, "err"), "S2": (StepState.ACTIVE, "")}, "red"),
+            # Mix of complete and pending → cyan (in progress)
+            ({"S1": (StepState.COMPLETE, "done"), "S2": (StepState.PENDING, "")}, "cyan"),
+        ],
+    )
+    def test_category_style_rules(self, steps, expected_style):
+        assert WorkflowDisplay._category_style(steps) == expected_style
+
+
+class TestContextManager:
+    """Context manager lifecycle."""
+
+    def test_enter_creates_live_session(self, mocker):
+        mock_live = MagicMock()
+        mock_live_cls = mocker.patch("azext_edge.edge.util.workflow_display.Live", return_value=mock_live)
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]})
+        with display:
+            mock_live_cls.assert_called_once()
+            call_kwargs = mock_live_cls.call_args.kwargs
+            assert call_kwargs["transient"] is True
+            assert call_kwargs["refresh_per_second"] == 8
+            # Console passed is our stderr console
+            assert call_kwargs["console"] is display._console
+            mock_live.__enter__.assert_called_once()
+
+    def test_exit_stops_live_session(self, mocker):
+        mock_live = MagicMock()
+        mocker.patch("azext_edge.edge.util.workflow_display.Live", return_value=mock_live)
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]})
+        with display:
+            pass
+
+        mock_live.__exit__.assert_called_once_with(None, None, None)
+        assert display._live is None
+
+    def test_exit_without_enter_is_safe(self, mocker):
+        mocker.patch("azext_edge.edge.util.workflow_display.Live")
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]})
+        display.__exit__(None, None, None)  # no error
+
+    def test_no_progress_skips_live(self):
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, no_progress=True)
+        with display:
+            assert display._live is None
+
+    def test_non_transient_passes_flag(self, mocker):
+        mock_live = MagicMock()
+        mock_live_cls = mocker.patch("azext_edge.edge.util.workflow_display.Live", return_value=mock_live)
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=False)
+        with display:
+            call_kwargs = mock_live_cls.call_args.kwargs
+            assert call_kwargs["transient"] is False
+
+    def test_get_renderable_override(self, mocker):
+        """Live's get_renderable is overridden to call _render() on each refresh."""
+        mock_live = MagicMock()
+        mocker.patch("azext_edge.edge.util.workflow_display.Live", return_value=mock_live)
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]})
+        with display:
+            assert mock_live.get_renderable == display._render
+
+    def test_transient_skips_progress_bar(self, mocker):
+        """Transient displays do not create a Progress bar."""
+        mocker.patch("azext_edge.edge.util.workflow_display.Live")
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=True)
+        with display:
+            assert display._progress_bar is None
+            assert display._task_id is None
+
+    def test_non_transient_creates_progress_bar(self, mocker):
+        """Non-transient displays create a Progress bar with a working task."""
+        mocker.patch("azext_edge.edge.util.workflow_display.Live")
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=False)
+        with display:
+            assert display._progress_bar is not None
+            assert display._task_id is not None
+            assert display._progress_bar.tasks[0].description == "Working..."
+
+    def test_progress_bar_done_on_exit(self, mocker):
+        """Non-transient displays update progress description to 'Done.' on exit."""
+        mocker.patch("azext_edge.edge.util.workflow_display.Live")
+
+        display = WorkflowDisplay("Test", {"Cat": ["S1"]}, transient=False)
+        with display:
+            pass
+        task = display._progress_bar.tasks[0]
+        assert task.description == "Done."
+        assert task.stop_time is not None
+
+
+class TestThreadSafety:
+    """Concurrent update_step calls from multiple threads."""
+
+    def test_concurrent_updates_no_crash(self):
+        categories = {"Cat": [f"Step {i}" for i in range(20)]}
+        display = WorkflowDisplay("Test", categories)
+
+        errors = []
+
+        def update_step(step_name: str) -> None:
+            try:
+                display.update_step("Cat", step_name, StepState.ACTIVE)
+                display.update_step("Cat", step_name, StepState.COMPLETE, "done")
+            except Exception as e:
+                errors.append(e)
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(update_step, f"Step {i}") for i in range(20)]
+            for f in futures:
+                f.result()
+
+        assert not errors
+        # All steps should be complete
+        for entry in display._steps["Cat"].values():
+            assert entry[0] == StepState.COMPLETE
+
+    def test_concurrent_render_and_update(self):
+        """Render and update can run concurrently without data corruption."""
+        categories = {"Cat": [f"Step {i}" for i in range(10)]}
+        display = WorkflowDisplay("Test", categories)
+
+        errors = []
+        stop_event = threading.Event()
+
+        def render_loop() -> None:
+            try:
+                while not stop_event.is_set():
+                    display._render()
+            except Exception as e:
+                errors.append(e)
+
+        def update_loop() -> None:
+            try:
+                for i in range(10):
+                    display.update_step("Cat", f"Step {i}", StepState.ACTIVE)
+                    display.update_step("Cat", f"Step {i}", StepState.COMPLETE, "done")
+            except Exception as e:
+                errors.append(e)
+
+        render_thread = threading.Thread(target=render_loop)
+        render_thread.start()
+
+        update_loop()
+        stop_event.set()
+        render_thread.join(timeout=2)
+
+        assert not errors
+
+
+class TestDotLeaderLayout:
+    """Dot-leader alignment and width calculations."""
+
+    def test_dot_leader_present(self):
+        display = WorkflowDisplay("Test", {"Cat": ["Step Name"]})
+        text = display._render_step("Step Name", StepState.COMPLETE, "done")
+        plain = text.plain
+        assert " . " not in plain or ".." in plain  # dots are contiguous
+        assert "Step Name" in plain
+        assert "done" in plain
+
+    def test_consistent_width(self):
+        """All completed steps should produce lines of the same total width."""
+        display = WorkflowDisplay("Test", {"Cat": ["Short", "A Much Longer Step Name"]})
+        text1 = display._render_step("Short", StepState.COMPLETE, "done")
+        text2 = display._render_step("A Much Longer Step Name", StepState.COMPLETE, "done")
+        # Both lines should be the same length (DISPLAY_WIDTH)
+        assert len(text1.plain) == len(text2.plain)
+
+    def test_minimum_dots(self):
+        """Very long name + status still gets at least 2 dots."""
+        long_name = "A" * 45
+        display = WorkflowDisplay("Test", {"Cat": [long_name]})
+        text = display._render_step(long_name, StepState.COMPLETE, "done")
+        plain = text.plain
+        # Should contain at least ".." surrounded by spaces
+        assert " .. " in plain
+
+
+def _render_grid_to_text(grid) -> str:
+    """Render a Rich renderable to plain text for assertion."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    Console(file=buf, width=120, no_color=True).print(grid)
+    return buf.getvalue()
+
+
+class TestFormatDotLeader:
+    """Unit tests for format_dot_leader() module function."""
+
+    def test_basic_output(self):
+        line = format_dot_leader("Topic space", "created")
+        assert line.startswith("    Topic space")
+        assert line.endswith("created")
+        assert ".." in line
+
+    def test_consistent_width(self):
+        """Different name lengths produce same total line width when detail is same length."""
+        line1 = format_dot_leader("Short", "done")
+        line2 = format_dot_leader("A Much Longer Step Name", "done")
+        assert len(line1) == len(line2)
+
+    def test_minimum_dots(self):
+        """Very long name + detail still gets at least 2 dots."""
+        long_name = "A" * 45
+        line = format_dot_leader(long_name, "done")
+        assert " .. " in line
+
+    def test_custom_width(self):
+        line = format_dot_leader("Step", "ok", width=30)
+        # 30 - 4 (indent) - 4 (Step) - 2 (ok) - 2 (spaces) = 18 dots
+        assert len(line) == 30
+
+    def test_custom_indent(self):
+        line = format_dot_leader("Step", "ok", indent="  ")
+        assert line.startswith("  Step")
+
+    def test_custom_dot_char(self):
+        line = format_dot_leader("Step", "ok", dot_char="-")
+        assert "--" in line
+        assert ".." not in line
+
+
+class TestRenderSummary:
+    """Unit tests for render_summary() module function."""
+
+    @staticmethod
+    def _call_and_capture(mocker, sections, title="Title", footer=""):
+        """Call render_summary() with a mocked Console and return the plain-text output."""
+        mock_console = MagicMock()
+        mocker.patch("azext_edge.edge.util.workflow_display.Console", return_value=mock_console)
+        render_summary(title, sections, footer=footer)
+        grid = mock_console.print.call_args[0][0]
+        return _render_grid_to_text(grid)
+
+    def test_basic_render(self, mocker):
+        """Renders title, sections with items, and footer."""
+        mock_console = MagicMock()
+        mock_console_cls = mocker.patch(
+            "azext_edge.edge.util.workflow_display.Console", return_value=mock_console,
+        )
+
+        sections = {
+            "Category A": [("Item 1", "detail1"), ("Item 2", "detail2")],
+            "Category B": [("Item 3", "detail3")],
+        }
+        render_summary("Test Title", sections, footer="A footer note.")
+
+        mock_console_cls.assert_called_once_with(stderr=True)
+        mock_console.print.assert_called_once()
+        output = _render_grid_to_text(mock_console.print.call_args[0][0])
+
+        assert "Test Title" in output
+        assert "Category A" in output
+        assert "Category B" in output
+        assert "Item 1" in output
+        assert "detail1" in output
+        assert "Item 3" in output
+        assert "A footer note." in output
+
+    def test_empty_sections_skipped(self, mocker):
+        """Empty item lists are silently skipped."""
+        sections = {
+            "Has Items": [("Item", "detail")],
+            "Empty": [],
+        }
+        output = self._call_and_capture(mocker, sections)
+
+        assert "Has Items" in output
+        assert "Empty" not in output
+
+    def test_all_empty_shows_fallback(self, mocker):
+        """When all sections are empty, shows fallback message."""
+        output = self._call_and_capture(mocker, {"A": [], "B": []})
+        assert "No resources found." in output
+
+    def test_no_footer(self, mocker):
+        """No footer when not provided."""
+        output = self._call_and_capture(mocker, {"Cat": [("Item", "detail")]})
+
+        # Footer area should not contain extra content beyond the sections
+        lines = [line for line in output.strip().split("\n") if line.strip()]
+        # Title + Category + Item = at least 3 non-empty lines, no footer
+        assert all("Note" not in line for line in lines)
+
+    def test_plain_string_items(self, mocker):
+        """Sections with plain string items render as simple indented lines."""
+        sections = {
+            "Category A": ["Item 1", "Item 2"],
+            "Category B": ["Item 3"],
+        }
+        output = self._call_and_capture(mocker, sections, title="Title (3)")
+
+        assert "Title (3)" in output
+        assert "Category A" in output
+        assert "Item 1" in output
+        assert "Item 2" in output
+        assert "Item 3" in output
+        # Plain items should NOT have dot-leaders
+        assert "..." not in output
+
+    def test_mixed_item_types(self, mocker):
+        """Sections can mix tuple items (dot-leaders) and string items (plain)."""
+        sections = {
+            "Tuples": [("Name", "detail")],
+            "Strings": ["Plain item"],
+        }
+        output = self._call_and_capture(mocker, sections, title="Mixed")
+
+        assert "Name" in output
+        assert "detail" in output
+        assert "Plain item" in output


### PR DESCRIPTION
Add WorkflowDisplay utility (workflow_display.py) providing thread-safe, real-time progress rendering for multi-step CLI operations. Integrate it into enable() and disable() with phased displays:

- Transient analyzing/discovery phase (vanishes before next phase)
- Persistent configuring/teardown phase with spinner + elapsed timer
- Static render_summary() table for disable confirmation prompt

Refine command return objects:
- Split permissionBindings into publisher/subscriber with independent clientGroup (fixes show() bug reading subscriber from publisher)
- Flatten deviceRegistryNamespace with managementEndpoint details
- Add "existed" flags to setup helpers for created/exists status words

Extract disable teardown into _teardown_aio_resources, _teardown_adr_endpoint, and _teardown_eg_resources methods with early-return guard when eg_ctx is None. Reorder enable() HTTP calls to place ADR namespace before dataflow endpoint.

Tests coverage across workflow_display + mgmt_actions