### PR TITLE
Test: Fix keyvaultResourceId causing SPC PUT validation failure

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -40,7 +40,6 @@ from ..common import (
     CONTRIBUTOR_ROLE_ID,
     CUSTOM_LOCATIONS_API_VERSION,
     KEYVAULT_CLOUD_API_VERSION,
-    KEYVAULT_URL,
     IdentityUsageType,
     MANAGED_IDENTITY_API_VERSION,
 )
@@ -419,7 +418,6 @@ class Instances(Queryable):
                     "properties": {
                         "clientId": mi_user_assigned["properties"]["clientId"],
                         "keyvaultName": keyvault_resource_id_container.resource_name,
-                        "keyvaultResourceId": keyvault_resource_id_container.resource_id,
                         "tenantId": get_tenant_id(),
                     },
                     **spc_kwargs,
@@ -535,7 +533,6 @@ class Instances(Queryable):
             spc_name = spc["name"]
             spc_properties = spc.get("properties", {})
             keyvault_name = spc_properties["keyvaultName"]
-            keyvault_resource_id = spc_properties.get("keyvaultResourceId")
 
             # Parse secret_map into akv_name=target_key pairs
             secret_mappings = []
@@ -553,14 +550,9 @@ class Instances(Queryable):
 
             # Step 2: Verify each AKV secret exists and detect encoding
             keyvault_client = get_keyvault_client(subscription_id=self.default_subscription_id)
-            if keyvault_resource_id:
-                kv_resource = self.resource_client.resources.get_by_id(
-                    resource_id=keyvault_resource_id, api_version=KEYVAULT_CLOUD_API_VERSION
-                )
-                vault_url = kv_resource["properties"]["vaultUri"]
-            else:
-                # Fallback for instances where secretsync was enabled prior to this change
-                vault_url = KEYVAULT_URL.format(keyvaultName=keyvault_name)
+            from azure.cli.core import get_default_cli
+            vault_suffix = get_default_cli().cloud.suffixes.keyvault_dns
+            vault_url = f"https://{keyvault_name}{vault_suffix}/"
             for mapping in secret_mappings:
                 try:
                     secret_response = keyvault_client.get_secret(

--- a/azext_edge/tests/edge/orchestration/resources/test_secretsync_secret_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_secretsync_secret_unit.py
@@ -78,14 +78,6 @@ def _setup_instance_and_spc(
     else:
         spc_record["properties"]["objects"] = ""
 
-    # Store KV resource ID so set_secretsync_secret can resolve vault URI via ARM GET
-    kv_resource_id = generate_resource_id(
-        resource_group_name=resource_group_name,
-        resource_provider="Microsoft.KeyVault",
-        resource_path=f"/vaults/{keyvault_name}",
-    )
-    spc_record["properties"]["keyvaultResourceId"] = kv_resource_id
-
     mocked_responses.add(
         method=responses.GET,
         url=spc_endpoint,
@@ -97,25 +89,14 @@ def _setup_instance_and_spc(
     return instance_record, spc_record
 
 
-def _add_kv_arm_mock(
-    mocked_responses: responses,
-    resource_group_name: str,
-    keyvault_name: str,
-) -> None:
-    """Register the ARM Key Vault GET mock that returns vaultUri for vault URL resolution."""
-    kv_resource_id = generate_resource_id(
-        resource_group_name=resource_group_name,
-        resource_provider="Microsoft.KeyVault",
-        resource_path=f"/vaults/{keyvault_name}",
-    )
-    kv_arm_endpoint = f"{BASE_URL}{kv_resource_id}?api-version=2022-07-01"
-    mocked_responses.add(
-        method=responses.GET,
-        url=kv_arm_endpoint,
-        json={"properties": {"vaultUri": f"https://{keyvault_name}.vault.azure.net/"}},
-        status=200,
-        content_type="application/json",
-    )
+@pytest.fixture(autouse=True)
+def mocked_default_cli(mocker):
+    """Mock get_default_cli() so vault suffix resolves without a real CLI context."""
+    mock_cloud = mocker.MagicMock()
+    mock_cloud.suffixes.keyvault_dns = ".vault.azure.net"
+    mock_cli = mocker.MagicMock()
+    mock_cli.cloud = mock_cloud
+    mocker.patch("azure.cli.core.get_default_cli", return_value=mock_cli)
 
 
 # --- secretsync secret set ---
@@ -153,7 +134,6 @@ def test_secretsync_secret_set(
         spc_name=spc_name,
         keyvault_name=keyvault_name,
     )
-    _add_kv_arm_mock(mocked_responses, resource_group_name, keyvault_name)
 
     # Mock KV secret verification for each secret name
     for entry in secret_map:
@@ -279,7 +259,6 @@ def test_secretsync_secret_set_hex_encoding_detection(
         spc_name=spc_name,
         keyvault_name=keyvault_name,
     )
-    _add_kv_arm_mock(mocked_responses, resource_group_name, keyvault_name)
 
     # Mock KV GET — return secret with or without the file-encoding tag
     mocked_responses.add(
@@ -407,7 +386,6 @@ def test_secretsync_secret_set_akv_not_found(
         resource_group_name=resource_group_name,
         spc_name=spc_name,
     )
-    _add_kv_arm_mock(mocked_responses, resource_group_name, "mykeyvault")
 
     # Mock KV secret NOT found (404)
     mocked_responses.add(


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
