### PR TITLE
fix: use imageConfigurationSettings.tag for connector template create image tag

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -1043,16 +1043,30 @@ class ConnectorTemplates(Queryable):
 
         # Extract image settings from metadata
         registry, image_name = self._split_image_reference(connector_metadata_ref)
-        image_tag = metadata.get("imageConfigurationSettings", {}).get("tag", metadata.get("version", ""))
+        image_settings = metadata.get("imageConfigurationSettings", {})
+
+        # Build tagDigestSettings: prefer tag, then digest, then fall back to version
+        if "tag" in image_settings:
+            tag_digest_settings = {
+                "tagDigestType": "Tag",
+                "tag": image_settings["tag"]
+            }
+        elif "digest" in image_settings:
+            tag_digest_settings = {
+                "tagDigestType": "Digest",
+                "digest": image_settings["digest"]
+            }
+        else:
+            tag_digest_settings = {
+                "tagDigestType": "Tag",
+                "tag": metadata.get("version", "")
+            }
 
         # Build image configuration settings
         # API expects imageName WITHOUT registry reference
         image_config_settings = {
             "imageName": image_name,
-            "tagDigestSettings": {
-                "tagDigestType": "Tag",
-                "tag": image_tag
-            }
+            "tagDigestSettings": tag_digest_settings
         }
 
         # Add registry settings if we have a registry

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -1043,7 +1043,7 @@ class ConnectorTemplates(Queryable):
 
         # Extract image settings from metadata
         registry, image_name = self._split_image_reference(connector_metadata_ref)
-        image_tag = metadata.get("version", "")
+        image_tag = metadata.get("imageConfigurationSettings", {}).get("tag", metadata.get("version", ""))
 
         # Build image configuration settings
         # API expects imageName WITHOUT registry reference

--- a/azext_edge/tests/edge/orchestration/resources/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_connector_templates_unit.py
@@ -883,6 +883,68 @@ class TestBuildTemplateProperties:
 
         assert properties["diagnostics"]["logs"]["level"] == DEFAULT_LOG_LEVEL
 
+    def test_image_tag_from_image_configuration_settings_not_version(
+        self, mocked_cmd, mocked_get_iotops_mgmt_client
+    ):
+        """image tag must come from imageConfigurationSettings.tag, not metadata.version.
+
+        Regression test: create was using metadata.version instead of
+        imageConfigurationSettings.tag, causing wrong image tag when they differ.
+        """
+        provider = ConnectorTemplates(mocked_cmd)
+        metadata = get_sample_metadata(version="2.0.0")
+        # Deliberately set imageConfigurationSettings.tag to a different value
+        metadata["imageConfigurationSettings"]["tag"] = "2.0.1"
+        metadata_ref = "mcr.microsoft.com/test/connector-metadata:2.0.1"
+
+        properties = provider._build_template_properties(
+            metadata=metadata,
+            connector_metadata_ref=metadata_ref,
+            replicas=None,
+            log_level=None,
+            image_pull_policy=None,
+            image_pull_secrets=None,
+            allocation_policy=None,
+            bucket_size=None,
+            secrets=None,
+            storage_volumes=None,
+            connector_config=None,
+            trust_settings_secret_ref=None,
+        )
+
+        managed_config = properties["runtimeConfiguration"]["managedConfigurationSettings"]
+        image_config = managed_config["imageConfigurationSettings"]
+        # Must use imageConfigurationSettings.tag (2.0.1), not metadata.version (2.0.0)
+        assert image_config["tagDigestSettings"]["tag"] == "2.0.1"
+
+    def test_image_tag_falls_back_to_version_when_tag_absent(
+        self, mocked_cmd, mocked_get_iotops_mgmt_client
+    ):
+        """Falls back to metadata.version if imageConfigurationSettings.tag is absent."""
+        provider = ConnectorTemplates(mocked_cmd)
+        metadata = get_sample_metadata(version="1.5.0")
+        del metadata["imageConfigurationSettings"]["tag"]
+        metadata_ref = "mcr.microsoft.com/test/connector-metadata:1.5.0"
+
+        properties = provider._build_template_properties(
+            metadata=metadata,
+            connector_metadata_ref=metadata_ref,
+            replicas=None,
+            log_level=None,
+            image_pull_policy=None,
+            image_pull_secrets=None,
+            allocation_policy=None,
+            bucket_size=None,
+            secrets=None,
+            storage_volumes=None,
+            connector_config=None,
+            trust_settings_secret_ref=None,
+        )
+
+        managed_config = properties["runtimeConfiguration"]["managedConfigurationSettings"]
+        image_config = managed_config["imageConfigurationSettings"]
+        assert image_config["tagDigestSettings"]["tag"] == "1.5.0"
+
 
 # =====================
 # Command Tests with Mocked Responses

--- a/azext_edge/tests/edge/orchestration/resources/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_connector_templates_unit.py
@@ -945,6 +945,65 @@ class TestBuildTemplateProperties:
         image_config = managed_config["imageConfigurationSettings"]
         assert image_config["tagDigestSettings"]["tag"] == "1.5.0"
 
+    def test_image_digest_from_image_configuration_settings(
+        self, mocked_cmd, mocked_get_iotops_mgmt_client
+    ):
+        """create uses digest when imageConfigurationSettings.digest is present (no tag)."""
+        provider = ConnectorTemplates(mocked_cmd)
+        metadata = get_sample_metadata(version="1.0.0")
+        del metadata["imageConfigurationSettings"]["tag"]
+        metadata["imageConfigurationSettings"]["digest"] = "sha256:abc123"
+        metadata_ref = "mcr.microsoft.com/test/connector-metadata:1.0.0"
+
+        properties = provider._build_template_properties(
+            metadata=metadata,
+            connector_metadata_ref=metadata_ref,
+            replicas=None,
+            log_level=None,
+            image_pull_policy=None,
+            image_pull_secrets=None,
+            allocation_policy=None,
+            bucket_size=None,
+            secrets=None,
+            storage_volumes=None,
+            connector_config=None,
+            trust_settings_secret_ref=None,
+        )
+
+        managed_config = properties["runtimeConfiguration"]["managedConfigurationSettings"]
+        image_config = managed_config["imageConfigurationSettings"]
+        assert image_config["tagDigestSettings"]["tagDigestType"] == "Digest"
+        assert image_config["tagDigestSettings"]["digest"] == "sha256:abc123"
+
+    def test_image_tag_takes_priority_over_digest(
+        self, mocked_cmd, mocked_get_iotops_mgmt_client
+    ):
+        """tag takes priority over digest when both are present in imageConfigurationSettings."""
+        provider = ConnectorTemplates(mocked_cmd)
+        metadata = get_sample_metadata(version="1.0.0")
+        metadata["imageConfigurationSettings"]["digest"] = "sha256:abc123"
+        metadata_ref = "mcr.microsoft.com/test/connector-metadata:1.0.0"
+
+        properties = provider._build_template_properties(
+            metadata=metadata,
+            connector_metadata_ref=metadata_ref,
+            replicas=None,
+            log_level=None,
+            image_pull_policy=None,
+            image_pull_secrets=None,
+            allocation_policy=None,
+            bucket_size=None,
+            secrets=None,
+            storage_volumes=None,
+            connector_config=None,
+            trust_settings_secret_ref=None,
+        )
+
+        managed_config = properties["runtimeConfiguration"]["managedConfigurationSettings"]
+        image_config = managed_config["imageConfigurationSettings"]
+        assert image_config["tagDigestSettings"]["tagDigestType"] == "Tag"
+        assert image_config["tagDigestSettings"]["tag"] == "1.0.0"
+
 
 # =====================
 # Command Tests with Mocked Responses


### PR DESCRIPTION
connector template create was using metadata.version as the image tag instead of metadata.imageConfigurationSettings.tag, deploying the wrong image when the two values differ. Fixed to use imageConfigurationSettings.tag (consistent with update), with fallback to version.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
