### PR TITLE
fix(check): guard resource fetch against None response on cluster access errors

### DIFF
--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -117,7 +117,7 @@ def get_resources_by_name(
     resource_name: str,
     namespace: str = None,
 ) -> List[dict]:
-    resources: list = api_info.get_resources(kind=kind, namespace=namespace).get("items", [])
+    resources: list = (api_info.get_resources(kind=kind, namespace=namespace) or {}).get("items", [])
     resources = filter_resources_by_name(resources, resource_name)
     return resources
 

--- a/azext_edge/tests/edge/checks/base/test_resource_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_resource_unit.py
@@ -989,3 +989,21 @@ def test_get_resources_grouped_by_namespace_none_or_empty(resources):
     get_resources_grouped_by_namespace must not raise AttributeError on None or []."""
     result = list(get_resources_grouped_by_namespace(resources))
     assert not result
+
+
+@pytest.mark.parametrize(
+    "get_resources_return_value",
+    [
+        None,
+        {"items": None},
+        {"items": []},
+    ],
+)
+def test_get_resources_by_name_none_or_empty(mocker, get_resources_return_value):
+    """Regression test: when cluster returns 403, get_resources() can return None.
+    get_resources_by_name must not raise AttributeError on None result."""
+    api_info_patch = mocker.patch("azext_edge.edge.providers.edge_api.EdgeResourceApi")
+    api_info_patch.get_resources.return_value = get_resources_return_value
+
+    result = get_resources_by_name(api_info_patch, "asset", None)
+    assert not result


### PR DESCRIPTION


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
