### PR TITLE
refactor(delete): tiered CL identification and responses test migration

### DIFF
--- a/azext_edge/edge/providers/orchestration/deletion2.py
+++ b/azext_edge/edge/providers/orchestration/deletion2.py
@@ -13,7 +13,7 @@ DeviceRegistry and SecretSync resources on the custom location.
 
 from collections import OrderedDict
 from sys import maxsize
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 from uuid import uuid4
 
 from azure.cli.core.azclierror import ArgumentUsageError, ResourceNotFoundError
@@ -64,6 +64,12 @@ _STEP_DEP_EXTENSIONS = "Dependency Extensions"
 
 # Extension types eligible for --include-deps deletion (excluding ACS, which is version-gated).
 _DEP_EXTENSION_TYPES = frozenset([EXTENSION_TYPE_CM, EXTENSION_TYPE_PLATFORM, EXTENSION_TYPE_SSC])
+
+# All AIO-related extension types — used for type-verified CL identification.
+_AIO_EXTENSION_TYPES = frozenset([EXTENSION_TYPE_OPS, EXTENSION_TYPE_ACS]) | _DEP_EXTENSION_TYPES
+
+# Default Kubernetes namespace for IoT Operations custom locations.
+_AIO_DEFAULT_NAMESPACE = "azure-iot-operations"
 
 # Friendly display labels for CL resource types (keyed by resource_type from parse_resource_id).
 _FRIENDLY_TYPE_LABELS: Dict[str, str] = {
@@ -142,6 +148,7 @@ class DeletionManager:
         self._sync_rules: List[IoTOperationsResource] = []
         self._cl_resource: Optional[IoTOperationsResource] = None
         self._cluster_extensions_client: Optional[ClusterExtensions] = None
+        self._aio_typed_ext_ids: Set[str] = set()
 
     def do_work(self, confirm_yes: Optional[bool] = None, force: Optional[bool] = None) -> None:
         if not any([self.cluster_name, self.instance_name]):
@@ -264,15 +271,17 @@ class DeletionManager:
         self._cluster_name = self.cluster_name
         cluster_id: str = self._cluster_resource["id"]
 
-        # Find CL on this cluster.
+        # Discover extensions first — populates type-verified IDs for CL identification.
+        self._discover_extensions()
+
+        # Find AIO custom location on this cluster using tiered identification.
         custom_locations = CustomLocations(self.cmd)
         all_cls = list(custom_locations.list(resource_group_name=self.resource_group_name))
-        matched_cl = None
-        for cl in all_cls:
-            host_id = cl.get("properties", {}).get("hostResourceId", "")
-            if host_id and host_id.lower() == cluster_id.lower():
-                matched_cl = cl
-                break
+        host_matched_cls = [
+            cl for cl in all_cls
+            if (cl.get("properties", {}).get("hostResourceId", "") or "").lower() == cluster_id.lower()
+        ]
+        matched_cl = self._identify_aio_cl(host_matched_cls)
 
         if matched_cl:
             self._cl_id = matched_cl["id"]
@@ -303,10 +312,38 @@ class DeletionManager:
         if self._instance:
             self._collect_spc_from_instance()
 
-        # Extensions, sync rules, ARG sweep — shared discovery.
-        self._discover_extensions()
+        # Sync rules and ARG sweep — remaining shared discovery.
         self._discover_sync_rules()
         self._run_arg_sweep()
+
+    def _identify_aio_cl(self, host_matched_cls: List[dict]) -> Optional[dict]:
+        """Identify the AIO custom location from CLs on the same cluster.
+
+        Tier 1: Cross-reference CL's clusterExtensionIds against type-verified
+        AIO extensions discovered on the cluster.
+        Tier 2: Match CL namespace against the default AIO namespace.
+        Raises if CLs exist on the host but none can be identified as AIO.
+        """
+        if not host_matched_cls:
+            return None
+
+        # Tier 1: Extension type cross-reference.
+        if self._aio_typed_ext_ids:
+            for cl in host_matched_cls:
+                cl_ext_ids = cl.get("properties", {}).get("clusterExtensionIds", []) or []
+                if any(eid.lower() in self._aio_typed_ext_ids for eid in cl_ext_ids):
+                    return cl
+
+        # Tier 2: Namespace match.
+        for cl in host_matched_cls:
+            ns = cl.get("properties", {}).get("namespace", "")
+            if ns and ns.lower() == _AIO_DEFAULT_NAMESPACE:
+                return cl
+
+        raise ResourceNotFoundError(
+            f"Could not identify an IoT Operations custom location on cluster '{self.cluster_name}'. "
+            "If resources remain, delete them manually."
+        )
 
     # ------------------------------------------------------------------
     # Shared Discovery Helpers
@@ -364,6 +401,10 @@ class DeletionManager:
                     display_name=ext_name,
                     api_version=CLUSTER_EXTENSIONS_API_VERSION,
                 ))
+
+            # Track type-verified extension IDs for CL identification.
+            if ext_type in _AIO_EXTENSION_TYPES:
+                self._aio_typed_ext_ids.add(ext_id.lower())
 
         # Version-gate ACS: only include if AIO version <= threshold.
         if acs_extension and self._should_include_acs(aio_version):
@@ -477,9 +518,6 @@ class DeletionManager:
         if self._instance_resource:
             sections[_STEP_INSTANCE] = [(self._instance_resource.display_name, "found")]
 
-        if self._aio_extension:
-            sections[_STEP_AIO_EXT] = [(self._aio_extension.display_name, "found")]
-
         if self._cl_resources:
             sections[_STEP_CL_RESOURCES] = [
                 (r.display_name, self._cl_resource_label(r.resource_id))
@@ -491,6 +529,9 @@ class DeletionManager:
 
         if self._cl_resource:
             sections[_STEP_CUSTOM_LOCATION] = [(self._cl_resource.display_name, "found")]
+
+        if self._aio_extension:
+            sections[_STEP_AIO_EXT] = [(self._aio_extension.display_name, "found")]
 
         if self.include_dependencies and self._dep_extensions:
             sections[_STEP_DEP_EXTENSIONS] = [(e.display_name, "found") for e in self._dep_extensions]
@@ -511,8 +552,6 @@ class DeletionManager:
 
         if self._instance_resource:
             categories[_STEP_INSTANCE] = [self._instance_resource.display_name]
-        if self._aio_extension:
-            categories[_STEP_AIO_EXT] = [self._aio_extension.display_name]
         if self._cl_resources:
             count = len(self._cl_resources)
             categories[_STEP_CL_RESOURCES] = [f"{count} resource{'s' if count != 1 else ''}"]
@@ -520,6 +559,8 @@ class DeletionManager:
             categories[_STEP_SYNC_RULES] = [r.display_name for r in self._sync_rules]
         if self._cl_resource:
             categories[_STEP_CUSTOM_LOCATION] = [self._cl_resource.display_name]
+        if self._aio_extension:
+            categories[_STEP_AIO_EXT] = [self._aio_extension.display_name]
         if self.include_dependencies and self._dep_extensions:
             categories[_STEP_DEP_EXTENSIONS] = [e.display_name for e in self._dep_extensions]
 
@@ -536,12 +577,6 @@ class DeletionManager:
                         display, _STEP_INSTANCE, self._instance_resource
                     )
 
-                # AIO extension (uses dedicated extensions client for proper LRO).
-                if self._aio_extension:
-                    self._execute_extension_single(
-                        display, _STEP_AIO_EXT, self._aio_extension
-                    )
-
                 # CL resources (SecretSync + DR assets) — collapsed summary step.
                 if self._cl_resources:
                     self._execute_cl_resources(display)
@@ -550,7 +585,7 @@ class DeletionManager:
                 if self._sync_rules:
                     self._execute_step_parallel(display, _STEP_SYNC_RULES, self._sync_rules)
 
-                # Custom location — soft-fail so dep extensions still run.
+                # Custom location — soft-fail so extensions still run.
                 if self._cl_resource:
                     try:
                         self._execute_step_single(
@@ -566,6 +601,12 @@ class DeletionManager:
                             "Resources scoped to it may still exist. "
                             "Re-run with --cluster to discover and clean them up."
                         )
+
+                # AIO extension (uses dedicated extensions client for proper LRO).
+                if self._aio_extension:
+                    self._execute_extension_single(
+                        display, _STEP_AIO_EXT, self._aio_extension
+                    )
 
                 # Dependency extensions (--include-deps only, dedicated client).
                 if self.include_dependencies and self._dep_extensions:

--- a/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
@@ -4,10 +4,13 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import List
-from unittest.mock import MagicMock, Mock
+import json
+import re
+from typing import List, Optional
+from unittest.mock import Mock
 
 import pytest
+import responses
 from azure.cli.core.azclierror import ArgumentUsageError, ResourceNotFoundError
 from azure.core.exceptions import HttpResponseError
 
@@ -29,14 +32,232 @@ from azext_edge.edge.providers.orchestration.deletion2 import (
 )
 from azext_edge.edge.util.az_client import DEFAULT_IOTOPS_MGMT_API_VERSION
 from azext_edge.edge.util.machinery import scoped_semver_import
-
-from ...generators import generate_resource_id, get_zeroed_subscription
+from ...generators import BASE_URL, generate_resource_id, get_zeroed_subscription
 
 semver = scoped_semver_import()
 ZEROED_SUBSCRIPTION = get_zeroed_subscription()
 IOTOPS_API_VERSION = DEFAULT_IOTOPS_MGMT_API_VERSION.value
 _ACS_THRESHOLD = semver.parse(MAX_INSTANCE_VERSION_ACS_DEPENDENCY)
 _ACS_ABOVE = str(_ACS_THRESHOLD.bump_patch())
+# Vendored ConnectedKubernetesClient bakes this version — no exported constant.
+CONNECTEDK8S_API_VERSION = "2024-07-15-preview"
+
+# Common resource IDs reused across tests (all in rg1).
+_RG = "rg1"
+_CL_ID = generate_resource_id(
+    resource_group_name=_RG,
+    resource_provider="Microsoft.ExtendedLocation",
+    resource_path="/customLocations/mycl",
+)
+_CLUSTER_ID = generate_resource_id(
+    resource_group_name=_RG,
+    resource_provider="Microsoft.Kubernetes",
+    resource_path="/connectedClusters/mycluster",
+)
+_SPC_ID = generate_resource_id(
+    resource_group_name=_RG,
+    resource_provider="Microsoft.SecretSyncController",
+    resource_path="/azureKeyVaultSecretProviderClasses/my-spc",
+)
+
+
+# ---------------------------------------------------------------------------
+# URL endpoint builders
+# ---------------------------------------------------------------------------
+
+
+def _build_instance_endpoint(name: str, rg: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.IoTOperations/instances/{name}"
+        f"?api-version={IOTOPS_API_VERSION}"
+    )
+
+
+def _build_instances_list_endpoint(rg: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.IoTOperations/instances"
+        f"?api-version={IOTOPS_API_VERSION}"
+    )
+
+
+def _build_cluster_endpoint(rg: str, cluster_name: str) -> str:
+    # connectedclustermgmt uses lowercase 'resourcegroups'.
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourcegroups/{rg}"
+        f"/providers/Microsoft.Kubernetes/connectedClusters/{cluster_name}"
+        f"?api-version={CONNECTEDK8S_API_VERSION}"
+    )
+
+
+def _build_cl_list_endpoint(rg: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.ExtendedLocation/customLocations"
+        f"?api-version={CUSTOM_LOCATIONS_API_VERSION}"
+    )
+
+
+def _build_sync_rules_list_endpoint(rg: str, cl_name: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.ExtendedLocation/customLocations/{cl_name}"
+        f"/resourceSyncRules?api-version={CUSTOM_LOCATIONS_API_VERSION}"
+    )
+
+
+def _build_extensions_list_endpoint(rg: str, cluster_name: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.Kubernetes/connectedClusters/{cluster_name}"
+        f"/providers/Microsoft.KubernetesConfiguration/extensions"
+        f"?api-version={CLUSTER_EXTENSIONS_API_VERSION}"
+    )
+
+
+def _build_extension_delete_endpoint(rg: str, cluster_name: str, ext_name: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.Kubernetes/connectedClusters/{cluster_name}"
+        f"/providers/Microsoft.KubernetesConfiguration/extensions/{ext_name}"
+        f"?api-version={CLUSTER_EXTENSIONS_API_VERSION}"
+    )
+
+
+def _build_resource_endpoint(resource_id: str, api_version: str) -> str:
+    """Build endpoint for generic resource operations (get_by_id, begin_delete_by_id)."""
+    return f"{BASE_URL}{resource_id}?api-version={api_version}"
+
+
+# Regex patterns for dynamic endpoint matching.
+_ARG_ENDPOINT_RE = re.compile(
+    r"https://management\.azure\.com/providers/Microsoft\.ResourceGraph/resources"
+)
+_DELETE_ENDPOINT_RE = re.compile(r"https://management\.azure\.com/.*")
+
+
+# ---------------------------------------------------------------------------
+# Mock registration helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_instance_discovery(
+    rsps: responses.RequestsMock,
+    *,
+    name: str = "myinst",
+    version: str = "1.2.0",
+    spc_id: str = "",
+    connectivity: str = "Connected",
+) -> None:
+    """Register GET mocks for the instance-name discovery path: instance → CL → cluster."""
+    rsps.assert_all_requests_are_fired = False
+    inst = _build_instance(name=name, rg=_RG, cl_id=_CL_ID, spc_id=spc_id, version=version)
+    rsps.add(method=responses.GET, url=_build_instance_endpoint(name, _RG), json=inst, status=200)
+    rsps.add(
+        method=responses.GET,
+        url=_build_resource_endpoint(_CL_ID, CUSTOM_LOCATIONS_API_VERSION),
+        json={
+            "id": _CL_ID, "name": "mycl",
+            "properties": {"hostResourceId": _CLUSTER_ID, "namespace": "azure-iot-operations"},
+        },
+        status=200,
+    )
+    rsps.add(
+        method=responses.GET,
+        url=_build_cluster_endpoint(_RG, "mycluster"),
+        json={"id": _CLUSTER_ID, "properties": {"connectivityStatus": connectivity}},
+        status=200,
+    )
+
+
+def _register_cluster_discovery(
+    rsps: responses.RequestsMock,
+    *,
+    cluster_name: str = "mycluster",
+    connectivity: str = "Connected",
+) -> None:
+    """Register GET mock for the cluster-name discovery path: cluster show."""
+    rsps.assert_all_requests_are_fired = False
+    rsps.add(
+        method=responses.GET,
+        url=_build_cluster_endpoint(_RG, cluster_name),
+        json={"id": _CLUSTER_ID, "properties": {"connectivityStatus": connectivity}},
+        status=200,
+    )
+
+
+def _register_extensions(
+    rsps: responses.RequestsMock, extensions: Optional[List[dict]] = None,
+) -> None:
+    """Register extensions list GET mock."""
+    rsps.add(
+        method=responses.GET,
+        url=_build_extensions_list_endpoint(_RG, "mycluster"),
+        json={"value": extensions or []},
+        status=200,
+    )
+
+
+def _register_cl_list(
+    rsps: responses.RequestsMock, cls: Optional[List[dict]] = None,
+) -> None:
+    """Register custom locations list GET mock."""
+    rsps.add(
+        method=responses.GET,
+        url=_build_cl_list_endpoint(_RG),
+        json={"value": cls or []},
+        status=200,
+    )
+
+
+def _register_instances_list(
+    rsps: responses.RequestsMock, instances: Optional[List[dict]] = None,
+) -> None:
+    """Register instances list GET mock."""
+    rsps.add(
+        method=responses.GET,
+        url=_build_instances_list_endpoint(_RG),
+        json={"value": instances or []},
+        status=200,
+    )
+
+
+def _register_sync_rules(
+    rsps: responses.RequestsMock, rules: Optional[List[dict]] = None, cl_name: str = "mycl",
+) -> None:
+    """Register sync rules list GET mock."""
+    rsps.add(
+        method=responses.GET,
+        url=_build_sync_rules_list_endpoint(_RG, cl_name),
+        json={"value": rules or []},
+        status=200,
+    )
+
+
+def _register_arg_sweep(
+    rsps: responses.RequestsMock, data: Optional[List[dict]] = None,
+) -> None:
+    """Register ARG sweep POST mock."""
+    sweep_data = data or []
+    rsps.add(
+        method=responses.POST,
+        url=_ARG_ENDPOINT_RE,
+        json={"data": sweep_data, "count": len(sweep_data), "totalRecords": len(sweep_data)},
+        status=200,
+    )
+
+
+def _register_delete_handler(rsps: responses.RequestsMock) -> None:
+    """Register a catch-all DELETE handler returning 200 (success).
+
+    Uses add_callback so it persists across multiple DELETE calls.
+    For error simulation, register a specific DELETE mock BEFORE this handler.
+    """
+    def _handle_delete(request):
+        return (200, {"content-type": "application/json"}, json.dumps({}))
+
+    rsps.add_callback(method=responses.DELETE, url=_DELETE_ENDPOINT_RE, callback=_handle_delete)
 
 
 # ---------------------------------------------------------------------------
@@ -55,79 +276,6 @@ def suppress_display(mocker):
 # ---------------------------------------------------------------------------
 # Shared mock fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def mocked_get_resource_client(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.get_resource_client", autospec=True
-    )
-    # begin_delete_by_id returns a mock poller by default.
-    mock_poller = MagicMock()
-    mock_poller.done.return_value = True
-    mock_poller.result.return_value = None
-    patched.return_value.resources.begin_delete_by_id.return_value = mock_poller
-    patched.return_value.resources.get_by_id.return_value = {
-        "properties": {"hostResourceId": ""},
-    }
-    yield patched
-
-
-@pytest.fixture
-def mocked_instances(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.Instances", autospec=True
-    )
-    yield patched
-
-
-@pytest.fixture
-def mocked_connected_clusters(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.ConnectedClusters", autospec=True
-    )
-    patched.return_value.show.return_value = {
-        "id": generate_resource_id(
-            resource_group_name="rg1",
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        ),
-        "properties": {"connectivityStatus": "Connected"},
-    }
-    yield patched
-
-
-@pytest.fixture
-def mocked_custom_locations(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.CustomLocations", autospec=True
-    )
-    patched.return_value.list.return_value = []
-    patched.return_value.list_resource_sync_rules.return_value = []
-    yield patched
-
-
-@pytest.fixture
-def mocked_cluster_extensions(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.ClusterExtensions"
-    )
-    patched.return_value.list.return_value = []
-    # ops.begin_delete returns a mock poller (used by _begin_delete_extension).
-    mock_poller = MagicMock()
-    mock_poller.done.return_value = True
-    mock_poller.result.return_value = None
-    patched.return_value.ops.begin_delete.return_value = mock_poller
-    yield patched
-
-
-@pytest.fixture
-def mocked_resource_graph(mocker):
-    patched = mocker.patch(
-        "azext_edge.edge.providers.orchestration.deletion2.ResourceGraph", autospec=True
-    )
-    patched.return_value.query_resources.return_value = {"data": []}
-    yield patched
 
 
 @pytest.fixture
@@ -187,16 +335,21 @@ def _build_cl(
     name: str = "mycl",
     rg: str = "rg1",
     host_resource_id: str = "",
+    namespace: str = "azure-iot-operations",
+    cluster_extension_ids: Optional[List[str]] = None,
 ) -> dict:
     cl_id = generate_resource_id(
         resource_group_name=rg,
         resource_provider="Microsoft.ExtendedLocation",
         resource_path=f"/customLocations/{name}",
     )
+    props: dict = {"hostResourceId": host_resource_id, "namespace": namespace}
+    if cluster_extension_ids is not None:
+        props["clusterExtensionIds"] = cluster_extension_ids
     return {
         "id": cl_id,
         "name": name,
-        "properties": {"hostResourceId": host_resource_id},
+        "properties": props,
     }
 
 
@@ -237,38 +390,35 @@ def _build_sync_rule(name: str = "aio-sync", rg: str = "rg1", cl_name: str = "my
 
 
 class TestDeleteOpsResourcesEntryPoint:
-    def test_no_instance_or_cluster_raises(self, mocked_cmd, mocked_get_resource_client):
+    def test_no_instance_or_cluster_raises(self, mocked_cmd):
         with pytest.raises(ArgumentUsageError, match="instance name or cluster name"):
             delete_ops_resources(cmd=mocked_cmd, resource_group_name="rg1")
 
     def test_delegates_to_manager(
         self,
-        mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
-        cl_id = "/subscriptions/00/resourceGroups/rg1/providers/Microsoft.ExtendedLocation/customLocations/cl1"
-        inst = _build_instance(cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": ""},
-        }
+        _register_instance_discovery(mocked_responses, name="myinstance")
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         delete_ops_resources(
             cmd=mocked_cmd,
-            resource_group_name="rg1",
+            resource_group_name=_RG,
             instance_name="myinstance",
             confirm_yes=True,
             no_progress=True,
         )
-        mocked_instances.return_value.show.assert_called_once()
+        # Verify instance GET was made.
+        instance_gets = [
+            c for c in mocked_responses.calls
+            if c.request.method == "GET" and "instances/myinstance" in c.request.url
+        ]
+        assert len(instance_gets) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -280,17 +430,20 @@ class TestInstanceNamePath:
     def test_instance_not_found_raises(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
+        mocked_responses,
     ):
         """Instance 404 on instance-name path → clear error directing to --cluster."""
-        mocked_instances.return_value.show.side_effect = HttpResponseError(
-            message="Not found", response=Mock(status_code=404)
+        mocked_responses.assert_all_requests_are_fired = False
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_instance_endpoint("ghost", _RG),
+            json={"error": {"code": "ResourceNotFound"}},
+            status=404,
         )
         with pytest.raises(ResourceNotFoundError, match="--cluster"):
             delete_ops_resources(
                 cmd=mocked_cmd,
-                resource_group_name="rg1",
+                resource_group_name=_RG,
                 instance_name="ghost",
                 confirm_yes=True,
             )
@@ -298,41 +451,18 @@ class TestInstanceNamePath:
     def test_discovers_instance_cl_cluster(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Instance-name path: discovers instance, CL, and cluster from ARM GETs."""
-        rg = "rg1"
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, version="1.2.0")
-        mocked_instances.return_value.show.return_value = inst
-
-        # CL GET returns hostResourceId pointing to cluster.
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -346,70 +476,54 @@ class TestInstanceNamePath:
     def test_spc_extracted_from_instance(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """SPC resource ID from instance properties is added to CL resources."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        spc_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.SecretSyncController",
-            resource_path="/azureKeyVaultSecretProviderClasses/my-spc",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, spc_id=spc_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses, spc_id=_SPC_ID)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         spc_ids = [r.resource_id for r in manager._cl_resources]
-        assert spc_id in spc_ids
+        assert _SPC_ID in spc_ids
 
     def test_cl_resolution_failure_continues(
         self,
         mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """CL get_by_id raises HttpResponseError → cluster stays None, deletion continues."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
+        mocked_responses.assert_all_requests_are_fired = False
+        inst = _build_instance(name="myinst", rg=_RG, cl_id=_CL_ID)
+        mocked_responses.add(
+            method=responses.GET, url=_build_instance_endpoint("myinst", _RG), json=inst, status=200,
         )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-
-        # CL resolution fails.
-        mocked_get_resource_client.return_value.resources.get_by_id.side_effect = HttpResponseError(
-            message="Internal error", response=Mock(status_code=500)
+        # CL resolution fails — 500 on get_by_id.
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_resource_endpoint(_CL_ID, CUSTOM_LOCATIONS_API_VERSION),
+            json={"error": {"code": "InternalServerError"}},
+            status=500,
         )
+        # Extensions, sync rules, and ARG are still attempted after CL resolution failure.
+        # Note: _discover_extensions() returns early (cluster_name is None).
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -432,36 +546,27 @@ class TestClusterNamePath:
     def test_discovers_instance_via_cl_filter(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Cluster-name path: list CLs + instances, filter by cluster → discovers instance."""
-        rg = "rg1"
-        cluster_name = "mycluster"
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path=f"/connectedClusters/{cluster_name}",
-        )
-        cl = _build_cl(name="mycl", rg=rg, host_resource_id=cluster_id)
-        cl_id = cl["id"]
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
+        _register_cluster_discovery(mocked_responses)
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
 
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-        mocked_custom_locations.return_value.list.return_value = [cl]
-        mocked_instances.return_value.list.return_value = [inst]
+        cl = _build_cl(
+            name="mycl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            cluster_extension_ids=[aio_ext["id"]],
+        )
+        inst = _build_instance(name="myinst", rg=_RG, cl_id=cl["id"])
+        _register_cl_list(mocked_responses, cls=[cl])
+        _register_instances_list(mocked_responses, instances=[inst])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, cluster_name=cluster_name, resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -472,43 +577,205 @@ class TestClusterNamePath:
     def test_no_instance_found_still_cleans_up(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Cluster-name path: no instance found → skips step 1, still cleans CL + extensions."""
-        rg = "rg1"
-        cluster_name = "mycluster"
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path=f"/connectedClusters/{cluster_name}",
-        )
-        cl = _build_cl(name="mycl", rg=rg, host_resource_id=cluster_id)
-
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-        mocked_custom_locations.return_value.list.return_value = [cl]
-        mocked_instances.return_value.list.return_value = []  # No instance.
-
-        # Add an extension so there's work to do.
+        _register_cluster_discovery(mocked_responses)
         ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
-        mocked_cluster_extensions.return_value.list.return_value = [ext]
+        _register_extensions(mocked_responses, extensions=[ext])
+
+        cl = _build_cl(
+            name="mycl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            cluster_extension_ids=[ext["id"]],
+        )
+        _register_cl_list(mocked_responses, cls=[cl])
+        _register_instances_list(mocked_responses, instances=[])  # No instance.
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, cluster_name=cluster_name, resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         assert manager._instance_resource is None
         assert manager._cl_resource is not None
+        assert manager._aio_extension is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: CL Identification (cluster-name path)
+# ---------------------------------------------------------------------------
+
+
+class TestClIdentification:
+    """Tiered CL identification when multiple CLs share the same host cluster."""
+
+    def test_tier1_picks_cl_by_extension_type(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Tier 1: CL with type-verified extension ID in clusterExtensionIds is chosen."""
+        _register_cluster_discovery(mocked_responses)
+
+        # AIO extension with a user-chosen name.
+        aio_ext = _build_extension(name="my-custom-aio", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+
+        # Two CLs on same host: CL1 has matching ext ID, CL2 has AIO namespace.
+        cl_aio = _build_cl(
+            name="aio-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="custom-ns",
+            cluster_extension_ids=[aio_ext["id"]],
+        )
+        cl_other = _build_cl(
+            name="other-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="azure-iot-operations",
+        )
+        _register_cl_list(mocked_responses, cls=[cl_aio, cl_other])
+        _register_instances_list(mocked_responses, instances=[])
+        _register_sync_rules(mocked_responses, cl_name="aio-cl")
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        # Tier 1 should pick cl_aio (ext ID match), not cl_other (namespace match).
+        assert manager._cl_resource is not None
+        assert manager._cl_resource.display_name == "aio-cl"
+
+    def test_tier2_namespace_fallback(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Tier 2: namespace match when no extension IDs match (extensions deleted)."""
+        _register_cluster_discovery(mocked_responses)
+
+        # No extensions found (already deleted).
+        _register_extensions(mocked_responses, extensions=[])
+
+        # Two CLs: one AIO namespace, one non-AIO.
+        cl_aio = _build_cl(
+            name="aio-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="azure-iot-operations",
+        )
+        cl_other = _build_cl(
+            name="other-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="other-service",
+        )
+        _register_cl_list(mocked_responses, cls=[cl_other, cl_aio])
+        _register_instances_list(mocked_responses, instances=[])
+        _register_sync_rules(mocked_responses, cl_name="aio-cl")
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        assert manager._cl_resource is not None
+        assert manager._cl_resource.display_name == "aio-cl"
+
+    def test_no_tier_match_raises_error(
+        self,
+        mocked_cmd,
+        mocked_responses,
+    ):
+        """No tier match: raises ResourceNotFoundError when CLs exist but none are AIO."""
+        _register_cluster_discovery(mocked_responses)
+        _register_extensions(mocked_responses, extensions=[])
+
+        cl = _build_cl(
+            name="non-aio-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="other-service",
+        )
+        _register_cl_list(mocked_responses, cls=[cl])
+
+        with pytest.raises(ResourceNotFoundError, match="Could not identify"):
+            delete_ops_resources(
+                cmd=mocked_cmd,
+                resource_group_name=_RG,
+                cluster_name="mycluster",
+                confirm_yes=True,
+                no_progress=True,
+            )
+
+    def test_tier1_rejects_cl_with_non_aio_extensions(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Tier 1: CL referencing non-AIO extension IDs is not matched — falls through to Tier 2."""
+        _register_cluster_discovery(mocked_responses)
+
+        # AIO extension exists on the cluster.
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+
+        # CL1 references a non-AIO extension (unknown type, not in _AIO_EXTENSION_TYPES).
+        foreign_ext_id = generate_resource_id(
+            resource_group_name=_RG,
+            resource_provider="Microsoft.KubernetesConfiguration",
+            resource_path="/extensions/foreign-svc",
+        )
+        cl_foreign = _build_cl(
+            name="foreign-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="foreign-ns",
+            cluster_extension_ids=[foreign_ext_id],
+        )
+        # CL2 is the real AIO CL with matching ext ID.
+        cl_aio = _build_cl(
+            name="aio-cl", rg=_RG, host_resource_id=_CLUSTER_ID,
+            namespace="custom-ns",
+            cluster_extension_ids=[aio_ext["id"]],
+        )
+        _register_cl_list(mocked_responses, cls=[cl_foreign, cl_aio])
+        _register_instances_list(mocked_responses, instances=[])
+        _register_sync_rules(mocked_responses, cl_name="aio-cl")
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        # Tier 1 should skip cl_foreign (ext ID not type-verified) and pick cl_aio.
+        assert manager._cl_resource is not None
+        assert manager._cl_resource.display_name == "aio-cl"
+
+    def test_no_cls_on_host_continues(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """No CLs on this host: CL stays None, extensions still cleaned up."""
+        _register_cluster_discovery(mocked_responses)
+
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_cl_list(mocked_responses, cls=[])
+        # No _register_instances_list — CL is None so instances list must not be called.
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        assert manager._cl_resource is None
         assert manager._aio_extension is not None
 
 
@@ -521,44 +788,22 @@ class TestExtensionDiscovery:
     def test_aio_extension_always_found(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """AIO extension is always discovered regardless of --include-deps."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
 
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="1.2.0")
         cm_ext = _build_extension(name="cm-ext", extension_type=EXTENSION_TYPE_CM)
-        mocked_cluster_extensions.return_value.list.return_value = [aio_ext, cm_ext]
+        _register_extensions(mocked_responses, extensions=[aio_ext, cm_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         # Without --include-deps.
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -572,6 +817,8 @@ class TestExtensionDiscovery:
             ("1.0.0", True),
             (_ACS_ABOVE, False),
             ("2.0.0", False),
+            ("not-a-version", False),
+            ("", False),
         ],
     )
     def test_acs_version_gating(
@@ -579,36 +826,11 @@ class TestExtensionDiscovery:
         aio_version: str,
         expect_acs: bool,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """ACS extension included only when AIO version <= threshold."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, version=aio_version)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses, version=aio_version)
 
         extensions = [
             _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version=aio_version),
@@ -616,21 +838,21 @@ class TestExtensionDiscovery:
             _build_extension(name="cm-ext", extension_type=EXTENSION_TYPE_CM),
             _build_extension(name="ssc-ext", extension_type=EXTENSION_TYPE_SSC),
         ]
-        mocked_cluster_extensions.return_value.list.return_value = extensions
+        _register_extensions(mocked_responses, extensions=extensions)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
             cmd=mocked_cmd,
             instance_name="myinst",
-            resource_group_name=rg,
+            resource_group_name=_RG,
             include_dependencies=True,
             no_progress=True,
         )
         manager.do_work(confirm_yes=True)
 
-        dep_types = []
-        for ext in manager._dep_extensions:
-            # Check the resource_id for the extension type name.
-            dep_types.append(ext.display_name)
+        dep_types = [ext.display_name for ext in manager._dep_extensions]
 
         if expect_acs:
             assert "acs-ext" in dep_types
@@ -644,47 +866,25 @@ class TestExtensionDiscovery:
     def test_platform_extension_included_as_dep(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Platform extension (deprecated CM) is included in deps when --include-deps."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, version="1.2.0")
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
 
         extensions = [
             _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="1.2.0"),
             _build_extension(name="plat-ext", extension_type=EXTENSION_TYPE_PLATFORM),
         ]
-        mocked_cluster_extensions.return_value.list.return_value = extensions
+        _register_extensions(mocked_responses, extensions=extensions)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
             cmd=mocked_cmd,
             instance_name="myinst",
-            resource_group_name=rg,
+            resource_group_name=_RG,
             include_dependencies=True,
             no_progress=True,
         )
@@ -692,110 +892,6 @@ class TestExtensionDiscovery:
 
         dep_names = [e.display_name for e in manager._dep_extensions]
         assert "plat-ext" in dep_names
-
-    def test_acs_version_gating_invalid_version(
-        self,
-        mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
-        mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
-    ):
-        """Unparseable AIO version → ACS preserved (safer for destructive operations)."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, version="not-a-version")
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-
-        extensions = [
-            _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="not-a-version"),
-            _build_extension(name="acs-ext", extension_type=EXTENSION_TYPE_ACS),
-        ]
-        mocked_cluster_extensions.return_value.list.return_value = extensions
-
-        manager = DeletionManager(
-            cmd=mocked_cmd,
-            instance_name="myinst",
-            resource_group_name=rg,
-            include_dependencies=True,
-            no_progress=True,
-        )
-        manager.do_work(confirm_yes=True)
-
-        dep_names = [e.display_name for e in manager._dep_extensions]
-        assert "acs-ext" not in dep_names
-
-    def test_acs_version_gating_empty_version(
-        self,
-        mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
-        mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
-    ):
-        """Empty AIO version on both extension and instance → ACS preserved."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, version="")
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-
-        extensions = [
-            _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version=""),
-            _build_extension(name="acs-ext", extension_type=EXTENSION_TYPE_ACS),
-        ]
-        mocked_cluster_extensions.return_value.list.return_value = extensions
-
-        manager = DeletionManager(
-            cmd=mocked_cmd,
-            instance_name="myinst",
-            resource_group_name=rg,
-            include_dependencies=True,
-            no_progress=True,
-        )
-        manager.do_work(confirm_yes=True)
-
-        dep_names = [e.display_name for e in manager._dep_extensions]
-        assert "acs-ext" not in dep_names
 
 
 # ---------------------------------------------------------------------------
@@ -807,39 +903,18 @@ class TestConnectivityGate:
     def test_disconnected_without_force_raises(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
     ):
         """Disconnected cluster without --force → error before prompt."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Disconnected"},
-        }
+        _register_instance_discovery(mocked_responses, connectivity="Disconnected")
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
 
         with pytest.raises(ArgumentUsageError, match="not connected"):
             delete_ops_resources(
                 cmd=mocked_cmd,
-                resource_group_name=rg,
+                resource_group_name=_RG,
                 instance_name="myinst",
                 confirm_yes=True,
             )
@@ -847,41 +922,20 @@ class TestConnectivityGate:
     def test_disconnected_with_force_proceeds(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Disconnected cluster with --force → proceeds with deletion."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Disconnected"},
-        }
+        _register_instance_discovery(mocked_responses, connectivity="Disconnected")
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         # Should not raise.
         delete_ops_resources(
             cmd=mocked_cmd,
-            resource_group_name=rg,
+            resource_group_name=_RG,
             instance_name="myinst",
             confirm_yes=True,
             force=True,
@@ -899,34 +953,28 @@ class TestSyncRulesDiscovery:
         self,
         mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """list_resource_sync_rules raises HttpResponseError → warning logged, deletion continues."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
 
-        # Sync rules list fails.
-        mocked_custom_locations.return_value.list_resource_sync_rules.side_effect = HttpResponseError(
-            message="Service unavailable", response=Mock(status_code=503)
+        # Sync rules list returns 503 instead of success.
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_sync_rules_list_endpoint(_RG, "mycl"),
+            status=503,
+            json={"error": {"code": "ServiceUnavailable", "message": "Service unavailable"}},
         )
+
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -946,42 +994,30 @@ class TestArgSweep:
     def test_sweep_adds_resources(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """ARG sweep returns DR assets + SecretSync → added to CL resources."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
 
         asset_id = generate_resource_id(
-            resource_group_name=rg,
+            resource_group_name=_RG,
             resource_provider="Microsoft.DeviceRegistry",
             resource_path="/assets/sensor1",
         )
-        mocked_resource_graph.return_value.query_resources.return_value = {
-            "data": [
-                {
-                    "id": asset_id, "name": "sensor1",
-                    "apiVersion": "2024-09-01-preview",
-                    "type": "microsoft.deviceregistry/assets",
-                },
-            ]
-        }
+        _register_arg_sweep(mocked_responses, data=[
+            {
+                "id": asset_id, "name": "sensor1",
+                "apiVersion": "2024-09-01-preview",
+                "type": "microsoft.deviceregistry/assets",
+            },
+        ])
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -992,45 +1028,33 @@ class TestArgSweep:
         self,
         mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """ARG sweep failure → warning logged, deletion continues with SPC from instance."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        spc_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.SecretSyncController",
-            resource_path="/azureKeyVaultSecretProviderClasses/my-spc",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, spc_id=spc_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses, spc_id=_SPC_ID)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
 
-        # ARG sweep fails with a realistic HTTP error.
-        mocked_resource_graph.return_value.query_resources.side_effect = HttpResponseError(
+        # ARG sweep fails — mock ResourceGraph to raise HttpResponseError.
+        mocker.patch(
+            "azext_edge.edge.providers.orchestration.deletion2.ResourceGraph"
+        ).return_value.query_resources.side_effect = HttpResponseError(
             message="429 throttled", response=Mock(status_code=429)
         )
+
+        _register_delete_handler(mocked_responses)
 
         mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         # SPC from instance ref is still present.
         spc_ids = [r.resource_id for r in manager._cl_resources]
-        assert spc_id in spc_ids
+        assert _SPC_ID in spc_ids
         # Warning was logged about sweep failure.
         warning_messages = [str(c.args[0]) for c in mock_logger.warning.call_args_list]
         assert any("CL-scoped resources" in msg for msg in warning_messages)
@@ -1038,61 +1062,35 @@ class TestArgSweep:
     def test_sweep_deduplicates_spc(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """ARG sweep returning same SPC as instance ref → deduplicated."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        spc_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.SecretSyncController",
-            resource_path="/azureKeyVaultSecretProviderClasses/my-spc",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id, spc_id=spc_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses, spc_id=_SPC_ID)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
 
         # ARG returns the same SPC.
-        mocked_resource_graph.return_value.query_resources.return_value = {
-            "data": [
-                {
-                    "id": spc_id, "name": "my-spc",
-                    "apiVersion": SECRET_SYNC_API_VERSION,
-                    "type": "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
-                },
-            ]
-        }
+        _register_arg_sweep(mocked_responses, data=[
+            {
+                "id": _SPC_ID, "name": "my-spc",
+                "apiVersion": SECRET_SYNC_API_VERSION,
+                "type": "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            },
+        ])
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         # SPC should appear exactly once.
-        spc_matches = [r for r in manager._cl_resources if r.resource_id.lower() == spc_id.lower()]
+        spc_matches = [r for r in manager._cl_resources if r.resource_id.lower() == _SPC_ID.lower()]
         assert len(spc_matches) == 1
 
     def test_sweep_excludes_iotops_namespaces_and_registries(
         self,
-        mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
-        mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Verify the KQL query uses exclusion-list: skips IoT Ops, DR namespaces, schema registries."""
         query_lower = _ARG_SWEEP_QUERY.lower()
@@ -1113,142 +1111,206 @@ class TestDeletionOrder:
     def test_instance_deleted_before_aio_extension(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
-        """Instance (step 1) is deleted before AIO extension (step 2)."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        """Instance (step 1) is deleted before AIO extension (step 5)."""
+        _register_instance_discovery(mocked_responses)
 
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
-        mocked_cluster_extensions.return_value.list.return_value = [aio_ext]
-
-        # Track delete call order across both resource client and extensions client.
-        delete_order: List[str] = []
-        mock_poller = mocked_get_resource_client.return_value.resources.begin_delete_by_id.return_value
-        ext_mock_poller = mocked_cluster_extensions.return_value.ops.begin_delete.return_value
-
-        def track_resource_delete(resource_id, **kwargs):
-            delete_order.append(resource_id)
-            return mock_poller
-
-        def track_extension_delete(**kwargs):
-            delete_order.append(f"extension:{kwargs.get('extension_name', '')}")
-            return ext_mock_poller
-
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = track_resource_delete
-        mocked_cluster_extensions.return_value.ops.begin_delete.side_effect = track_extension_delete
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         # Instance should be deleted before extension.
-        instance_idx = next(i for i, rid in enumerate(delete_order) if "instances/myinst" in rid.lower())
-        ext_idx = next(i for i, rid in enumerate(delete_order) if "extension:aio-ext" in rid.lower())
+        delete_urls = [c.request.url for c in mocked_responses.calls if c.request.method == "DELETE"]
+        instance_idx = next(i for i, url in enumerate(delete_urls) if "instances/myinst" in url.lower())
+        ext_idx = next(i for i, url in enumerate(delete_urls) if "/extensions/aio-ext" in url.lower())
         assert instance_idx < ext_idx
 
     def test_cl_resources_deleted_before_cl(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
-        """CL resources (step 3) and sync rules (step 4) deleted before CL (step 5)."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        """CL resources (step 2) and sync rules (step 3) deleted before CL (step 4)."""
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
 
         # Add a sync rule.
-        sync_rule = _build_sync_rule(name="aio-sync", rg=rg, cl_name="mycl")
-        mocked_custom_locations.return_value.list_resource_sync_rules.return_value = [sync_rule]
+        sync_rule = _build_sync_rule(name="aio-sync", rg=_RG, cl_name="mycl")
+        _register_sync_rules(mocked_responses, rules=[sync_rule])
 
         # Add a CL resource from ARG sweep.
         asset_id = generate_resource_id(
-            resource_group_name=rg,
+            resource_group_name=_RG,
             resource_provider="Microsoft.DeviceRegistry",
             resource_path="/assets/sensor1",
         )
-        mocked_resource_graph.return_value.query_resources.return_value = {
-            "data": [
-                {
-                    "id": asset_id, "name": "sensor1",
-                    "apiVersion": "2024-09-01-preview",
-                    "type": "microsoft.deviceregistry/assets",
-                },
-            ]
-        }
-
-        delete_order: List[str] = []
-        mock_poller = mocked_get_resource_client.return_value.resources.begin_delete_by_id.return_value
-
-        def track_delete(resource_id, **kwargs):
-            delete_order.append(resource_id)
-            return mock_poller
-
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = track_delete
+        _register_arg_sweep(mocked_responses, data=[
+            {
+                "id": asset_id, "name": "sensor1",
+                "apiVersion": "2024-09-01-preview",
+                "type": "microsoft.deviceregistry/assets",
+            },
+        ])
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         # Find indices.
+        delete_urls = [c.request.url for c in mocked_responses.calls if c.request.method == "DELETE"]
         cl_delete_idx = next(
             (
-                i for i, rid in enumerate(delete_order)
-                if "customlocations/mycl" in rid.lower()
-                and "resourcesyncrules" not in rid.lower()
+                i for i, url in enumerate(delete_urls)
+                if "customlocations/mycl" in url.lower()
+                and "resourcesyncrules" not in url.lower()
             ),
             None
         )
         if cl_delete_idx is not None:
             # Asset and sync rule should be before CL.
-            for rid in delete_order[:cl_delete_idx]:
-                rid_lower = rid.lower()
+            for url in delete_urls[:cl_delete_idx]:
+                url_lower = url.lower()
                 assert (
-                    "customlocations/mycl" not in rid_lower
-                    or "resourcesyncrules" in rid_lower
-                    or "assets" in rid_lower
-                    or "instances" in rid_lower
-                    or "extensions" in rid_lower
+                    "customlocations/mycl" not in url_lower
+                    or "resourcesyncrules" in url_lower
+                    or "assets" in url_lower
+                    or "instances" in url_lower
+                    or "extensions" in url_lower
                 )
+
+    def test_aio_extension_deleted_after_cl(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """AIO extension (step 5) deleted after custom location (step 4)."""
+        _register_instance_discovery(mocked_responses)
+
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        delete_urls = [c.request.url for c in mocked_responses.calls if c.request.method == "DELETE"]
+        cl_idx = next(
+            i for i, url in enumerate(delete_urls)
+            if "customlocations/mycl" in url.lower() and "resourcesyncrules" not in url.lower()
+        )
+        ext_idx = next(i for i, url in enumerate(delete_urls) if "/extensions/aio-ext" in url.lower())
+        assert cl_idx < ext_idx
+
+    def test_full_execution_order(
+        self,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Full 6-step ordering: instance → CL resources → sync rules → CL → AIO ext → dep ext."""
+        _register_instance_discovery(mocked_responses, spc_id=_SPC_ID)
+
+        # Extensions: AIO + CM dep.
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="1.2.0")
+        cm_ext = _build_extension(name="cm-ext", extension_type=EXTENSION_TYPE_CM)
+        _register_extensions(mocked_responses, extensions=[aio_ext, cm_ext])
+
+        # Sync rule.
+        sync_rule = _build_sync_rule(name="aio-sync", rg=_RG, cl_name="mycl")
+        _register_sync_rules(mocked_responses, rules=[sync_rule])
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+
+        manager = DeletionManager(
+            cmd=mocked_cmd,
+            instance_name="myinst",
+            resource_group_name=_RG,
+            include_dependencies=True,
+            no_progress=True,
+        )
+        manager.do_work(confirm_yes=True)
+
+        # Build index map by category.
+        delete_urls = [c.request.url for c in mocked_responses.calls if c.request.method == "DELETE"]
+
+        def find_idx(substring: str) -> int:
+            return next(i for i, url in enumerate(delete_urls) if substring in url.lower())
+
+        instance_idx = find_idx("instances/myinst")
+        spc_idx = find_idx("azurekeyvaultsecretproviderclasses")
+        sync_idx = find_idx("resourcesyncrules")
+        cl_idx = next(
+            i for i, url in enumerate(delete_urls)
+            if "customlocations/mycl" in url.lower() and "resourcesyncrules" not in url.lower()
+        )
+        aio_ext_idx = find_idx("/extensions/aio-ext")
+        dep_ext_idx = find_idx("/extensions/cm-ext")
+
+        # Verify strict step ordering.
+        assert instance_idx < spc_idx, "Instance must be before CL resources"
+        assert spc_idx < sync_idx, "CL resources must be before sync rules"
+        assert sync_idx < cl_idx, "Sync rules must be before CL"
+        assert cl_idx < aio_ext_idx, "CL must be before AIO extension"
+        assert aio_ext_idx < dep_ext_idx, "AIO extension must be before dep extensions"
+
+    def test_cl_delete_failure_continues_to_aio_extension(
+        self,
+        mocker,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """CL delete failure (step 4) → AIO extension (step 5) still executes."""
+        _register_instance_discovery(mocked_responses)
+
+        aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+
+        # CL DELETE returns 409 conflict. Register BEFORE catch-all (FIFO).
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=f"{BASE_URL}{_CL_ID}",
+            status=409,
+            json={"error": {"code": "Conflict", "message": "Conflict: resources still scoped"}},
+        )
+        _register_delete_handler(mocked_responses)
+
+        mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        # CL failure warning was logged.
+        warning_messages = [str(c.args[0]) for c in mock_logger.warning.call_args_list]
+        assert any("custom location" in msg.lower() for msg in warning_messages)
+
+        # AIO extension still ran despite CL failure.
+        ext_deletes = [
+            c for c in mocked_responses.calls
+            if c.request.method == "DELETE" and "/extensions/aio-ext" in c.request.url.lower()
+        ]
+        assert len(ext_deletes) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -1260,83 +1322,57 @@ class TestIdempotentRecovery:
     def test_404_on_delete_treated_as_success(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """404 during begin_delete_by_id → treated as success, execution continues."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+
+        # Instance DELETE returns 404 (already deleted). Register BEFORE catch-all (FIFO).
+        inst_id = generate_resource_id(
+            resource_group_name=_RG,
+            resource_provider="Microsoft.IoTOperations",
+            resource_path="/instances/myinst",
         )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-
-        # First delete (instance) returns 404, second (CL) succeeds.
-        mock_404_error = HttpResponseError(message="Not found", response=Mock(status_code=404))
-        mock_404_error.status_code = 404
-        mock_poller = MagicMock()
-        mock_poller.done.return_value = True
-        mock_poller.result.return_value = None
-
-        call_count = [0]
-
-        def conditional_delete(resource_id, **kwargs):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                raise mock_404_error
-            return mock_poller
-
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = conditional_delete
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=f"{BASE_URL}{inst_id}",
+            status=404,
+            json={"error": {"code": "ResourceNotFound", "message": "Not found"}},
+        )
+        _register_delete_handler(mocked_responses)
 
         # Should not raise.
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
     def test_partial_rerun_cluster_path(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Re-run after instance already deleted (cluster-name path) → proceeds with remaining."""
-        rg = "rg1"
-        cluster_name = "mycluster"
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path=f"/connectedClusters/{cluster_name}",
-        )
-        cl = _build_cl(name="mycl", rg=rg, host_resource_id=cluster_id)
+        _register_cluster_discovery(mocked_responses)
+        _register_extensions(mocked_responses, extensions=[])
 
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-        mocked_custom_locations.return_value.list.return_value = [cl]
-        mocked_instances.return_value.list.return_value = []  # Already deleted.
+        cl = _build_cl(name="mycl", rg=_RG, host_resource_id=_CLUSTER_ID)
+        _register_cl_list(mocked_responses, cls=[cl])
+        _register_instances_list(mocked_responses, instances=[])  # Already deleted.
 
         # Sync rules remain.
-        sync_rule = _build_sync_rule(name="aio-sync", rg=rg, cl_name="mycl")
-        mocked_custom_locations.return_value.list_resource_sync_rules.return_value = [sync_rule]
+        sync_rule = _build_sync_rule(name="aio-sync", rg=_RG, cl_name="mycl")
+        _register_sync_rules(mocked_responses, rules=[sync_rule])
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, cluster_name=cluster_name, resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -1348,33 +1384,30 @@ class TestIdempotentRecovery:
     def test_non_404_error_propagates(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Non-404 HttpResponseError during deletion → re-raised."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
 
-        mock_500_error = HttpResponseError(
-            message="Internal server error", response=Mock(status_code=500)
+        # Instance DELETE returns 500.
+        inst_id = generate_resource_id(
+            resource_group_name=_RG,
+            resource_provider="Microsoft.IoTOperations",
+            resource_path="/instances/myinst",
         )
-        mock_500_error.status_code = 500
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = mock_500_error
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=f"{BASE_URL}{inst_id}",
+            status=500,
+            json={"error": {"code": "InternalServerError", "message": "Internal server error"}},
+        )
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         with pytest.raises(HttpResponseError):
             manager.do_work(confirm_yes=True)
@@ -1382,50 +1415,30 @@ class TestIdempotentRecovery:
     def test_extension_404_treated_as_success(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """404 on extension begin_delete → treated as success, deletion continues."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
 
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
-        mocked_cluster_extensions.return_value.list.return_value = [aio_ext]
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
 
-        # Extension delete returns 404.
-        mock_404_error = HttpResponseError(
-            message="Not found", response=Mock(status_code=404)
+        # Extension DELETE returns 404. Register BEFORE catch-all (FIFO).
+        ext_url = _build_extension_delete_endpoint(_RG, "mycluster", "aio-ext")
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=ext_url,
+            status=404,
+            json={"error": {"code": "ResourceNotFound", "message": "Not found"}},
         )
-        mock_404_error.status_code = 404
-        mocked_cluster_extensions.return_value.ops.begin_delete.side_effect = mock_404_error
+        _register_delete_handler(mocked_responses)
 
         # Should not raise.
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -1433,65 +1446,33 @@ class TestIdempotentRecovery:
         self,
         mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """CL delete failure (e.g. orphaned resources) → logs warning, still deletes dep extensions."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
 
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="1.2.0")
         cm_ext = _build_extension(name="cm-ext", extension_type=EXTENSION_TYPE_CM)
-        mocked_cluster_extensions.return_value.list.return_value = [aio_ext, cm_ext]
+        _register_extensions(mocked_responses, extensions=[aio_ext, cm_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
 
-        # CL delete raises a conflict error (orphaned resources).
-        mock_conflict = HttpResponseError(
-            message="Conflict: resources still scoped", response=Mock(status_code=409)
+        # CL DELETE returns 409. Register BEFORE catch-all (FIFO).
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=f"{BASE_URL}{_CL_ID}",
+            status=409,
+            json={"error": {"code": "Conflict", "message": "Conflict: resources still scoped"}},
         )
-        mock_conflict.status_code = 409
-        mock_poller = MagicMock()
-        mock_poller.done.return_value = True
-
-        call_count = [0]
-
-        def conditional_delete(resource_id, **kwargs):
-            call_count[0] += 1
-            if "customlocations/mycl" in resource_id.lower() and "resourcesyncrules" not in resource_id.lower():
-                raise mock_conflict
-            return mock_poller
-
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = conditional_delete
+        _register_delete_handler(mocked_responses)
 
         mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
 
         manager = DeletionManager(
             cmd=mocked_cmd,
             instance_name="myinst",
-            resource_group_name=rg,
+            resource_group_name=_RG,
             include_dependencies=True,
             no_progress=True,
         )
@@ -1503,7 +1484,11 @@ class TestIdempotentRecovery:
         assert any("custom location" in msg.lower() and "--cluster" in msg for msg in warning_messages)
 
         # Dep extensions still ran.
-        mocked_cluster_extensions.return_value.ops.begin_delete.assert_called()
+        ext_deletes = [
+            c for c in mocked_responses.calls
+            if c.request.method == "DELETE" and "/extensions/" in c.request.url.lower()
+        ]
+        assert len(ext_deletes) >= 2  # AIO + CM
 
 
 # ---------------------------------------------------------------------------
@@ -1516,32 +1501,17 @@ class TestNothingToDelete:
         self,
         mocker,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
     ):
         """Cluster-name path with nothing found → warning logged, no prompt."""
-        rg = "rg1"
-        cluster_name = "mycluster"
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path=f"/connectedClusters/{cluster_name}",
-        )
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
-        mocked_custom_locations.return_value.list.return_value = []
-        mocked_instances.return_value.list.return_value = []
+        _register_cluster_discovery(mocked_responses)
+        _register_extensions(mocked_responses, extensions=[])
+        _register_cl_list(mocked_responses, cls=[])
 
         mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
 
         manager = DeletionManager(
-            cmd=mocked_cmd, cluster_name=cluster_name, resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, cluster_name="mycluster", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -1557,71 +1527,50 @@ class TestSegmentDepthBatching:
     def test_mixed_depth_resources_batched_correctly(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
-        mocked_wait_for_terminal_states,
     ):
         """Resources at different segment depths are batched and deleted deepest-first."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
 
         # Simulate DR resources at different depths from ARG sweep.
         deep_asset_id = generate_resource_id(
-            resource_group_name=rg,
+            resource_group_name=_RG,
             resource_provider="Microsoft.DeviceRegistry",
             resource_path="/namespaces/myns/assets/sensor1",
         )
         shallow_spc_id = generate_resource_id(
-            resource_group_name=rg,
+            resource_group_name=_RG,
             resource_provider="Microsoft.SecretSyncController",
             resource_path="/azureKeyVaultSecretProviderClasses/my-spc",
         )
-        mocked_resource_graph.return_value.query_resources.return_value = {
-            "data": [
-                {
-                    "id": deep_asset_id, "name": "sensor1",
-                    "apiVersion": "2024-09-01-preview",
-                    "type": "microsoft.deviceregistry/namespaces/assets",
-                },
-                {
-                    "id": shallow_spc_id, "name": "my-spc",
-                    "apiVersion": SECRET_SYNC_API_VERSION,
-                    "type": "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
-                },
-            ]
-        }
-
-        delete_order: List[str] = []
-        mock_poller = mocked_get_resource_client.return_value.resources.begin_delete_by_id.return_value
-
-        def track_delete(resource_id, **kwargs):
-            delete_order.append(resource_id)
-            return mock_poller
-
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.side_effect = track_delete
+        _register_arg_sweep(mocked_responses, data=[
+            {
+                "id": deep_asset_id, "name": "sensor1",
+                "apiVersion": "2024-09-01-preview",
+                "type": "microsoft.deviceregistry/namespaces/assets",
+            },
+            {
+                "id": shallow_spc_id, "name": "my-spc",
+                "apiVersion": SECRET_SYNC_API_VERSION,
+                "type": "microsoft.secretsynccontroller/azurekeyvaultsecretproviderclasses",
+            },
+        ])
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
         # Deep asset (more segments) should be deleted before shallow SPC.
-        if deep_asset_id in delete_order and shallow_spc_id in delete_order:
-            deep_idx = delete_order.index(deep_asset_id)
-            shallow_idx = delete_order.index(shallow_spc_id)
-            assert deep_idx < shallow_idx
+        delete_urls = [c.request.url for c in mocked_responses.calls if c.request.method == "DELETE"]
+        deep_match = [i for i, url in enumerate(delete_urls) if deep_asset_id.lower() in url.lower()]
+        shallow_match = [i for i, url in enumerate(delete_urls) if shallow_spc_id.lower() in url.lower()]
+        if deep_match and shallow_match:
+            assert deep_match[0] < shallow_match[0]
 
 
 # ---------------------------------------------------------------------------
@@ -1633,32 +1582,25 @@ class TestUserPrompt:
     def test_user_cancels_prompt(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
     ):
         """User declines confirmation → no deletion occurs."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+
         mocked_should_continue_prompt.return_value = False
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work()
 
         # No delete calls.
-        mocked_get_resource_client.return_value.resources.begin_delete_by_id.assert_not_called()
+        delete_calls = [c for c in mocked_responses.calls if c.request.method == "DELETE"]
+        assert len(delete_calls) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1670,27 +1612,18 @@ class TestApiVersions:
     def test_instance_uses_iotops_api_version(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Instance resource uses DEFAULT_IOTOPS_MGMT_API_VERSION."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -1699,27 +1632,18 @@ class TestApiVersions:
     def test_cl_uses_custom_locations_api_version(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """CL resource uses CUSTOM_LOCATIONS_API_VERSION."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
+        _register_instance_discovery(mocked_responses)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 
@@ -1728,42 +1652,20 @@ class TestApiVersions:
     def test_extensions_use_cluster_extensions_api_version(
         self,
         mocked_cmd,
-        mocked_get_resource_client,
-        mocked_instances,
-        mocked_connected_clusters,
-        mocked_custom_locations,
-        mocked_cluster_extensions,
-        mocked_resource_graph,
+        mocked_responses,
         mocked_should_continue_prompt,
-        mocked_wait_for_terminal_state,
     ):
         """Extensions use CLUSTER_EXTENSIONS_API_VERSION."""
-        rg = "rg1"
-        cl_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.ExtendedLocation",
-            resource_path="/customLocations/mycl",
-        )
-        cluster_id = generate_resource_id(
-            resource_group_name=rg,
-            resource_provider="Microsoft.Kubernetes",
-            resource_path="/connectedClusters/mycluster",
-        )
-        inst = _build_instance(name="myinst", rg=rg, cl_id=cl_id)
-        mocked_instances.return_value.show.return_value = inst
-        mocked_get_resource_client.return_value.resources.get_by_id.return_value = {
-            "properties": {"hostResourceId": cluster_id},
-        }
-        mocked_connected_clusters.return_value.show.return_value = {
-            "id": cluster_id,
-            "properties": {"connectivityStatus": "Connected"},
-        }
+        _register_instance_discovery(mocked_responses)
 
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS)
-        mocked_cluster_extensions.return_value.list.return_value = [aio_ext]
+        _register_extensions(mocked_responses, extensions=[aio_ext])
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
 
         manager = DeletionManager(
-            cmd=mocked_cmd, instance_name="myinst", resource_group_name=rg, no_progress=True
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
         )
         manager.do_work(confirm_yes=True)
 


### PR DESCRIPTION
Add two-tier custom location identification for cluster-name path:
- Tier 1: cross-reference CL clusterExtensionIds against type-verified AIO extensions discovered on the cluster
- Tier 2: fall back to namespace match (azure-iot-operations)
- Raise ResourceNotFoundError when CLs exist but none match

Reorder cluster-name path to discover extensions before CL identification so type-verified extension IDs are available for Tier 1 matching.

Move AIO extension deletion (step 5) after CL deletion (step 4) so CL soft-failure still allows extension cleanup.

Migrate deletion unit tests from mocker.patch provider-level mocking to responses library HTTP-level mocking.