### PR TITLE
feat(mgmt-actions): add execute command for invoking management actions on namespace assets

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -2196,6 +2196,49 @@ def load_iotops_help():
     """
 
     helps[
+        "iot ops mgmt-actions execute"
+    ] = """
+        type: command
+        short-summary: Execute a management action on a namespace asset.
+        long-summary: |
+            Invokes a management action defined on a namespace asset via the Device Registry
+            executeAction operation. The management actions infrastructure must be enabled
+            (`az iot ops mgmt-actions enable`) before actions can be executed.
+
+            The command resolves the ADR namespace from the IoT Operations instance and
+            submits the action as a long-running operation. The result includes the action
+            status, any response from the asset, and error details if the action failed.
+
+        examples:
+        - name: Execute a management action with no payload.
+          text: >
+            az iot ops mgmt-actions execute
+            --instance myinstance
+            -g myresourcegroup
+            --asset myasset
+            --group mygroup
+            --action reboot
+        - name: Execute a management action with inline JSON payload.
+          text: >
+            az iot ops mgmt-actions execute
+            --instance myinstance
+            -g myresourcegroup
+            --asset myasset
+            --group mygroup
+            --action configure
+            -p '{"temperature": {"setpoint": 72}}'
+        - name: Execute a management action with payload from file.
+          text: >
+            az iot ops mgmt-actions execute
+            --instance myinstance
+            -g myresourcegroup
+            --asset myasset
+            --group mygroup
+            --action configure
+            -p payload.json
+    """
+
+    helps[
         "iot ops schema"
     ] = """
         type: group

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -66,6 +66,7 @@ def load_iotops_commands(self, _):
         cmd_group.command("enable", "mgmt_actions_enable")
         cmd_group.command("disable", "mgmt_actions_disable")
         cmd_group.show_command("show", "mgmt_actions_show")
+        cmd_group.command("execute", "mgmt_actions_execute")
 
     with self.command_group(
         "iot ops support",

--- a/azext_edge/edge/commands_mgmt_actions.py
+++ b/azext_edge/edge/commands_mgmt_actions.py
@@ -64,3 +64,24 @@ def mgmt_actions_disable(
         confirm_yes=confirm_yes,
         **kwargs,
     )
+
+
+def mgmt_actions_execute(
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    group_name: str,
+    action_name: str,
+    payload: Optional[str] = None,
+    **kwargs,
+) -> Dict:
+    return MgmtActions(cmd).execute(
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        asset_name=asset_name,
+        group_name=group_name,
+        action_name=action_name,
+        payload=payload,
+        **kwargs,
+    )

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1576,6 +1576,28 @@ def load_iotops_arguments(self, _):
             help="Registry endpoint name for the dataflow graph. Default: 'default'.",
         )
 
+    with self.argument_context("iot ops mgmt-actions execute") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset"],
+            help="Name of the namespace asset to execute the management action on.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--group"],
+            help="Management group name under which the action is defined.",
+        )
+        context.argument(
+            "action_name",
+            options_list=["--action"],
+            help="Management action name to execute.",
+        )
+        context.argument(
+            "payload",
+            options_list=["--payload", "-p"],
+            help="JSON payload for the management action. Inline JSON string or file path (e.g., payload.json).",
+        )
+
     with self.argument_context("iot ops schema") as context:
         context.argument(
             "schema_name",

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -2028,8 +2028,10 @@ class MgmtActions(Queryable):
             "managementActionName": action_name,
             "managementGroupName": group_name,
         }
-        if payload is not None:
+        if payload:
             body["payload"] = deserialize_json_input(payload)
+
+        logger.debug("Execute action request body: %s", body)
 
         console = Console()
         with console.status("Executing management action..."):

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -5,11 +5,12 @@
 # ----------------------------------------------------------------------------------------------
 
 import json
-from typing import TYPE_CHECKING, Callable, Dict, List, NamedTuple, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from knack.log import get_logger
+from rich.console import Console
 
 from ...util.az_client import (
     get_eventgrid_mgmt_client,
@@ -1993,3 +1994,49 @@ class MgmtActions(Queryable):
             }
 
         return result
+
+    def execute(
+        self,
+        instance_name: str,
+        resource_group_name: str,
+        asset_name: str,
+        group_name: str,
+        action_name: str,
+        payload: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Execute a management action on a namespace asset.
+
+        Resolves the ADR namespace from the instance, then invokes the executeAction
+        ARM operation as an LRO. Returns the action result (status, response, errors).
+        """
+        from ...util.file_operations import deserialize_json_input
+
+        instance = self.iotops_mgmt_client.instance.get(
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+        )
+        adr_namespace_ref = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+        if not adr_namespace_ref:
+            raise ValidationError(
+                "Instance does not have an ADR namespace reference. "
+                "Ensure the instance is properly configured."
+            )
+        parsed_adr = parse_resource_id_dict(adr_namespace_ref)
+
+        body: Dict[str, Any] = {
+            "managementActionName": action_name,
+            "managementGroupName": group_name,
+        }
+        if payload is not None:
+            body["payload"] = deserialize_json_input(payload)
+
+        console = Console()
+        with console.status("Executing management action..."):
+            poller = self.registry_mgmt_client.namespace_assets.begin_execute_action(
+                resource_group_name=parsed_adr["resource_group"],
+                namespace_name=parsed_adr["name"],
+                asset_name=asset_name,
+                body=body,
+            )
+            return wait_for_terminal_state(poller, **kwargs)

--- a/azext_edge/edge/util/__init__.py
+++ b/azext_edge/edge/util/__init__.py
@@ -24,6 +24,7 @@ from .common import (
 )
 from .file_operations import (
     deserialize_file_content,
+    deserialize_json_input,
     dump_content_to_file,
     normalize_dir,
     read_file_content,
@@ -35,6 +36,7 @@ __all__ = [
     "build_query",
     "chunk_list",
     "deserialize_file_content",
+    "deserialize_json_input",
     "dump_content_to_file",
     "generate_secret",
     "generate_self_signed_cert",

--- a/azext_edge/edge/util/file_operations.py
+++ b/azext_edge/edge/util/file_operations.py
@@ -116,6 +116,28 @@ def deserialize_file_content(file_path: str) -> Any:
     raise FileOperationError(f"File contents for {file_path} cannot be read.")
 
 
+def deserialize_json_input(value: str) -> Any:
+    """Deserialize a JSON input that is either a file path or an inline JSON string.
+
+    Attempts to read the value as a file path first. If that fails (file does not exist
+    or is not a file), falls back to treating the raw value as an inline JSON string.
+    Returns the parsed Python object (dict, list, etc.).
+
+    Raises:
+        InvalidArgumentValueError: If the input cannot be parsed as valid JSON.
+    """
+    raw = value
+    try:
+        raw = read_file_content(value)
+    except FileOperationError:
+        pass  # not a file path — treat as inline JSON
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise InvalidArgumentValueError(f"Failed to parse JSON input: {e}") from e
+
+
 def validate_file_extension(file_name: str, expected_exts: set[str]) -> str:
     ext = os.path.splitext(file_name)[1]
     lowercased_exts = {ext.lower() for ext in expected_exts}

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -3658,3 +3658,290 @@ class TestShow:
 
         assert result == {"enabled": False}
         assert len(mocked_responses.calls) == 1
+
+
+class TestExecute:
+    """Tests for MgmtActions.execute()."""
+
+    def _build_execute_action_endpoint(
+        self,
+        namespace_name: str,
+        resource_group_name: str,
+        asset_name: str,
+        subscription_id: Optional[str] = None,
+    ) -> str:
+        """Build the executeAction POST URL."""
+        sub_id = subscription_id or ZEROED_SUBSCRIPTION
+        return (
+            f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+            f"/providers/{DEVICEREGISTRY_RP}/namespaces/{namespace_name}"
+            f"/assets/{asset_name}/executeAction"
+            f"?api-version={DEVICEREGISTRY_API_VERSION}"
+        )
+
+    def _make_execute_fixtures(self) -> dict:
+        """Build common test fixtures for execute tests."""
+        instance_name = generate_random_string()
+        rg = generate_random_string()
+        adr_ns_name = f"{instance_name}-adr-ns"
+        asset_name = generate_random_string()
+        group_name = generate_random_string()
+        action_name = generate_random_string()
+        return {
+            "instance_name": instance_name,
+            "rg": rg,
+            "adr_ns_name": adr_ns_name,
+            "asset_name": asset_name,
+            "group_name": group_name,
+            "action_name": action_name,
+        }
+
+    def _register_execute_mocks(
+        self,
+        mocked_responses: responses,
+        instance_name: str,
+        rg: str,
+        adr_ns_name: str,
+        asset_name: str,
+        execute_response: dict,
+        execute_status: int = 200,
+        instance_response: Optional[dict] = None,
+    ) -> None:
+        """Register HTTP mocks for instance GET and executeAction POST."""
+        if instance_response is None:
+            instance_response = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns_name)
+
+        # Instance GET
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg),
+            json=instance_response,
+            status=200,
+        )
+
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(adr_ns_name, rg, asset_name),
+            json=execute_response,
+            status=execute_status,
+        )
+
+    def test_happy_path_with_payload(self, mocked_cmd, mocked_responses: responses):
+        """Execute with payload — verify request body and return value."""
+        f = self._make_execute_fixtures()
+        payload_str = '{"On": true}'
+        expected_response = {
+            "assetResourceId": f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{f['rg']}"
+            f"/providers/{DEVICEREGISTRY_RP}/namespaces/{f['adr_ns_name']}/assets/{f['asset_name']}",
+            "managementGroupName": f["group_name"],
+            "managementActionName": f["action_name"],
+            "status": "Succeeded",
+            "response": '{"result": "ok"}',
+        }
+        self._register_execute_mocks(
+            mocked_responses,
+            instance_name=f["instance_name"],
+            rg=f["rg"],
+            adr_ns_name=f["adr_ns_name"],
+            asset_name=f["asset_name"],
+            execute_response=expected_response,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload=payload_str,
+            wait_sec=0,
+        )
+
+        assert result == expected_response
+        assert len(mocked_responses.calls) == 2
+
+        # Verify the request body sent to executeAction
+        execute_request = mocked_responses.calls[1]
+        body = json.loads(execute_request.request.body)
+        assert body["managementActionName"] == f["action_name"]
+        assert body["managementGroupName"] == f["group_name"]
+        assert body["payload"] == {"On": True}
+
+    def test_without_payload(self, mocked_cmd, mocked_responses: responses):
+        """Execute without payload — verify payload key absent from request body."""
+        f = self._make_execute_fixtures()
+        expected_response = {
+            "assetResourceId": "some-id",
+            "managementGroupName": f["group_name"],
+            "managementActionName": f["action_name"],
+            "status": "Succeeded",
+        }
+        self._register_execute_mocks(
+            mocked_responses,
+            instance_name=f["instance_name"],
+            rg=f["rg"],
+            adr_ns_name=f["adr_ns_name"],
+            asset_name=f["asset_name"],
+            execute_response=expected_response,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            wait_sec=0,
+        )
+
+        assert result == expected_response
+
+        # Verify no payload in request body
+        execute_request = mocked_responses.calls[1]
+        body = json.loads(execute_request.request.body)
+        assert "payload" not in body
+
+    def test_no_adr_namespace_ref(self, mocked_cmd, mocked_responses: responses):
+        """Instance without adrNamespaceRef raises ValidationError."""
+        instance_name = generate_random_string()
+        rg = generate_random_string()
+
+        instance_response = {
+            "id": (
+                f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+                f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+            ),
+            "name": instance_name,
+            "location": "eastus",
+            "extendedLocation": _make_extended_location(),
+            "properties": {
+                "provisioningState": "Succeeded",
+            },
+        }
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg),
+            json=instance_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        with pytest.raises(ValidationError, match="Instance does not have an ADR namespace reference"):
+            provider.execute(
+                instance_name=instance_name,
+                resource_group_name=rg,
+                asset_name="some-asset",
+                group_name="some-group",
+                action_name="some-action",
+                wait_sec=0,
+            )
+
+        # Only instance GET — no executeAction call
+        assert len(mocked_responses.calls) == 1
+
+    def test_action_failed_on_device(self, mocked_cmd, mocked_responses: responses):
+        """LRO completes with status Failed — error details returned, not raised."""
+        f = self._make_execute_fixtures()
+        expected_response = {
+            "assetResourceId": "some-id",
+            "managementGroupName": f["group_name"],
+            "managementActionName": f["action_name"],
+            "status": "Failed",
+            "error": {
+                "code": "DeviceError",
+                "message": "The device rejected the action.",
+            },
+        }
+        self._register_execute_mocks(
+            mocked_responses,
+            instance_name=f["instance_name"],
+            rg=f["rg"],
+            adr_ns_name=f["adr_ns_name"],
+            asset_name=f["asset_name"],
+            execute_response=expected_response,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            wait_sec=0,
+        )
+
+        # Failed status is returned as-is — not raised as an exception
+        assert result["status"] == "Failed"
+        assert result["error"]["code"] == "DeviceError"
+
+    def test_invalid_payload(self, mocked_cmd, mocked_responses: responses):
+        """Invalid JSON payload raises InvalidArgumentValueError before any API call."""
+        f = self._make_execute_fixtures()
+
+        # Only register instance GET — executeAction POST should never fire
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=_build_instance_response(f["instance_name"], f["rg"], adr_namespace_name=f["adr_ns_name"]),
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        with pytest.raises(InvalidArgumentValueError, match="Failed to parse JSON input"):
+            provider.execute(
+                instance_name=f["instance_name"],
+                resource_group_name=f["rg"],
+                asset_name=f["asset_name"],
+                group_name=f["group_name"],
+                action_name=f["action_name"],
+                payload="not valid json",
+                wait_sec=0,
+            )
+
+        # Instance GET fires, but executeAction should not
+        assert len(mocked_responses.calls) == 1
+
+    def test_payload_from_file(self, mocker, mocked_cmd, mocked_responses: responses):
+        """Payload resolved from file path via deserialize_json_input."""
+        f = self._make_execute_fixtures()
+        file_content = '{"temperature": {"setpoint": 72}}'
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            return_value=file_content,
+        )
+        expected_response = {
+            "assetResourceId": "some-id",
+            "managementGroupName": f["group_name"],
+            "managementActionName": f["action_name"],
+            "status": "Succeeded",
+        }
+        self._register_execute_mocks(
+            mocked_responses,
+            instance_name=f["instance_name"],
+            rg=f["rg"],
+            adr_ns_name=f["adr_ns_name"],
+            asset_name=f["asset_name"],
+            execute_response=expected_response,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload="somefile.json",
+            wait_sec=0,
+        )
+
+        assert result == expected_response
+
+        # Verify payload was deserialized from file content
+        execute_request = mocked_responses.calls[1]
+        body = json.loads(execute_request.request.body)
+        assert body["payload"] == {"temperature": {"setpoint": 72}}

--- a/azext_edge/tests/utility/test_file_operations_unit.py
+++ b/azext_edge/tests/utility/test_file_operations_unit.py
@@ -12,7 +12,7 @@ from typing import List, NamedTuple, Optional, Union
 from pathlib import Path
 
 import pytest
-from azure.cli.core.azclierror import FileOperationError
+from azure.cli.core.azclierror import FileOperationError, InvalidArgumentValueError
 
 from ..generators import generate_random_string
 
@@ -230,3 +230,63 @@ def test_try_loading_as(mocker, error, raise_error, return_value):
         )
         assert result == (None if error else return_value)
     loader.assert_called_once_with(content)
+
+
+class TestDeserializeJsonInput:
+    """Tests for deserialize_json_input — file path or inline JSON → parsed object."""
+
+    def test_inline_json_dict(self, mocker):
+        """Valid inline JSON dict is parsed correctly."""
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            side_effect=FileOperationError("Not a file"),
+        )
+        from azext_edge.edge.util import deserialize_json_input
+
+        result = deserialize_json_input('{"key": "value", "nested": {"a": 1}}')
+        assert result == {"key": "value", "nested": {"a": 1}}
+
+    def test_inline_json_list(self, mocker):
+        """Valid inline JSON list is parsed correctly."""
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            side_effect=FileOperationError("Not a file"),
+        )
+        from azext_edge.edge.util import deserialize_json_input
+
+        result = deserialize_json_input('[1, 2, 3]')
+        assert result == [1, 2, 3]
+
+    def test_file_path(self, mocker):
+        """File path input reads file content and parses JSON."""
+        file_content = '{"fromFile": true}'
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            return_value=file_content,
+        )
+        from azext_edge.edge.util import deserialize_json_input
+
+        result = deserialize_json_input("payload.json")
+        assert result == {"fromFile": True}
+
+    def test_invalid_json(self, mocker):
+        """Invalid JSON raises InvalidArgumentValueError."""
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            side_effect=FileOperationError("Not a file"),
+        )
+        from azext_edge.edge.util import deserialize_json_input
+
+        with pytest.raises(InvalidArgumentValueError, match="Failed to parse JSON input"):
+            deserialize_json_input("not valid json")
+
+    def test_file_with_invalid_json(self, mocker):
+        """File that exists but contains invalid JSON raises InvalidArgumentValueError."""
+        mocker.patch(
+            "azext_edge.edge.util.file_operations.read_file_content",
+            return_value="not valid json in file",
+        )
+        from azext_edge.edge.util import deserialize_json_input
+
+        with pytest.raises(InvalidArgumentValueError, match="Failed to parse JSON input"):
+            deserialize_json_input("somefile.json")


### PR DESCRIPTION
- Add MgmtActions.execute() provider method with instance → ADR namespace resolution
- Add deserialize_json_input() generic utility for inline JSON or file path parsing
- Register execute command, params (--asset, --group, --action, --payload/-p), and help text
- Add UX spinner while polling LRO
- Add unit tests for execute and deserialize_json_input