### PR TITLE
fix(check): handle None pods gracefully when cluster access is forbidden (403)

### DIFF
--- a/azext_edge/edge/providers/base.py
+++ b/azext_edge/edge/providers/base.py
@@ -167,6 +167,7 @@ def get_namespaced_pods_by_prefix(
         _namespaced_pods_cache[target_pods_key] = pods_list.items
     except ApiException as ae:
         logger.debug(str(ae))
+        return []
     else:
         return filter_pods_from_cache(target_pods_key)
 

--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -82,6 +82,9 @@ def filter_resources_by_name(
 ) -> List[dict]:
     from fnmatch import fnmatch
 
+    if not resources:
+        return []
+
     if not resource_name:
         return resources
 
@@ -120,6 +123,8 @@ def get_resources_by_name(
 
 
 def get_resources_grouped_by_namespace(resources: List[dict]):
+    if not resources:
+        return []
     resources.sort(key=_get_namespace)
     return groupby(resources, key=_get_namespace)
 

--- a/azext_edge/tests/edge/checks/base/test_resource_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_resource_unit.py
@@ -988,4 +988,4 @@ def test_get_resources_grouped_by_namespace_none_or_empty(resources):
     """Regression test: when cluster returns 403, get_namespaced_pods_by_prefix returns None.
     get_resources_grouped_by_namespace must not raise AttributeError on None or []."""
     result = list(get_resources_grouped_by_namespace(resources))
-    assert result == []
+    assert not result

--- a/azext_edge/tests/edge/checks/base/test_resource_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_resource_unit.py
@@ -25,6 +25,7 @@ from azext_edge.edge.providers.check.base.resource import (
     calculate_status,
     combine_statuses,
     decorate_resource_status,
+    get_resources_grouped_by_namespace,
     process_resource_property_by_type,
     validate_runtime_resource_ref,
 )
@@ -974,3 +975,17 @@ def test_validate_runtime_resource_ref(mocker, name, namespace, ref_type, ref_ob
     is_valid = validate_runtime_resource_ref(name, namespace, ref_type)
 
     assert is_valid == expected_is_valid
+
+
+@pytest.mark.parametrize(
+    "resources",
+    [
+        None,
+        [],
+    ],
+)
+def test_get_resources_grouped_by_namespace_none_or_empty(resources):
+    """Regression test: when cluster returns 403, get_namespaced_pods_by_prefix returns None.
+    get_resources_grouped_by_namespace must not raise AttributeError on None or []."""
+    result = list(get_resources_grouped_by_namespace(resources))
+    assert result == []

--- a/azext_edge/tests/edge/checks/test_akri_checks_unit.py
+++ b/azext_edge/tests/edge/checks/test_akri_checks_unit.py
@@ -37,6 +37,21 @@ def test_check_akri_by_resource_types(ops_service, mocker, mock_resource_types, 
 
 
 @pytest.mark.parametrize("detail_level", ResourceOutputDetailLevel.list())
+@pytest.mark.parametrize("resource_name", [None, "akri-*"])
+def test_evaluate_core_service_runtime_none_pods(mocker, detail_level, resource_name):
+    """Regression test: when cluster returns 403, get_namespaced_pods_by_prefix returns None or [].
+    The check should not raise AttributeError and should complete gracefully."""
+    for return_value in [None, []]:
+        mocker.patch(
+            "azext_edge.edge.providers.check.akri.get_namespaced_pods_by_prefix",
+            return_value=return_value,
+        )
+        # Should not raise AttributeError: 'NoneType' object has no attribute 'sort'
+        result = evaluate_core_service_runtime(detail_level=detail_level, resource_name=resource_name)
+        assert result["name"] == "evalCoreServiceRuntime"
+
+
+@pytest.mark.parametrize("detail_level", ResourceOutputDetailLevel.list())
 @pytest.mark.parametrize("resource_name", [None, "akri-*", "AKRI-*"])
 @pytest.mark.parametrize(
     "pods, namespace_conditions, namespace_evaluations",


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
