### PR TITLE
fix: raise friendly error for invalid JSON in --config-file

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/reskit.py
+++ b/azext_edge/edge/providers/orchestration/resources/reskit.py
@@ -7,11 +7,16 @@
 import json
 from typing import Protocol, Dict
 
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
 from ....util import read_file_content
 
 
 def get_file_config(file_path: str) -> dict:
-    config = json.loads(read_file_content(file_path=file_path))
+    try:
+        config = json.loads(read_file_content(file_path=file_path))
+    except json.JSONDecodeError as e:
+        raise InvalidArgumentValueError(f"Failed to parse config file as JSON: {e}") from e
     if "properties" in config:
         config = config["properties"]
     return config

--- a/azext_edge/edge/providers/orchestration/resources/reskit.py
+++ b/azext_edge/edge/providers/orchestration/resources/reskit.py
@@ -16,7 +16,9 @@ def get_file_config(file_path: str) -> dict:
     try:
         config = json.loads(read_file_content(file_path=file_path))
     except json.JSONDecodeError as e:
-        raise InvalidArgumentValueError(f"Failed to parse config file as JSON: {e}") from e
+        raise InvalidArgumentValueError(
+            f"Failed to parse config file provided via '--config-file' as JSON: {file_path}: {e}"
+        ) from e
     if "properties" in config:
         config = config["properties"]
     return config

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -195,6 +195,26 @@ def test_dataflow_graph_list(mocked_cmd, mocked_responses: responses, records: i
 # ---------------------------------------------------------------------------
 
 
+def test_dataflow_graph_apply_invalid_json_config(
+    mocked_cmd,
+    mocked_get_file_config: Mock,
+):
+    mocked_get_file_config.return_value = "bad json {"
+
+    with pytest.raises(InvalidArgumentValueError) as exc:
+        apply_dataflow_graph(
+            cmd=mocked_cmd,
+            dataflow_graph_name=generate_random_string(),
+            profile_name=generate_random_string(),
+            instance_name=generate_random_string(),
+            resource_group_name=generate_random_string(),
+            config_file="config.json",
+        )
+
+    assert "--config-file" in exc.value.error_msg
+    assert "config.json" in exc.value.error_msg
+
+
 @pytest.mark.parametrize(
     "scenario",
     [
@@ -287,6 +307,7 @@ def test_dataflow_graph_apply(
     mocked_get_file_config: Mock,
     scenario: dict,
 ):
+
     graph_name = generate_random_string()
     profile_name = generate_random_string()
     instance_name = "myinstance"


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
