### PR TITLE
feat: raise error when opcua.mode is Disabled on cert add commands

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -74,8 +74,8 @@ class OpcUACerts(Queryable):
         """Raise ValidationError if OPC UA is explicitly disabled on the instance."""
         if self.opcua_mode == "Disabled":
             raise ValidationError(
-                f"OPC UA is disabled for instance '{self.instance_name}'. "
-                "Enable it before managing OPC UA certificates:\n"
+                f"OPC UA connector is disabled for instance '{self.instance_name}'. "
+                "Enable it before managing OPC UA connector certificates:\n"
                 f"  az iot ops update -n {self.instance_name} -g {self.resource_group_name} "
                 "--feature opcua.mode=Stable"
             )

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -12,7 +12,7 @@ from typing import List, Optional, Tuple, Union, cast
 
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.pipeline.transport import HttpTransport
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from knack.log import get_logger
 from rich.console import Console
 import yaml
@@ -68,6 +68,17 @@ class OpcUACerts(Queryable):
         self.resource_map = self.instances.get_resource_map(instance)
         self.extended_location = instance["extendedLocation"]
         self.location = instance["location"]
+        self.opcua_mode = instance.get("properties", {}).get("features", {}).get("opcua", {}).get("mode")
+
+    def _assert_opcua_enabled(self) -> None:
+        """Raise ValidationError if OPC UA is explicitly disabled on the instance."""
+        if self.opcua_mode == "Disabled":
+            raise ValidationError(
+                f"OPC UA is disabled for instance '{self.instance_name}'. "
+                "Enable it before managing OPC UA certificates:\n"
+                f"  az iot ops update -n {self.instance_name} -g {self.resource_group_name} "
+                "--feature opcua.mode=Stable"
+            )
 
     def trust_add(
         self,
@@ -76,6 +87,7 @@ class OpcUACerts(Queryable):
         secret_name: Optional[str] = None,
         expiration_date: Optional[str] = None,
     ) -> dict:
+        self._assert_opcua_enabled()
         default_spc = self.instances.get_default_spc(
             instance_name=self.instance_name,
             resource_group_name=self.resource_group_name,
@@ -141,6 +153,7 @@ class OpcUACerts(Queryable):
         overwrite_secret: bool = False,
         secret_name: Optional[str] = None,
     ) -> dict:
+        self._assert_opcua_enabled()
         # get default SPC
         default_spc = self.instances.get_default_spc(self.instance_name, self.resource_group_name)
         spc_name = default_spc["name"]
@@ -243,6 +256,7 @@ class OpcUACerts(Queryable):
         public_key_secret_name: Optional[str] = None,
         private_key_secret_name: Optional[str] = None,
     ) -> dict:
+        self._assert_opcua_enabled()
         default_spc = self.instances.get_default_spc(
             instance_name=self.instance_name,
             resource_group_name=self.resource_group_name,

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/conftest.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/conftest.py
@@ -34,7 +34,13 @@ def mocked_instance(mocker):
     patched = mocker.patch(
         "azext_edge.edge.providers.orchestration.resources.connector.opcua.certs.Instances",
     )
-    yield patched()
+    mock_inst = patched()
+    mock_inst.show.return_value = {
+        "extendedLocation": {"name": "mock-cl", "type": "CustomLocations"},
+        "location": "eastus",
+        "properties": {},
+    }
+    yield mock_inst
 
 
 @pytest.fixture

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
@@ -10,7 +10,7 @@ import pytest
 
 import responses
 from azure.core.exceptions import ResourceNotFoundError
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azext_edge.edge.commands_connector import (
     add_connector_opcua_client,
     remove_connector_opcua_client,
@@ -32,6 +32,35 @@ from .conftest import (
     build_mock_cert,
 )
 from azext_edge.tests.generators import generate_random_string
+
+
+def test_client_add_opcua_disabled(
+    mocked_cmd,
+    mocked_instance: Mock,
+):
+    """Verify client_add raises ValidationError when opcua.mode is Disabled."""
+    instance_name = generate_random_string()
+    rg_name = "mock-rg"
+    mocked_instance.show.return_value = {
+        "extendedLocation": {"name": "mock-cl", "type": "CustomLocations"},
+        "location": "eastus",
+        "properties": {"features": {"opcua": {"mode": "Disabled"}}},
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        add_connector_opcua_client(
+            cmd=mocked_cmd,
+            instance_name=instance_name,
+            resource_group=rg_name,
+            public_key_file="/fake/path/cert.der",
+            private_key_file="/fake/path/cert.pem",
+        )
+
+    exc_str = str(exc_info.value)
+    assert "OPC UA is disabled" in exc_str
+    assert instance_name in exc_str
+    assert "az iot ops update" in exc_str
+    assert "opcua.mode=Stable" in exc_str
 
 
 # TODO: Resturcture parameters into dict

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_client_unit.py
@@ -57,7 +57,7 @@ def test_client_add_opcua_disabled(
         )
 
     exc_str = str(exc_info.value)
-    assert "OPC UA is disabled" in exc_str
+    assert "OPC UA connector is disabled" in exc_str
     assert instance_name in exc_str
     assert "az iot ops update" in exc_str
     assert "opcua.mode=Stable" in exc_str

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
@@ -12,7 +12,7 @@ import pytest
 
 import responses
 from azure.core.exceptions import ResourceNotFoundError
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azext_edge.edge.commands_connector import (
     add_connector_opcua_issuer,
     remove_connector_opcua_issuer,
@@ -33,6 +33,34 @@ from azext_edge.tests.edge.orchestration.resources.connector.opcua.conftest impo
 )
 from azext_edge.tests.generators import generate_random_string
 from azext_edge.tests.helpers import generate_ops_resource
+
+
+def test_issuer_add_opcua_disabled(
+    mocked_cmd,
+    mocked_instance: Mock,
+):
+    """Verify issuer_add raises ValidationError when opcua.mode is Disabled."""
+    instance_name = generate_random_string()
+    rg_name = "mock-rg"
+    mocked_instance.show.return_value = {
+        "extendedLocation": {"name": "mock-cl", "type": "CustomLocations"},
+        "location": "eastus",
+        "properties": {"features": {"opcua": {"mode": "Disabled"}}},
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        add_connector_opcua_issuer(
+            cmd=mocked_cmd,
+            instance_name=instance_name,
+            resource_group=rg_name,
+            file="/fake/path/certificate.der",
+        )
+
+    exc_str = str(exc_info.value)
+    assert "OPC UA is disabled" in exc_str
+    assert instance_name in exc_str
+    assert "az iot ops update" in exc_str
+    assert "opcua.mode=Stable" in exc_str
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_issuer_unit.py
@@ -57,7 +57,7 @@ def test_issuer_add_opcua_disabled(
         )
 
     exc_str = str(exc_info.value)
-    assert "OPC UA is disabled" in exc_str
+    assert "OPC UA connector is disabled" in exc_str
     assert instance_name in exc_str
     assert "az iot ops update" in exc_str
     assert "opcua.mode=Stable" in exc_str

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
@@ -10,7 +10,7 @@ from azext_edge.edge.providers.orchestration.resources.instances import SECRET_S
 import pytest
 
 import responses
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azext_edge.edge.commands_connector import (
     add_connector_opcua_trust,
     remove_connector_opcua_trust,
@@ -148,6 +148,34 @@ def test_trust_add(
             )
             return
         assert result == expected_secret_sync
+
+
+def test_trust_add_opcua_disabled(
+    mocked_cmd,
+    mocked_instance: Mock,
+):
+    """Verify trust_add raises ValidationError when opcua.mode is Disabled."""
+    instance_name = generate_random_string()
+    rg_name = "mock-rg"
+    mocked_instance.show.return_value = {
+        "extendedLocation": {"name": "mock-cl", "type": "CustomLocations"},
+        "location": "eastus",
+        "properties": {"features": {"opcua": {"mode": "Disabled"}}},
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        add_connector_opcua_trust(
+            cmd=mocked_cmd,
+            instance_name=instance_name,
+            resource_group=rg_name,
+            file="/fake/path/certificate.der",
+        )
+
+    exc_str = str(exc_info.value)
+    assert "OPC UA is disabled" in exc_str
+    assert instance_name in exc_str
+    assert "az iot ops update" in exc_str
+    assert "opcua.mode=Stable" in exc_str
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/opcua/test_opcua_certs_trust_unit.py
@@ -172,7 +172,7 @@ def test_trust_add_opcua_disabled(
         )
 
     exc_str = str(exc_info.value)
-    assert "OPC UA is disabled" in exc_str
+    assert "OPC UA connector is disabled" in exc_str
     assert instance_name in exc_str
     assert "az iot ops update" in exc_str
     assert "opcua.mode=Stable" in exc_str


### PR DESCRIPTION
The error looks like this when opcua is not enabled by default and users are trying to use those commands.
<img width="1892" height="128" alt="image" src="https://github.com/user-attachments/assets/a8a3f230-88bc-467a-aebf-8463a7392d99" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
