### PR TITLE
fix(support-bundle): capture aio-broker-generation-id configmap via field selector

### DIFF
--- a/azext_edge/edge/providers/support/meso.py
+++ b/azext_edge/edge/providers/support/meso.py
@@ -29,6 +29,8 @@ MESO_NAME_LABEL = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-observ
 MESO_CLUSTER_METRICS_LABEL = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-observability-cluster-metrics")
 MESO_OPERATOR_MANAGER_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="aio-observability-operator-manager-role")
 MESO_DIRECTORY_PATH = "meso"
+# azure-iot-operations-observability-trust-bundle does not have the common label
+MESO_TRUST_BUNDLE_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="azure-iot-operations-observability-trust-bundle")
 
 # List of label selectors to iterate through for most resources
 MESO_LABEL_SELECTORS = [MESO_NAME_LABEL, MESO_CLUSTER_METRICS_LABEL]
@@ -92,6 +94,12 @@ def fetch_config_maps():
                 label_selector=label_selector,
             )
         )
+    results.extend(
+        process_config_maps(
+            directory_path=MESO_DIRECTORY_PATH,
+            field_selector=MESO_TRUST_BUNDLE_FIELD_SELECTOR,
+        )
+    )
     return results
 
 

--- a/azext_edge/edge/providers/support/meso.py
+++ b/azext_edge/edge/providers/support/meso.py
@@ -29,8 +29,6 @@ MESO_NAME_LABEL = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-observ
 MESO_CLUSTER_METRICS_LABEL = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-observability-cluster-metrics")
 MESO_OPERATOR_MANAGER_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="aio-observability-operator-manager-role")
 MESO_DIRECTORY_PATH = "meso"
-# azure-iot-operations-observability-trust-bundle does not have the common label
-MESO_TRUST_BUNDLE_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="azure-iot-operations-observability-trust-bundle")
 
 # List of label selectors to iterate through for most resources
 MESO_LABEL_SELECTORS = [MESO_NAME_LABEL, MESO_CLUSTER_METRICS_LABEL]
@@ -94,12 +92,6 @@ def fetch_config_maps():
                 label_selector=label_selector,
             )
         )
-    results.extend(
-        process_config_maps(
-            directory_path=MESO_DIRECTORY_PATH,
-            field_selector=MESO_TRUST_BUNDLE_FIELD_SELECTOR,
-        )
-    )
     return results
 
 

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -26,12 +26,14 @@ from .base import (
     process_v1_pods,
     process_validating_webhook_configurations,
 )
-from .common import NAME_LABEL_FORMAT
+from .common import NAME_LABEL_FORMAT, RESOURCE_NAME_FIELD_FORMAT
 
 logger = get_logger(__name__)
 
 MQ_NAME_LABEL = NAME_LABEL_FORMAT.format(label=MQ_ACTIVE_API.label)
 MQ_DIRECTORY_PATH = MQ_ACTIVE_API.moniker
+# aio-broker-generation-id does not have the common label
+MQ_GENERATION_ID_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="aio-broker-generation-id")
 
 
 def fetch_diagnostic_traces():
@@ -98,10 +100,17 @@ def fetch_jobs():
 
 
 def fetch_configmaps():
-    return process_config_maps(
+    result = process_config_maps(
         directory_path=MQ_DIRECTORY_PATH,
         label_selector=MQ_NAME_LABEL,
     )
+    result.extend(
+        process_config_maps(
+            directory_path=MQ_DIRECTORY_PATH,
+            field_selector=MQ_GENERATION_ID_FIELD_SELECTOR,
+        )
+    )
+    return result
 
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):


### PR DESCRIPTION

Overview:

- aio-broker-generation-id configmap is missing the app.kubernetes.io/name label, causing it to be silently skipped by the MQ support bundle module.

- Added a secondary metadata.name=aio-broker-generation-id field selector query in fetch_configmaps() in mq.py as a fallback.

- Verified via before/after bundle generation on a live 2603 cluster (AIO 1.3.31) — resource now appears at azure-iot-operations/broker/configmap.aio-broker-generation-id.yaml.