### PR TITLE
ci: default upload_wheel input to true in release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -21,7 +21,7 @@ on:
         description: Upload wheel to storage
         type: boolean
         required: false
-        default: false
+        default: true
 jobs:
   security:
     permissions:


### PR DESCRIPTION
Flips the default value of the upload_wheel workflow_dispatch input from false to true in release_workflow.yml