### PR TITLE
feat(mgmt-actions): add client-side payload schema validation for execute

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -2211,6 +2211,11 @@ def load_iotops_help():
             submits the action as a long-running operation. The result includes the action
             status, any response from the asset, and error details if the action failed.
 
+            When a payload is provided, the CLI validates it against the action's request
+            schema (if available) before sending the request. Use --no-validate to skip
+            this check. Use --show-schema to view the action's request schema without
+            executing.
+
         examples:
         - name: Execute a management action with no payload.
           text: >
@@ -2238,6 +2243,25 @@ def load_iotops_help():
             --group mygroup
             --action configure
             -p payload.json
+        - name: Show the request schema for a management action.
+          text: >
+            az iot ops mgmt-actions execute
+            --instance myinstance
+            -g myresourcegroup
+            --asset myasset
+            --group mygroup
+            --action configure
+            --show-schema
+        - name: Execute with payload, skipping schema validation.
+          text: >
+            az iot ops mgmt-actions execute
+            --instance myinstance
+            -g myresourcegroup
+            --asset myasset
+            --group mygroup
+            --action configure
+            -p '{"temperature": {"setpoint": 72}}'
+            --no-validate
     """
 
     helps[

--- a/azext_edge/edge/commands_mgmt_actions.py
+++ b/azext_edge/edge/commands_mgmt_actions.py
@@ -80,6 +80,8 @@ def mgmt_actions_execute(
     group_name: str,
     action_name: str,
     payload: Optional[str] = None,
+    no_validate: bool = False,
+    show_schema: bool = False,
     **kwargs,
 ) -> Dict:
     return MgmtActions(cmd).execute(
@@ -89,6 +91,8 @@ def mgmt_actions_execute(
         group_name=group_name,
         action_name=action_name,
         payload=payload,
+        no_validate=no_validate,
+        show_schema=show_schema,
         **kwargs,
     )
 

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -1614,6 +1614,18 @@ def load_iotops_arguments(self, _):
             options_list=["--payload", "-p"],
             help="JSON payload for the management action. Inline JSON string or file path (e.g., payload.json).",
         )
+        context.argument(
+            "no_validate",
+            options_list=["--no-validate"],
+            help="Skip client-side payload validation against the action's request schema.",
+            action="store_true",
+        )
+        context.argument(
+            "show_schema",
+            options_list=["--show-schema"],
+            help="Resolve and display the action's request schema. No action is executed.",
+            action="store_true",
+        )
 
     with self.argument_context("iot ops schema") as context:
         context.argument(

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -350,36 +350,6 @@ def ensure_schema_structure(schema: dict, input_data: dict, name: Optional[str] 
     """
     Validates the input data against the provided schema using jsonschema.
     """
-    import jsonschema
+    from ...util.schema_validation import validate_data_against_schema
 
-    validator = jsonschema.validators.validator_for(schema)(schema)
-    errors = sorted(validator.iter_errors(input_data), key=lambda e: str(list(e.path)))
-
-    if errors:
-        final_messages = []
-        for error in errors:
-            path = ".".join([str(p) for p in error.path])
-            if error.validator in ["oneOf", "anyOf"] and error.context:
-                # Try to find the most relevant error from the context
-                # We prefer errors that are not about structural mismatch (like additionalProperties)
-                # if there are other errors available.
-                context_errors = error.context
-                # Filter for errors that indicate a value mismatch rather than a structure mismatch
-                value_errors = [
-                    e for e in context_errors
-                    if e.validator not in ["additionalProperties", "required", "type", "const", "enum"]
-                ]
-
-                best = jsonschema.exceptions.best_match(value_errors or context_errors)
-                msg = best.message
-            else:
-                msg = error.message
-
-            if path:
-                final_messages.append(f"Property '{path}' is invalid: {msg}")
-            else:
-                final_messages.append(f"Invalid configuration: {msg}")
-
-        error_msg = "\n".join(final_messages)
-        prefix = f"The following {name} values are invalid:\n" if name else "Invalid input data:\n"
-        raise InvalidArgumentValueError(f"{prefix}{error_msg}")
+    validate_data_against_schema(schema, input_data, name=name)

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -2152,6 +2152,115 @@ class MgmtActions(Queryable):
 
         return result
 
+    def _resolve_request_schema(
+        self,
+        instance: dict,
+        namespace_rg: str,
+        namespace_name: str,
+        asset_name: str,
+        group_name: str,
+        action_name: str,
+    ) -> Optional[dict]:
+        """Resolve the request JSON schema for a management action.
+
+        Walks the resolution chain: instance schemaRegistryRef → asset status →
+        action's requestMessageSchemaReference → schema version content.
+        Returns the parsed JSON Schema dict, or None if any step fails.
+        """
+        # Resolve schema registry from instance
+        schema_registry_id = (
+            instance.get("properties", {})
+            .get("schemaRegistryRef", {})
+            .get("resourceId")
+        )
+        if not schema_registry_id:
+            logger.debug("No schemaRegistryRef on instance — skipping payload validation.")
+            return None
+
+        parsed_registry = parse_resource_id_dict(schema_registry_id)
+        registry_rg = parsed_registry.get("resource_group")
+        registry_name = parsed_registry.get("name")
+        registry_sub = parsed_registry.get("subscription")
+        if not registry_rg or not registry_name:
+            logger.debug("Could not parse schema registry resource ID — skipping payload validation.")
+            return None
+
+        # Resolve client for schema registry operations (may be cross-subscription)
+        if registry_sub and registry_sub.casefold() != self.default_subscription_id.casefold():
+            logger.debug(
+                "Schema registry is in subscription %s — using cross-subscription client.",
+                registry_sub,
+            )
+            schema_client = get_registry_mgmt_client(**self._get_client_kwargs(subscription_id=registry_sub))
+        else:
+            schema_client = self.registry_mgmt_client
+
+        # Fetch asset with status to get requestMessageSchemaReference
+        try:
+            asset = self.registry_mgmt_client.namespace_assets.get(
+                resource_group_name=namespace_rg,
+                namespace_name=namespace_name,
+                asset_name=asset_name,
+            )
+        except HttpResponseError as e:
+            logger.debug("Failed to fetch asset for schema resolution: %s", e)
+            return None
+
+        # Find matching group + action in status
+        schema_ref = None
+        for mg in asset.get("properties", {}).get("status", {}).get("managementGroups", []):
+            if mg.get("name", "").casefold() != group_name.casefold():
+                continue
+            for action in mg.get("actions", []):
+                if action.get("name", "").casefold() != action_name.casefold():
+                    continue
+                schema_ref = action.get("requestMessageSchemaReference")
+                break
+            if schema_ref:
+                break
+
+        if not schema_ref:
+            logger.debug(
+                "No requestMessageSchemaReference found for group=%s action=%s — skipping.",
+                group_name,
+                action_name,
+            )
+            return None
+
+        schema_name = schema_ref.get("schemaName")
+        schema_version = schema_ref.get("schemaVersion")
+        if not schema_name or not schema_version:
+            logger.debug(
+                "Incomplete schemaReference (name=%s, version=%s) — skipping.",
+                schema_name,
+                schema_version,
+            )
+            return None
+
+        # Fetch schema version content
+        try:
+            schema_version_resource = schema_client.schema_versions.get(
+                resource_group_name=registry_rg,
+                schema_registry_name=registry_name,
+                schema_name=schema_name,
+                schema_version_name=schema_version,
+            )
+        except HttpResponseError as e:
+            logger.debug("Failed to fetch schema version %s/%s: %s", schema_name, schema_version, e)
+            return None
+
+        schema_content_str = schema_version_resource.get("properties", {}).get("schemaContent")
+        if not schema_content_str:
+            logger.debug("Schema version has no schemaContent — skipping payload validation.")
+            return None
+
+        # Parse schemaContent JSON
+        try:
+            return json.loads(schema_content_str)
+        except json.JSONDecodeError as e:
+            logger.debug("schemaContent is not valid JSON: %s — skipping payload validation.", e)
+            return None
+
     def execute(
         self,
         instance_name: str,
@@ -2160,15 +2269,22 @@ class MgmtActions(Queryable):
         group_name: str,
         action_name: str,
         payload: Optional[str] = None,
+        no_validate: bool = False,
+        show_schema: bool = False,
         **kwargs,
     ) -> dict:
         """Execute a management action on a namespace asset.
 
-        Resolves the ADR namespace from the instance, then invokes the executeAction
+        Resolves the ADR namespace from the instance, then optionally validates the
+        payload against the action's request schema before invoking the executeAction
         ARM operation as an LRO. Returns the action result (status, response, errors).
+
+        When show_schema is True, resolves and returns the request schema without
+        executing the action.
         """
         from ...util.file_operations import deserialize_json_input
 
+        # Resolve instance → ADR namespace
         instance = self.iotops_mgmt_client.instance.get(
             instance_name=instance_name,
             resource_group_name=resource_group_name,
@@ -2180,20 +2296,77 @@ class MgmtActions(Queryable):
                 "Ensure the instance is properly configured."
             )
         parsed_adr = parse_resource_id_dict(adr_namespace_ref)
+        namespace_rg = parsed_adr.get("resource_group")
+        namespace_name = parsed_adr.get("name")
+        if not namespace_rg or not namespace_name:
+            raise ValidationError(
+                f"Could not parse ADR namespace resource ID: {adr_namespace_ref}"
+            )
 
+        # --show-schema: resolve and return the request schema, then exit
+        if show_schema:
+            with console.status("Resolving request schema..."):
+                request_schema = self._resolve_request_schema(
+                    instance=instance,
+                    namespace_rg=namespace_rg,
+                    namespace_name=namespace_name,
+                    asset_name=asset_name,
+                    group_name=group_name,
+                    action_name=action_name,
+                )
+            if not request_schema:
+                raise ResourceNotFoundError(
+                    f"Could not resolve the request schema for action '{action_name}' "
+                    f"in group '{group_name}' on asset '{asset_name}'. "
+                    "The schema may not be published, the asset status may not be populated, "
+                    "or the schema registry may be inaccessible."
+                )
+            return request_schema
+
+        # Build request body
         body: Dict[str, Any] = {
             "managementActionName": action_name,
             "managementGroupName": group_name,
         }
+        deserialized_payload = None
         if payload:
-            body["payload"] = deserialize_json_input(payload)
+            deserialized_payload = deserialize_json_input(payload)
+            body["payload"] = deserialized_payload
+
+        # Validate payload against request schema (when validation is enabled)
+        if not no_validate:
+            with console.status("Validating payload..."):
+                request_schema = self._resolve_request_schema(
+                    instance=instance,
+                    namespace_rg=namespace_rg,
+                    namespace_name=namespace_name,
+                    asset_name=asset_name,
+                    group_name=group_name,
+                    action_name=action_name,
+                )
+                if request_schema:
+                    from ...util.schema_validation import check_json_schema, validate_data_against_schema
+
+                    schema_issue = check_json_schema(request_schema)
+                    if schema_issue:
+                        logger.warning(
+                            "%s — skipping validation. Use --show-schema to inspect the schema.",
+                            schema_issue,
+                        )
+                    else:
+                        validate_data_against_schema(
+                            request_schema,
+                            deserialized_payload if deserialized_payload is not None else {},
+                            name="payload",
+                        )
 
         logger.debug("Execute action request body: %s", body)
 
+        # Execute action (LRO)
         with console.status("Sending request...") as status:
             poller = self.registry_mgmt_client.namespace_assets.begin_execute_action(
-                resource_group_name=parsed_adr["resource_group"],
-                namespace_name=parsed_adr["name"],
+                resource_group_name=namespace_rg,
+                namespace_name=namespace_name,
                 asset_name=asset_name,
                 body=body,
             )

--- a/azext_edge/edge/util/schema_validation.py
+++ b/azext_edge/edge/util/schema_validation.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import Optional
+
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+
+def check_json_schema(schema: dict) -> Optional[str]:
+    """Check whether a schema is a recognized, valid JSON Schema suitable for validation.
+
+    Returns None if the schema is usable. Returns a human-readable reason string if
+    validation should be skipped — either because the $schema dialect is not recognized
+    (e.g., IoT Operations custom formats) or the schema is structurally invalid.
+    """
+    import jsonschema
+
+    schema_dialect = schema.get("$schema", "")
+    if schema_dialect and "json-schema.org" not in schema_dialect:
+        return f"Schema dialect '{schema_dialect}' is not a recognized JSON Schema format"
+
+    validator_cls = jsonschema.validators.validator_for(schema)
+    try:
+        validator_cls.check_schema(schema)
+    except jsonschema.SchemaError as e:
+        return f"Schema is not valid JSON Schema: {e.message}"
+
+    return None
+
+
+def validate_data_against_schema(schema: dict, data: dict, name: Optional[str] = None) -> None:
+    """Validate data against a JSON Schema, raising on validation failures.
+
+    Collects all validation errors, formats them with property paths and
+    oneOf/anyOf context handling, and raises InvalidArgumentValueError.
+    Assumes the schema itself is valid — use check_json_schema() first
+    for untrusted schemas.
+    """
+    import jsonschema
+
+    validator = jsonschema.validators.validator_for(schema)(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: str(list(e.path)))
+
+    if not errors:
+        return
+
+    final_messages = []
+    for error in errors:
+        path = ".".join([str(p) for p in error.path])
+        if error.validator in ("oneOf", "anyOf") and error.context:
+            # Prefer value-mismatch errors over structural-mismatch errors
+            # when multiple sub-schema alternatives fail.
+            value_errors = [
+                e for e in error.context
+                if e.validator not in ("additionalProperties", "required", "type", "const", "enum")
+            ]
+            best = jsonschema.exceptions.best_match(value_errors or error.context)
+            msg = best.message
+        else:
+            msg = error.message
+
+        if path:
+            final_messages.append(f"Property '{path}' is invalid: {msg}")
+        else:
+            final_messages.append(f"Invalid configuration: {msg}")
+
+    error_msg = "\n".join(final_messages)
+    prefix = f"The following {name} values are invalid:\n" if name else "Invalid input data:\n"
+    raise InvalidArgumentValueError(f"{prefix}{error_msg}")

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -11,7 +11,7 @@ import pytest
 import responses
 from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
 from azext_edge.edge.providers.orchestration.common import (
     CUSTOM_LOCATIONS_API_VERSION,
@@ -69,6 +69,7 @@ def suppress_workflow_display(mocker):
     """Prevent WorkflowDisplay and render_summary from writing to stderr during tests."""
     mocker.patch("azext_edge.edge.providers.orchestration.mgmt_actions.WorkflowDisplay")
     mocker.patch("azext_edge.edge.providers.orchestration.mgmt_actions.render_summary")
+    mocker.patch("azext_edge.edge.providers.orchestration.mgmt_actions.console")
 
 
 # ---------------------------------------------------------------------------
@@ -4489,6 +4490,836 @@ class TestExecute:
         execute_request = mocked_responses.calls[1]
         body = json.loads(execute_request.request.body)
         assert body["payload"] == {"temperature": {"setpoint": 72}}
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests for execute()
+# ---------------------------------------------------------------------------
+
+
+def _build_namespace_asset_endpoint(
+    namespace_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    subscription_id: Optional[str] = None,
+) -> str:
+    """Build a full management endpoint URL for a namespace asset GET."""
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    return (
+        f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+        f"/providers/{DEVICEREGISTRY_RP}/namespaces/{namespace_name}/assets/{asset_name}"
+        f"?api-version={DEVICEREGISTRY_API_VERSION}"
+    )
+
+
+def _build_schema_version_endpoint(
+    registry_rg: str,
+    registry_name: str,
+    schema_name: str,
+    schema_version: str,
+    subscription_id: Optional[str] = None,
+) -> str:
+    """Build a full management endpoint URL for a schema version GET."""
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    return (
+        f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{registry_rg}"
+        f"/providers/{DEVICEREGISTRY_RP}/schemaRegistries/{registry_name}"
+        f"/schemas/{schema_name}/schemaVersions/{schema_version}"
+        f"?api-version={DEVICEREGISTRY_API_VERSION}"
+    )
+
+
+def _build_asset_response_with_schema(
+    asset_name: str,
+    group_name: str,
+    action_name: str,
+    schema_name: str,
+    schema_version: str,
+) -> dict:
+    """Build a namespace asset GET response with requestMessageSchemaReference in status."""
+    return {
+        "name": asset_name,
+        "properties": {
+            "provisioningState": "Succeeded",
+            "status": {
+                "managementGroups": [
+                    {
+                        "name": group_name,
+                        "actions": [
+                            {
+                                "name": action_name,
+                                "requestMessageSchemaReference": {
+                                    "schemaName": schema_name,
+                                    "schemaVersion": schema_version,
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+        },
+    }
+
+
+def _build_schema_version_response(schema_content: str) -> dict:
+    """Build a schema version GET response with stringified JSON Schema."""
+    return {
+        "properties": {
+            "schemaContent": schema_content,
+        },
+    }
+
+
+class _SchemaTestBase:
+    """Shared fixtures and helpers for schema-related execute() tests."""
+
+    SCHEMA_NAME = "temperatureSchema"
+    SCHEMA_VERSION = "1"
+    REGISTRY_NAME = "mySchemaRegistry"
+
+    def _make_fixtures(self) -> dict:
+        instance_name = generate_random_string()
+        rg = generate_random_string()
+        adr_ns_name = f"{instance_name}-adr-ns"
+        asset_name = generate_random_string()
+        group_name = generate_random_string()
+        action_name = generate_random_string()
+        return {
+            "instance_name": instance_name,
+            "rg": rg,
+            "adr_ns_name": adr_ns_name,
+            "asset_name": asset_name,
+            "group_name": group_name,
+            "action_name": action_name,
+        }
+
+    def _build_instance_with_registry(self, f: dict) -> dict:
+        """Build instance response with schemaRegistryRef."""
+        resp = _build_instance_response(f["instance_name"], f["rg"], adr_namespace_name=f["adr_ns_name"])
+        registry_id = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{f['rg']}"
+            f"/providers/{DEVICEREGISTRY_RP}/schemaRegistries/{self.REGISTRY_NAME}"
+        )
+        resp["properties"]["schemaRegistryRef"] = {"resourceId": registry_id}
+        return resp
+
+    def _build_execute_action_endpoint(
+        self,
+        namespace_name: str,
+        resource_group_name: str,
+        asset_name: str,
+    ) -> str:
+        sub_id = ZEROED_SUBSCRIPTION
+        return (
+            f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+            f"/providers/{DEVICEREGISTRY_RP}/namespaces/{namespace_name}"
+            f"/assets/{asset_name}/executeAction"
+            f"?api-version={DEVICEREGISTRY_API_VERSION}"
+        )
+
+    def _register_schema_resolution_mocks(
+        self,
+        mocked_responses: responses,
+        f: dict,
+        schema_content: str,
+    ) -> None:
+        """Register mocks for schema resolution: Instance GET → Asset GET → Schema Version GET."""
+        # Instance GET
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        # Asset GET
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=_build_asset_response_with_schema(
+                f["asset_name"], f["group_name"], f["action_name"],
+                self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            status=200,
+        )
+        # Schema Version GET
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_schema_version_endpoint(
+                f["rg"], self.REGISTRY_NAME, self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            json=_build_schema_version_response(schema_content),
+            status=200,
+        )
+
+
+class TestExecutePayloadValidation(_SchemaTestBase):
+    """Tests for payload-against-schema validation in execute().
+
+    Schema resolution is soft-fail during normal execution — if any step
+    in the chain fails, validation is skipped and executeAction proceeds.
+    """
+
+    def _register_full_validation_mocks(
+        self,
+        mocked_responses: responses,
+        f: dict,
+        schema_content: str,
+        execute_response: dict,
+    ) -> None:
+        """Register all mocks for a full validation+execution flow.
+
+        Order: Instance GET → Asset GET → Schema Version GET → executeAction POST
+        """
+        self._register_schema_resolution_mocks(mocked_responses, f, schema_content)
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+    def test_validation_passes(self, mocked_cmd, mocked_responses: responses):
+        """Schema resolved and payload conforms → executeAction called normally."""
+        f = self._make_fixtures()
+        schema = json.dumps({
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        })
+        execute_response = {"status": "Succeeded"}
+        self._register_full_validation_mocks(mocked_responses, f, schema, execute_response)
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET, executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+    def test_validation_fails(self, mocked_cmd, mocked_responses: responses):
+        """Schema resolved, payload violates schema → InvalidArgumentValueError before POST."""
+        f = self._make_fixtures()
+        schema = json.dumps({
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+            "required": ["temperature"],
+            "additionalProperties": False,
+        })
+        # Register all mocks except POST (validation should fail before it)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=_build_asset_response_with_schema(
+                f["asset_name"], f["group_name"], f["action_name"],
+                self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_schema_version_endpoint(
+                f["rg"], self.REGISTRY_NAME, self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            json=_build_schema_version_response(schema),
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        with pytest.raises(InvalidArgumentValueError, match="payload"):
+            provider.execute(
+                instance_name=f["instance_name"],
+                resource_group_name=f["rg"],
+                asset_name=f["asset_name"],
+                group_name=f["group_name"],
+                action_name=f["action_name"],
+                payload='{"badField": "wrong"}',
+                wait_sec=0,
+            )
+
+        # 3 calls: Instance GET, Asset GET, Schema Version GET — no POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_no_payload_validates_empty_object(self, mocked_cmd, mocked_responses: responses):
+        """No payload → schema resolved, {} validated against it, executeAction proceeds."""
+        f = self._make_fixtures()
+        schema = json.dumps({
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        })
+        execute_response = {"status": "Succeeded"}
+        self._register_full_validation_mocks(mocked_responses, f, schema, execute_response)
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET, executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+    def test_no_payload_required_fields_fails(self, mocked_cmd, mocked_responses: responses):
+        """No payload + schema has required fields → InvalidArgumentValueError before POST."""
+        f = self._make_fixtures()
+        schema = json.dumps({
+            "type": "object",
+            "properties": {"mode": {"type": "string"}},
+            "required": ["mode"],
+        })
+        # Register all mocks except POST (validation should fail before it)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=_build_asset_response_with_schema(
+                f["asset_name"], f["group_name"], f["action_name"],
+                self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_schema_version_endpoint(
+                f["rg"], self.REGISTRY_NAME, self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            json=_build_schema_version_response(schema),
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        with pytest.raises(InvalidArgumentValueError, match="payload"):
+            provider.execute(
+                instance_name=f["instance_name"],
+                resource_group_name=f["rg"],
+                asset_name=f["asset_name"],
+                group_name=f["group_name"],
+                action_name=f["action_name"],
+                wait_sec=0,
+            )
+
+        # 3 calls: Instance GET, Asset GET, Schema Version GET — no POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_no_validate_skips_resolution(self, mocked_cmd, mocked_responses: responses):
+        """no_validate=True → _resolve_request_schema not called, executeAction proceeds."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        # Only register instance GET and executeAction POST — no schema mocks
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            no_validate=True,
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 2 calls only: Instance GET, executeAction POST
+        assert len(mocked_responses.calls) == 2
+
+    def test_schema_resolution_fails_soft(self, mocked_cmd, mocked_responses: responses):
+        """Asset GET fails → validation skipped, executeAction proceeds."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        # Instance GET (with registry)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        # Asset GET returns 404
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json={"error": {"code": "ResourceNotFound"}},
+            status=404,
+        )
+        # executeAction POST (should proceed despite schema failure)
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 3 calls: Instance GET, Asset GET (404), executeAction POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_no_schema_registry_ref(self, mocked_cmd, mocked_responses: responses):
+        """Instance has no schemaRegistryRef → validation skipped, executeAction proceeds."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        # Instance without schemaRegistryRef
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=_build_instance_response(f["instance_name"], f["rg"], adr_namespace_name=f["adr_ns_name"]),
+            status=200,
+        )
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 2 calls: Instance GET, executeAction POST — no schema resolution attempted
+        assert len(mocked_responses.calls) == 2
+
+    def test_cross_subscription_registry(self, mocked_cmd, mocked_responses: responses):
+        """Schema registry in different subscription → cross-sub client created, validation works."""
+        f = self._make_fixtures()
+        cross_sub = "11111111-1111-1111-1111-111111111111"
+        schema = json.dumps({
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        })
+        execute_response = {"status": "Succeeded"}
+
+        # Build instance with cross-subscription registry
+        instance_resp = _build_instance_response(
+            f["instance_name"], f["rg"], adr_namespace_name=f["adr_ns_name"],
+        )
+        registry_id = (
+            f"/subscriptions/{cross_sub}/resourceGroups/{f['rg']}"
+            f"/providers/{DEVICEREGISTRY_RP}/schemaRegistries/{self.REGISTRY_NAME}"
+        )
+        instance_resp["properties"]["schemaRegistryRef"] = {"resourceId": registry_id}
+
+        # Instance GET
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=instance_resp,
+            status=200,
+        )
+        # Asset GET (same subscription as instance — uses self.registry_mgmt_client)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=_build_asset_response_with_schema(
+                f["asset_name"], f["group_name"], f["action_name"],
+                self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            status=200,
+        )
+        # Schema Version GET — note cross_sub in the URL (uses cross-sub client)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_schema_version_endpoint(
+                f["rg"], self.REGISTRY_NAME, self.SCHEMA_NAME, self.SCHEMA_VERSION,
+                subscription_id=cross_sub,
+            ),
+            json=_build_schema_version_response(schema),
+            status=200,
+        )
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET (cross-sub), executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+    def test_no_matching_action_in_status(self, mocked_cmd, mocked_responses: responses):
+        """Asset status has no matching group/action → validation skipped."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        # Asset with different group/action in status
+        asset_response = _build_asset_response_with_schema(
+            f["asset_name"], "otherGroup", "otherAction",
+            self.SCHEMA_NAME, self.SCHEMA_VERSION,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=asset_response,
+            status=200,
+        )
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 3 calls: Instance GET, Asset GET, executeAction POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_schema_content_not_json(self, mocked_cmd, mocked_responses: responses):
+        """schemaContent is malformed → validation skipped, executeAction proceeds."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=_build_asset_response_with_schema(
+                f["asset_name"], f["group_name"], f["action_name"],
+                self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            status=200,
+        )
+        # Schema version with non-JSON content
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_schema_version_endpoint(
+                f["rg"], self.REGISTRY_NAME, self.SCHEMA_NAME, self.SCHEMA_VERSION,
+            ),
+            json=_build_schema_version_response("not valid json {{{"),
+            status=200,
+        )
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET, executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+    def test_incomplete_schema_reference(self, mocked_cmd, mocked_responses: responses):
+        """requestMessageSchemaReference missing schemaVersion → validation skipped."""
+        f = self._make_fixtures()
+        execute_response = {"status": "Succeeded"}
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=self._build_instance_with_registry(f),
+            status=200,
+        )
+        # Asset with incomplete schema reference (missing schemaVersion)
+        asset_response = {
+            "name": f["asset_name"],
+            "properties": {
+                "provisioningState": "Succeeded",
+                "status": {
+                    "managementGroups": [
+                        {
+                            "name": f["group_name"],
+                            "actions": [
+                                {
+                                    "name": f["action_name"],
+                                    "requestMessageSchemaReference": {
+                                        "schemaName": self.SCHEMA_NAME,
+                                        # schemaVersion intentionally missing
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        }
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_namespace_asset_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=asset_response,
+            status=200,
+        )
+        # executeAction POST
+        mocked_responses.add(
+            method=responses.POST,
+            url=self._build_execute_action_endpoint(f["adr_ns_name"], f["rg"], f["asset_name"]),
+            json=execute_response,
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 3 calls: Instance GET, Asset GET, executeAction POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_non_jsonschema_format_skips_validation(self, mocked_cmd, mocked_responses: responses):
+        """Schema with non-standard $schema dialect → validation skipped, executeAction proceeds."""
+        f = self._make_fixtures()
+        schema = json.dumps({
+            "$schema": "iot-operations/1.0",
+            "fields": [{"name": "temperature", "type": "float"}],
+        })
+        execute_response = {"status": "Succeeded"}
+        self._register_full_validation_mocks(mocked_responses, f, schema, execute_response)
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET, executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+    def test_malformed_jsonschema_skips_validation(self, mocked_cmd, mocked_responses: responses):
+        """Schema with recognized $schema but malformed body → SchemaError caught, executeAction proceeds."""
+        f = self._make_fixtures()
+        # Valid $schema URI but body uses invalid JSON Schema constructs
+        schema = json.dumps({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": "not-a-dict",
+        })
+        execute_response = {"status": "Succeeded"}
+        self._register_full_validation_mocks(mocked_responses, f, schema, execute_response)
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            wait_sec=0,
+        )
+
+        assert result == execute_response
+        # 4 calls: Instance GET, Asset GET, Schema Version GET, executeAction POST
+        assert len(mocked_responses.calls) == 4
+
+
+class TestExecuteShowSchema(_SchemaTestBase):
+    """Tests for --show-schema mode.
+
+    When show_schema=True, the command resolves the request schema and returns
+    it without executing the action. Failures are hard (ResourceNotFoundError)
+    because the user explicitly requested the schema.
+    """
+
+    def test_show_schema_returns_schema(self, mocked_cmd, mocked_responses: responses):
+        """show_schema=True → resolves full chain → returns parsed JSON Schema dict."""
+        f = self._make_fixtures()
+        schema_dict = {
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        }
+        self._register_schema_resolution_mocks(mocked_responses, f, json.dumps(schema_dict))
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            show_schema=True,
+            wait_sec=0,
+        )
+
+        assert result == schema_dict
+        # 3 calls: Instance GET, Asset GET, Schema Version GET — no executeAction POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_show_schema_resolution_fails(self, mocked_cmd, mocked_responses: responses):
+        """show_schema=True, no schemaRegistryRef → ResourceNotFoundError."""
+        f = self._make_fixtures()
+        # Instance without schemaRegistryRef
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(f["instance_name"], f["rg"]),
+            json=_build_instance_response(f["instance_name"], f["rg"], adr_namespace_name=f["adr_ns_name"]),
+            status=200,
+        )
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        with pytest.raises(ResourceNotFoundError, match="Could not resolve the request schema"):
+            provider.execute(
+                instance_name=f["instance_name"],
+                resource_group_name=f["rg"],
+                asset_name=f["asset_name"],
+                group_name=f["group_name"],
+                action_name=f["action_name"],
+                show_schema=True,
+                wait_sec=0,
+            )
+
+        # 1 call: Instance GET only
+        assert len(mocked_responses.calls) == 1
+
+    def test_show_schema_ignores_payload(self, mocked_cmd, mocked_responses: responses):
+        """show_schema=True + payload → payload ignored, schema returned."""
+        f = self._make_fixtures()
+        schema_dict = {
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        }
+        self._register_schema_resolution_mocks(mocked_responses, f, json.dumps(schema_dict))
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            payload='{"temperature": 72}',
+            show_schema=True,
+            wait_sec=0,
+        )
+
+        assert result == schema_dict
+        # 3 calls: Instance GET, Asset GET, Schema Version GET — no executeAction POST
+        assert len(mocked_responses.calls) == 3
+
+    def test_show_schema_ignores_no_validate(self, mocked_cmd, mocked_responses: responses):
+        """show_schema=True + no_validate=True → schema returned normally."""
+        f = self._make_fixtures()
+        schema_dict = {
+            "type": "object",
+            "properties": {"temperature": {"type": "number"}},
+        }
+        self._register_schema_resolution_mocks(mocked_responses, f, json.dumps(schema_dict))
+
+        provider = MgmtActions(cmd=mocked_cmd)
+        result = provider.execute(
+            instance_name=f["instance_name"],
+            resource_group_name=f["rg"],
+            asset_name=f["asset_name"],
+            group_name=f["group_name"],
+            action_name=f["action_name"],
+            show_schema=True,
+            no_validate=True,
+            wait_sec=0,
+        )
+
+        assert result == schema_dict
+        # 3 calls: Instance GET, Asset GET, Schema Version GET
+        assert len(mocked_responses.calls) == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolve the action's request JSON Schema from the schema registry and validate the payload before sending executeAction. Add --no-validate to skip validation and --show-schema to inspect the schema without executing.

Extract shared jsonschema logic into util/schema_validation.py, reused by both mgmt_actions and adr/helpers.
