### PR TITLE
feat(queryable): plumb ARM endpoint from az cloud config to all vendored clients

### DIFF
--- a/azext_edge/edge/providers/adr/asset_endpoint_profiles.py
+++ b/azext_edge/edge/providers/adr/asset_endpoint_profiles.py
@@ -44,7 +44,7 @@ class AssetEndpointProfiles(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "AEPOperations" = self.deviceregistry_mgmt_client.asset_endpoint_profiles
 

--- a/azext_edge/edge/providers/adr/assets.py
+++ b/azext_edge/edge/providers/adr/assets.py
@@ -43,7 +43,7 @@ class Assets(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "AssetsOperations" = self.deviceregistry_mgmt_client.assets
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -53,10 +53,10 @@ class NamespaceAssets(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.resource_mgmt_client = get_resource_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "NamespaceAssetsOperations" = self.deviceregistry_mgmt_client.namespace_assets
         self.device_ops: "NamespaceDevicesOperations" = self.deviceregistry_mgmt_client.namespace_devices

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -71,10 +71,10 @@ class NamespaceDevices(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.resource_mgmt_client = get_resource_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "NamespaceDevicesOperations" = self.deviceregistry_mgmt_client.namespace_devices
         self.namespace_ops: "NamespacesOperations" = self.deviceregistry_mgmt_client.namespaces

--- a/azext_edge/edge/providers/adr/namespaces.py
+++ b/azext_edge/edge/providers/adr/namespaces.py
@@ -30,10 +30,10 @@ class Namespaces(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.deviceregistry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.resource_mgmt_client = get_resource_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "NamespacesOperations" = self.deviceregistry_mgmt_client.namespaces
         self.resource_ops: "ResourcesOperations" = self.resource_mgmt_client.resources

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -227,14 +227,14 @@ class MgmtActions(Queryable):
     def __init__(self, cmd, subscription_id: Optional[str] = None):
         super().__init__(cmd=cmd, subscription_id=subscription_id)
         self.iotops_mgmt_client = get_iotops_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.registry_mgmt_client: "MicrosoftDeviceRegistryManagementService" = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         # May be replaced with a cross-subscription client by _validate_eg_namespace
         self.eventgrid_mgmt_client: "EventGridManagementClient" = get_eventgrid_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.permission_manager = PermissionManager(self.default_subscription_id)
 
@@ -1335,7 +1335,7 @@ class MgmtActions(Queryable):
         # Handle cross-subscription EG namespace
         if eg_subscription_id.lower() != self.default_subscription_id.lower():
             self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
-                subscription_id=eg_subscription_id,
+                **self._get_client_kwargs(subscription_id=eg_subscription_id)
             )
 
         return eg_ctx
@@ -1379,7 +1379,9 @@ class MgmtActions(Queryable):
                 eg_subscription_id,
                 self.default_subscription_id,
             )
-            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(subscription_id=eg_subscription_id)
+            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
+                **self._get_client_kwargs(subscription_id=eg_subscription_id)
+            )
 
         # Fetch the namespace
         try:
@@ -1998,7 +2000,7 @@ class MgmtActions(Queryable):
         if mi_subscription.lower() != self.default_subscription_id.lower():
             from ...util.az_client import get_resource_client
 
-            client = get_resource_client(subscription_id=mi_subscription)
+            client = get_resource_client(**self._get_client_kwargs(subscription_id=mi_subscription))
         else:
             client = self.resource_client
 

--- a/azext_edge/edge/providers/orchestration/migration.py
+++ b/azext_edge/edge/providers/orchestration/migration.py
@@ -55,7 +55,7 @@ class AssetMigrationManager(Queryable):
         super().__init__(cmd=cmd)
         from ...util.machinery import scoped_semver_import
 
-        self.deviceregistry_mgmt_client = get_registry_mgmt_client(subscription_id=self.default_subscription_id)
+        self.deviceregistry_mgmt_client = get_registry_mgmt_client(**self._get_client_kwargs())
         self.ops: "NamespacesOperations" = self.deviceregistry_mgmt_client.namespaces
         self.instances = Instances(self.cmd)
         self.permission_manager = PermissionManager(self.default_subscription_id)
@@ -192,7 +192,7 @@ class SecretSyncMigrationManager(Queryable):
         secretsync_resources: dict[str, list[dict]],
     ):
         super().__init__(cmd=cmd)
-        self.ssc_mgmt_client = get_ssc_mgmt_client(subscription_id=self.default_subscription_id)
+        self.ssc_mgmt_client = get_ssc_mgmt_client(**self._get_client_kwargs())
         self.instance_record = instance_record
         self.resource_map = resource_map
         self.secretsync_resources = secretsync_resources

--- a/azext_edge/edge/providers/orchestration/resources/clusters.py
+++ b/azext_edge/edge/providers/orchestration/resources/clusters.py
@@ -23,7 +23,7 @@ class ConnectedClusters(Queryable):
     def __init__(self, cmd, subscription_id: Optional[str] = None):
         super().__init__(cmd=cmd, subscriptions=[subscription_id] if subscription_id else None)
         self.connectedk8s_mgmt_client = get_connectedk8s_mgmt_client(
-            subscription_id=self.subscriptions[0],
+            **self._get_client_kwargs(subscription_id=self.subscriptions[0])
         )
         self.ops: "ConnectedClusterOperations" = self.connectedk8s_mgmt_client.connected_cluster
         self.extensions: ClusterExtensions = ClusterExtensions(cmd)
@@ -39,7 +39,7 @@ class ClusterExtensions(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.clusterconfig_mgmt_client = get_clusterconfig_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.ops: "ExtensionsOperations" = self.clusterconfig_mgmt_client.extensions
 

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -56,7 +56,7 @@ class OpcUACerts(Queryable):
         super().__init__(cmd=cmd)
         self.instances = Instances(self.cmd)
         self.ssc_mgmt_client = get_ssc_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.keyvault_client = get_keyvault_client(
             subscription_id=self.default_subscription_id,

--- a/azext_edge/edge/providers/orchestration/resources/custom_locations.py
+++ b/azext_edge/edge/providers/orchestration/resources/custom_locations.py
@@ -22,7 +22,7 @@ class CustomLocations(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.extloc_mgmt_client = get_extloc_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.ops: "CustomLocationsOperations" = self.extloc_mgmt_client.custom_locations
 

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -101,13 +101,13 @@ class Instances(Queryable):
         # TODO: longer term pattern?
         super().__init__(cmd=cmd, subscriptions=[subscription_id] if subscription_id else None)
         self.iotops_mgmt_client = get_iotops_mgmt_client(
-            subscription_id=self.subscriptions[0],
+            **self._get_client_kwargs(subscription_id=self.subscriptions[0])
         )
         self.msi_mgmt_client = get_msi_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.ssc_mgmt_client = get_ssc_mgmt_client(
-            subscription_id=self.default_subscription_id,
+            **self._get_client_kwargs()
         )
         self.permission_manager = PermissionManager(self.default_subscription_id)
 

--- a/azext_edge/edge/providers/orchestration/resources/schema_registries.py
+++ b/azext_edge/edge/providers/orchestration/resources/schema_registries.py
@@ -55,7 +55,7 @@ class SchemaRegistries(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.registry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "SchemaRegistriesOperations" = self.registry_mgmt_client.schema_registries
 
@@ -86,7 +86,7 @@ class SchemaRegistries(Queryable):
             storage_id_container = parse_resource_id(storage_account_resource_id)
 
             self.storage_mgmt_client = get_storage_mgmt_client(
-                subscription_id=storage_id_container.subscription_id,
+                **self._get_client_kwargs(subscription_id=storage_id_container.subscription_id)
             )
             storage_account: dict = self.storage_mgmt_client.storage_accounts.get_properties(
                 resource_group_name=storage_id_container.resource_group_name,
@@ -184,7 +184,7 @@ class Schemas(Queryable):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.registry_mgmt_client = get_registry_mgmt_client(
-            subscription_id=self.default_subscription_id
+            **self._get_client_kwargs()
         )
         self.ops: "SchemasOperations" = self.registry_mgmt_client.schemas
         self.version_ops: "SchemaVersionsOperations" = self.registry_mgmt_client.schema_versions

--- a/azext_edge/edge/providers/orchestration/resources/sync_rules.py
+++ b/azext_edge/edge/providers/orchestration/resources/sync_rules.py
@@ -40,7 +40,7 @@ class SyncRules(Queryable):
         self.custom_location = self.instances.get_associated_cl(
             self.instances.show(name=self.instance_name, resource_group_name=self.resource_group_name)
         )
-        self.extloc_mgmt_client = get_extloc_mgmt_client(self.default_subscription_id)
+        self.extloc_mgmt_client = get_extloc_mgmt_client(**self._get_client_kwargs())
 
     def enable(
         self,

--- a/azext_edge/edge/util/queryable.py
+++ b/azext_edge/edge/util/queryable.py
@@ -29,6 +29,7 @@ class Queryable:
         from azure.cli.core.commands.client_factory import get_subscription_id
 
         self.cmd = cmd
+        self._arm_endpoint: str = cmd.cli_ctx.cloud.endpoints.resource_manager
         self.default_subscription_id: str = subscription_id or get_subscription_id(cli_ctx=cmd.cli_ctx)
 
         if not subscriptions:
@@ -37,9 +38,21 @@ class Queryable:
         self.subscriptions: List[str] = subscriptions
         self.resource_graph = ResourceGraph(cmd=cmd, subscriptions=self.subscriptions)
 
+    def _get_client_kwargs(self, *, subscription_id: Optional[str] = None, **overrides) -> dict:
+        """Build common kwargs for az_client factory functions.
+
+        Bundles subscription_id and ARM endpoint so providers don't repeat them at every call site.
+        Accepts overrides for cross-subscription or non-default api_version scenarios.
+        """
+        return {
+            "subscription_id": subscription_id or self.default_subscription_id,
+            "endpoint": self._arm_endpoint,
+            **overrides,
+        }
+
     @cached_property
     def resource_client(self):
-        return get_resource_client(subscription_id=self.default_subscription_id)
+        return get_resource_client(**self._get_client_kwargs())
 
     def _process_query_result(self, result: dict, first: bool = False) -> Optional[Union[dict, List[dict]]]:
         if "data" in result:

--- a/azext_edge/tests/utility/test_queryable_unit.py
+++ b/azext_edge/tests/utility/test_queryable_unit.py
@@ -11,6 +11,8 @@ import pytest
 
 MODULE_PATH = "azext_edge.edge.util.queryable"
 
+MOCK_ARM_ENDPOINT = "https://custom-arm-endpoint.example.com"
+
 
 @pytest.fixture
 def mock_get_subscription_id(mocker):
@@ -35,9 +37,10 @@ def mock_get_resource_client(mocker):
 
 @pytest.fixture
 def mock_cmd():
-    """Minimal mock cmd object with cli_ctx."""
+    """Minimal mock cmd object with cli_ctx and cloud endpoints."""
     cmd = MagicMock()
     cmd.cli_ctx = MagicMock()
+    cmd.cli_ctx.cloud.endpoints.resource_manager = MOCK_ARM_ENDPOINT
     return cmd
 
 
@@ -116,7 +119,7 @@ class TestQueryableResourceClientLazy:
         queryable_deps["get_resource_client"].assert_not_called()
 
     def test_resource_client_created_on_first_access(self, queryable_deps):
-        """get_resource_client is called on first property access."""
+        """get_resource_client is called with subscription_id and endpoint."""
         from azext_edge.edge.util.queryable import Queryable
 
         q = Queryable(cmd=queryable_deps["cmd"])
@@ -124,6 +127,7 @@ class TestQueryableResourceClientLazy:
 
         queryable_deps["get_resource_client"].assert_called_once_with(
             subscription_id="default-sub-id",
+            endpoint=MOCK_ARM_ENDPOINT,
         )
 
     def test_resource_client_cached(self, queryable_deps):
@@ -210,6 +214,71 @@ class TestQueryableGetResourceGroup:
         queryable_deps["get_resource_client"].return_value.resource_groups.get.assert_called_once_with(
             resource_group_name="my-rg",
         )
+
+
+class TestQueryableArmEndpoint:
+    """Tests for _arm_endpoint sourced from cloud config."""
+
+    def test_arm_endpoint_stored_from_cloud(self, queryable_deps):
+        """_arm_endpoint is set from cmd.cli_ctx.cloud.endpoints.resource_manager."""
+        from azext_edge.edge.util.queryable import Queryable
+
+        q = Queryable(cmd=queryable_deps["cmd"])
+        assert q._arm_endpoint == MOCK_ARM_ENDPOINT
+
+
+class TestQueryableGetClientKwargs:
+    """Tests for _get_client_kwargs helper."""
+
+    def test_default_kwargs(self, queryable_deps):
+        """Returns default_subscription_id and arm endpoint."""
+        from azext_edge.edge.util.queryable import Queryable
+
+        q = Queryable(cmd=queryable_deps["cmd"])
+        result = q._get_client_kwargs()
+
+        assert result == {
+            "subscription_id": "default-sub-id",
+            "endpoint": MOCK_ARM_ENDPOINT,
+        }
+
+    def test_subscription_override(self, queryable_deps):
+        """subscription_id kwarg overrides default."""
+        from azext_edge.edge.util.queryable import Queryable
+
+        q = Queryable(cmd=queryable_deps["cmd"])
+        result = q._get_client_kwargs(subscription_id="override-sub")
+
+        assert result == {
+            "subscription_id": "override-sub",
+            "endpoint": MOCK_ARM_ENDPOINT,
+        }
+
+    def test_extra_overrides_passed_through(self, queryable_deps):
+        """Additional kwargs (e.g., api_version) are included."""
+        from azext_edge.edge.util.queryable import Queryable
+
+        q = Queryable(cmd=queryable_deps["cmd"])
+        result = q._get_client_kwargs(api_version="2025-01-01")
+
+        assert result == {
+            "subscription_id": "default-sub-id",
+            "endpoint": MOCK_ARM_ENDPOINT,
+            "api_version": "2025-01-01",
+        }
+
+    def test_subscription_and_extra_overrides(self, queryable_deps):
+        """subscription_id override + extra kwargs both work together."""
+        from azext_edge.edge.util.queryable import Queryable
+
+        q = Queryable(cmd=queryable_deps["cmd"])
+        result = q._get_client_kwargs(subscription_id="other-sub", api_version="2025-01-01")
+
+        assert result == {
+            "subscription_id": "other-sub",
+            "endpoint": MOCK_ARM_ENDPOINT,
+            "api_version": "2025-01-01",
+        }
 
 
 class TestQueryableBackwardCompat:


### PR DESCRIPTION
Store cmd.cli_ctx.cloud.endpoints.resource_manager in Queryable._arm_endpoint and add _get_client_kwargs() helper that bundles subscription_id + endpoint. Convert all 27 factory call sites across 13 provider files to use the helper, enabling az cloud set --endpoint-resource-manager for canary/dogfood testing.
