### PR TITLE
feat: skip version gate for pre-release instance versions

### DIFF
--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -276,8 +276,10 @@ class MgmtActions(Queryable):
 
                 # Validate instance version
                 instance_version = instance.get("properties", {}).get("version", "")
-                if not instance_version or (
-                    semver.parse(instance_version) < semver.parse(MIN_INSTANCE_VERSION_MGMT_ACTIONS)
+                parsed_version = semver.parse(instance_version) if instance_version else None
+                if not parsed_version or (
+                    not parsed_version.prerelease
+                    and parsed_version < semver.parse(MIN_INSTANCE_VERSION_MGMT_ACTIONS)
                 ):
                     raise ValidationError(
                         f"Instance '{name}' version '{instance_version}' does not meet the minimum "

--- a/azext_edge/edge/util/machinery.py
+++ b/azext_edge/edge/util/machinery.py
@@ -4,17 +4,13 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Type
 
-Version = object  # Placeholder for the actual Version type from semver
-
-
-class HasSemverParse(Protocol):
-    def parse(self, version: str, optional_minor_and_patch: bool = False) -> Version:
-        ...
+if TYPE_CHECKING:
+    from semver.version import Version
 
 
-def scoped_semver_import() -> HasSemverParse:
+def scoped_semver_import() -> "Type[Version]":
     """
     This is necessary to avoid conflicts with Az CLI semver import.
     """

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -2798,6 +2798,39 @@ class TestEnable:
 
         assert len(mocked_responses.calls) == 1
 
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.3.0-main.20260307.5",
+            "1.0.0-alpha.1",
+            "1.3.14-rc.1",
+            "2.0.0-beta.1",
+        ],
+        ids=[
+            "ci-build-below-min-patch",
+            "prerelease-well-below-min",
+            "prerelease-at-exact-min",
+            "prerelease-above-min-major",
+        ],
+    )
+    def test_prerelease_version_skips_gate(self, mocked_cmd, mocked_responses: responses, mocker, version: str):
+        """enable() skips the minimum version check when instance version has a pre-release component."""
+        f = self._make_enable_fixtures()
+        f["instance_response"]["properties"]["version"] = version
+        mocker.patch.object(MgmtActions, "_resolve_dataflow_auth_identity", return_value="df-pid")
+        mocker.patch.object(MgmtActions, "_setup_role_assignments", return_value={})
+        self._register_enable_mocks(mocked_responses, f)
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.enable(
+            name=f["instance_name"],
+            resource_group_name=f["rg"],
+            eg_resource_id=f["eg_rid"],
+            wait_sec=0,
+        )
+
+        assert result  # Flow completed without ValidationError
+
     def test_custom_dataflow_profile(self, mocked_cmd, mocked_responses: responses, mocker):
         """enable() uses a custom dataflow profile name when provided."""
         custom_profile = "my-custom-profile"


### PR DESCRIPTION
Internal CI pipeline builds produce versions like 1.3.0-main.20260307.5 which are semver-less-than the MIN but contain all required features. Skip the minimum version check when a pre-release component is present.

Also replace Protocol-based typing in scoped_semver_import with TYPE_CHECKING guard for full Version intellisense.