### PR TITLE
feat(dataflowgraph): validate node connection directions and required graph node config params

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -812,9 +812,10 @@ def load_iotops_help():
 
           The above example defines a graph with an MQTT source flowing through a Graph processing
           node that fans out to a Kafka destination and an OpenTelemetry destination. Graph nodes
-          reference an artifact (format: `<name>:<version>`) from a registry endpoint. If the
-          artifact requires configuration parameters, supply them as a list of {"key", "value"}
-          string pairs in graphSettings.configuration — omit the field entirely when no
+          reference an artifact (format: `<name>:<version>`) from a registry endpoint. The
+          example above includes graphSettings.configuration only to illustrate the format when
+          an artifact requires configuration parameters; in that case, supply them as a list of
+          {"key", "value"} string pairs. Omit graphSettings.configuration entirely when no
           configuration is needed.
           Supported nodeTypes are: Source, Destination, and Graph. Data flow graphs support only
           MQTT, Kafka, and OpenTelemetry endpoints. The file can also be the full ARM resource

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -794,7 +794,11 @@ def load_iotops_help():
                 "nodeType": "Graph",
                 "graphSettings": {
                   "registryEndpointRef": "my-registry-endpoint",
-                  "artifact": "my-processing-module:1.0.0"
+                  "artifact": "my-processing-module:1.0.0",
+                  "configuration": [
+                    { "key": "paramName", "value": "paramValue" },
+                    { "key": "anotherParam", "value": "anotherValue" }
+                  ]
                 }
               }
             ],
@@ -808,7 +812,10 @@ def load_iotops_help():
 
           The above example defines a graph with an MQTT source flowing through a Graph processing
           node that fans out to a Kafka destination and an OpenTelemetry destination. Graph nodes
-          reference an artifact (format: `<name>:<version>`) from a registry endpoint.
+          reference an artifact (format: `<name>:<version>`) from a registry endpoint. If the
+          artifact requires configuration parameters, supply them as a list of {"key", "value"}
+          string pairs in graphSettings.configuration — omit the field entirely when no
+          configuration is needed.
           Supported nodeTypes are: Source, Destination, and Graph. Data flow graphs support only
           MQTT, Kafka, and OpenTelemetry endpoints. The file can also be the full ARM resource
           wrapper (properties is auto-extracted). extendedLocation is always auto-populated from

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -180,7 +180,6 @@ class DataFlowGraphs(Queryable):
                         "Failed to fetch OCI artifact '%s' — skipping client-side config validation. %s",
                         image_ref,
                         ex,
-                        exc_info=True,
                     )
                     artifact_info_cache[image_ref] = None
             return artifact_info_cache[image_ref]

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -4,6 +4,8 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import yaml
+
 from typing import TYPE_CHECKING, Iterable, Optional
 
 from rich.console import Console
@@ -13,6 +15,7 @@ from azure.core.exceptions import ResourceNotFoundError
 
 from ....util.az_client import wait_for_terminal_state
 from ....util.common import should_continue_prompt
+from ....util.oci_client import get_oci_client
 from ....util.queryable import Queryable
 from ..common import DataflowEndpointType, KAFKA_ENDPOINT_TYPE, MQTT_ENDPOINT_TYPE
 from .instances import Instances
@@ -124,7 +127,7 @@ class DataFlowGraphs(Queryable):
         instance_name: str,
         resource_group_name: str,
     ):
-        nodes, declared_names = self._validate_nodes(graph_config)
+        nodes, name_to_type = self._validate_nodes(graph_config)
 
         source_nodes = [n for n in nodes if n.get("nodeType") == "Source"]
         destination_nodes = [n for n in nodes if n.get("nodeType") == "Destination"]
@@ -139,7 +142,7 @@ class DataFlowGraphs(Queryable):
                 "The dataflow graph config must contain at least one node with nodeType 'Destination'."
             )
 
-        self._validate_node_connections(graph_config, declared_names)
+        self._validate_node_connections(graph_config, name_to_type)
 
         endpoint_cache: dict = {}
 
@@ -171,7 +174,7 @@ class DataFlowGraphs(Queryable):
                 "'nodes' is required and must contain at least one node in the dataflow graph config."
             )
 
-        declared_names = set()
+        name_to_type: dict = {}
         for i, node in enumerate(nodes):
             if not isinstance(node, dict):
                 raise InvalidArgumentValueError(
@@ -193,16 +196,16 @@ class DataFlowGraphs(Queryable):
                     f"Node '{node_name}' has invalid nodeType '{node_type}'. "
                     f"Valid nodeType values are: {', '.join(sorted(_VALID_NODE_TYPES))}."
                 )
-            if node_name in declared_names:
+            if node_name in name_to_type:
                 raise InvalidArgumentValueError(
                     f"Duplicate node name '{node_name}' found at index {i}. "
                     "Each node in the dataflow graph config must have a unique 'name'."
                 )
-            declared_names.add(node_name)
+            name_to_type[node_name] = node_type
 
-        return nodes, declared_names
+        return nodes, name_to_type
 
-    def _validate_node_connections(self, graph_config: dict, declared_names: set):
+    def _validate_node_connections(self, graph_config: dict, name_to_type: dict):
         node_connections = graph_config.get("nodeConnections", [])
         if not isinstance(node_connections, list) or not node_connections:
             raise InvalidArgumentValueError(
@@ -229,15 +232,25 @@ class DataFlowGraphs(Queryable):
                 raise InvalidArgumentValueError(
                     f"nodeConnection at index {i} is a self-loop: 'from' and 'to' both reference node '{from_name}'."
                 )
-            if from_name not in declared_names:
+            if from_name not in name_to_type:
                 raise InvalidArgumentValueError(
                     f"nodeConnection at index {i} references unknown 'from' node '{from_name}'. "
-                    f"Declared node names: {', '.join(sorted(declared_names))}."
+                    f"Declared node names: {', '.join(sorted(name_to_type))}."
                 )
-            if to_name not in declared_names:
+            if to_name not in name_to_type:
                 raise InvalidArgumentValueError(
                     f"nodeConnection at index {i} references unknown 'to' node '{to_name}'. "
-                    f"Declared node names: {', '.join(sorted(declared_names))}."
+                    f"Declared node names: {', '.join(sorted(name_to_type))}."
+                )
+            if name_to_type[from_name] == "Destination":
+                raise InvalidArgumentValueError(
+                    f"nodeConnection at index {i} uses Destination node '{from_name}' as a 'from' (source). "
+                    "Destination nodes are sinks and cannot be the source of a connection."
+                )
+            if name_to_type[to_name] == "Source":
+                raise InvalidArgumentValueError(
+                    f"nodeConnection at index {i} uses Source node '{to_name}' as a 'to' (destination). "
+                    "Source nodes are producers and cannot be the destination of a connection."
                 )
 
     def _validate_source_nodes(self, source_nodes: list, get_endpoint_cached):
@@ -317,7 +330,7 @@ class DataFlowGraphs(Queryable):
                 raise InvalidArgumentValueError(
                     f"Graph node '{node.get('name')}' is missing 'graphSettings.registryEndpointRef'."
                 )
-            get_registry_endpoint_cached(registry_endpoint_ref)
+            registry_endpoint_obj = get_registry_endpoint_cached(registry_endpoint_ref)
             artifact = graph_settings.get("artifact", "")
             if not artifact:
                 raise InvalidArgumentValueError(
@@ -327,6 +340,46 @@ class DataFlowGraphs(Queryable):
                 raise InvalidArgumentValueError(
                     f"Graph node '{node.get('name')}' has an invalid 'graphSettings.artifact' value '{artifact}'. "
                     "Expected format: '<artifact-name>:<version>'."
+                )
+            self._validate_graph_node_artifact_config(node, graph_settings, registry_endpoint_obj, artifact)
+
+    def _validate_graph_node_artifact_config(
+        self,
+        node: dict,
+        graph_settings: dict,
+        registry_endpoint_obj: dict,
+        artifact: str,
+    ):
+        """Fetch the OCI artifact YAML layer and validate that all required parameters are provided.
+
+        The YAML layer contains moduleConfigurations[*].parameters where each entry has a
+        'required' field. Each required parameter must appear as a {"key": ..., "value": ...}
+        entry in graphSettings.configuration.
+        """
+        registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
+        image_ref = f"{registry_host}/{artifact}"
+        artifact_info = get_oci_client().fetch_first_layer(image_ref=image_ref, cmd=self.cmd)
+
+        yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
+
+        required_params: set = set()
+        for module_config in yaml_data.get("moduleConfigurations", []):
+            parameters = module_config.get("parameters", {})
+            if isinstance(parameters, dict):
+                for param_name, param_info in parameters.items():
+                    if isinstance(param_info, dict) and param_info.get("required", False):
+                        required_params.add(param_name)
+
+        if required_params:
+            configuration = graph_settings.get("configuration") or []
+            provided_keys = {item.get("key") for item in configuration if isinstance(item, dict)}
+            missing = required_params - provided_keys
+            if missing:
+                raise InvalidArgumentValueError(
+                    f"Graph node '{node.get('name')}' artifact '{artifact}' requires configuration "
+                    f"parameter(s) {sorted(missing)} but they are not provided in "
+                    "'graphSettings.configuration'. Each required parameter must be supplied as a "
+                    '{"key": "<param-name>", "value": "<value>"} entry.'
                 )
 
     def _get_endpoint(

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -12,8 +12,7 @@ from knack.log import get_logger
 from rich.console import Console
 
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from azure.cli.core.azclierror import ValidationError as AzValidationError
-from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.core.exceptions import ResourceNotFoundError
 
 from ....util.az_client import wait_for_terminal_state
 from ....util.common import should_continue_prompt
@@ -176,7 +175,7 @@ class DataFlowGraphs(Queryable):
                     artifact_info_cache[image_ref] = get_oci_client().fetch_first_layer(
                         image_ref=image_ref, cmd=self.cmd
                     )
-                except (AzValidationError, HttpResponseError) as ex:
+                except Exception as ex:  # best-effort: skip validation on any fetch failure
                     logger.warning(
                         "Failed to fetch OCI artifact '%s' — skipping client-side config validation. %s",
                         image_ref,
@@ -411,7 +410,7 @@ class DataFlowGraphs(Queryable):
 
         try:
             yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
-        except (yaml.YAMLError, UnicodeDecodeError) as ex:
+        except (yaml.YAMLError, UnicodeDecodeError, AttributeError, TypeError) as ex:
             logger.debug(
                 "OCI artifact '%s' does not contain valid YAML — skipping config validation. %s",
                 image_ref,
@@ -454,9 +453,10 @@ class DataFlowGraphs(Queryable):
                     if artifact and artifact != image_ref
                     else f"image '{image_ref}'"
                 )
+                missing_params = ", ".join(f"'{p}'" for p in sorted(missing))
                 raise InvalidArgumentValueError(
                     f"Graph node '{node.get('name')}' {artifact_description} requires "
-                    f"configuration parameter(s) {sorted(missing)} but they are not provided in "
+                    f"configuration parameter(s) {missing_params} but they are not provided in "
                     "'graphSettings.configuration'. Each required parameter must be supplied as a "
                     '{"key": "<param-name>", "value": "<value>"} entry.'
                 )

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Iterable, Optional
 from knack.log import get_logger
 from rich.console import Console
 
-logger = get_logger(__name__)
-
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from azure.core.exceptions import ResourceNotFoundError
+from azure.cli.core.azclierror import ValidationError as AzValidationError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
 from ....util.az_client import wait_for_terminal_state
 from ....util.common import should_continue_prompt
@@ -24,6 +23,7 @@ from ..common import DataflowEndpointType, KAFKA_ENDPOINT_TYPE, MQTT_ENDPOINT_TY
 from .instances import Instances
 from .reskit import get_file_config
 
+logger = get_logger(__name__)
 console = Console()
 
 # Endpoint types supported in data flow graphs (MQTT family + Kafka family + OpenTelemetry).
@@ -176,11 +176,12 @@ class DataFlowGraphs(Queryable):
                     artifact_info_cache[image_ref] = get_oci_client().fetch_first_layer(
                         image_ref=image_ref, cmd=self.cmd
                     )
-                except Exception as ex:
-                    logger.debug(
+                except (AzValidationError, HttpResponseError) as ex:
+                    logger.warning(
                         "Failed to fetch OCI artifact '%s' — skipping client-side config validation. %s",
                         image_ref,
                         ex,
+                        exc_info=True,
                     )
                     artifact_info_cache[image_ref] = None
             return artifact_info_cache[image_ref]
@@ -361,8 +362,15 @@ class DataFlowGraphs(Queryable):
                     f"Graph node '{node.get('name')}' has an invalid 'graphSettings.artifact' value '{artifact}'. "
                     "Expected format: '<artifact-name>:<version>'."
                 )
+            registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
+            if not isinstance(registry_host, str) or not registry_host.strip():
+                raise InvalidArgumentValueError(
+                    f"Graph node '{node.get('name')}' artifact '{artifact}' references a misconfigured "
+                    "registry endpoint: missing required 'properties.host'."
+                )
+            image_ref = f"{registry_host.strip()}/{artifact}"
             self._validate_graph_node_artifact_config(
-                node, graph_settings, registry_endpoint_obj, artifact, get_artifact_info_cached
+                node, graph_settings, image_ref, get_artifact_info_cached
             )
 
     @staticmethod
@@ -384,8 +392,7 @@ class DataFlowGraphs(Queryable):
         self,
         node: dict,
         graph_settings: dict,
-        registry_endpoint_obj: dict,
-        artifact: str,
+        image_ref: str,
         get_artifact_info_cached,
     ):
         """Fetch the OCI artifact YAML layer and validate that all required parameters are provided.
@@ -394,13 +401,6 @@ class DataFlowGraphs(Queryable):
         'required' field. Each required parameter must appear as a {"key": ..., "value": ...}
         entry in graphSettings.configuration.
         """
-        registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
-        if not isinstance(registry_host, str) or not registry_host.strip():
-            raise InvalidArgumentValueError(
-                f"Graph node '{node.get('name')}' artifact '{artifact}' references a misconfigured "
-                "registry endpoint: missing required 'properties.host'."
-            )
-        image_ref = f"{registry_host.strip()}/{artifact}"
         artifact_info = get_artifact_info_cached(image_ref)
         if artifact_info is None:
             return
@@ -435,6 +435,8 @@ class DataFlowGraphs(Queryable):
 
         if required_params:
             configuration = graph_settings.get("configuration") or []
+            if not isinstance(configuration, list):
+                configuration = []
             provided_keys = {
                 item.get("key")
                 for item in configuration
@@ -443,7 +445,7 @@ class DataFlowGraphs(Queryable):
             missing = required_params - provided_keys
             if missing:
                 raise InvalidArgumentValueError(
-                    f"Graph node '{node.get('name')}' artifact '{artifact}' requires configuration "
+                    f"Graph node '{node.get('name')}' image '{image_ref}' requires configuration "
                     f"parameter(s) {sorted(missing)} but they are not provided in "
                     "'graphSettings.configuration'. Each required parameter must be supplied as a "
                     '{"key": "<param-name>", "value": "<value>"} entry.'

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -8,7 +8,10 @@ import yaml
 
 from typing import TYPE_CHECKING, Iterable, Optional
 
+from knack.log import get_logger
 from rich.console import Console
+
+logger = get_logger(__name__)
 
 from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.core.exceptions import ResourceNotFoundError
@@ -169,9 +172,17 @@ class DataFlowGraphs(Queryable):
 
         def get_artifact_info_cached(image_ref: str):
             if image_ref not in artifact_info_cache:
-                artifact_info_cache[image_ref] = get_oci_client().fetch_first_layer(
-                    image_ref=image_ref, cmd=self.cmd
-                )
+                try:
+                    artifact_info_cache[image_ref] = get_oci_client().fetch_first_layer(
+                        image_ref=image_ref, cmd=self.cmd
+                    )
+                except Exception as ex:
+                    logger.debug(
+                        "Failed to fetch OCI artifact '%s' — skipping client-side config validation. %s",
+                        image_ref,
+                        ex,
+                    )
+                    artifact_info_cache[image_ref] = None
             return artifact_info_cache[image_ref]
 
         self._validate_graph_nodes(graph_nodes, get_registry_endpoint_cached, get_artifact_info_cached)
@@ -354,6 +365,21 @@ class DataFlowGraphs(Queryable):
                 node, graph_settings, registry_endpoint_obj, artifact, get_artifact_info_cached
             )
 
+    @staticmethod
+    def _is_config_entry_provided(item: dict) -> bool:
+        """Return True only when a configuration entry has a valid non-empty key and value."""
+        if not isinstance(item, dict):
+            return False
+        key = item.get("key")
+        if not isinstance(key, str) or not key:
+            return False
+        if "value" not in item or item.get("value") is None:
+            return False
+        value = item.get("value")
+        if isinstance(value, str) and not value.strip():
+            return False
+        return True
+
     def _validate_graph_node_artifact_config(
         self,
         node: dict,
@@ -369,39 +395,50 @@ class DataFlowGraphs(Queryable):
         entry in graphSettings.configuration.
         """
         registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
-        image_ref = f"{registry_host}/{artifact}"
+        if not isinstance(registry_host, str) or not registry_host.strip():
+            raise InvalidArgumentValueError(
+                f"Graph node '{node.get('name')}' artifact '{artifact}' references a misconfigured "
+                "registry endpoint: missing required 'properties.host'."
+            )
+        image_ref = f"{registry_host.strip()}/{artifact}"
         artifact_info = get_artifact_info_cached(image_ref)
+        if artifact_info is None:
+            return
 
         try:
             yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
         except yaml.YAMLError as ex:
-            raise InvalidArgumentValueError(
-                f"Graph node '{node.get('name')}' artifact '{artifact}' does not contain valid YAML."
-            ) from ex
-        if not isinstance(yaml_data, dict):
-            raise InvalidArgumentValueError(
-                f"Graph node '{node.get('name')}' artifact '{artifact}' must contain a top-level YAML object."
+            logger.debug(
+                "OCI artifact '%s' does not contain valid YAML — skipping config validation. %s",
+                image_ref,
+                ex,
             )
+            return
+        if not isinstance(yaml_data, dict):
+            logger.debug(
+                "OCI artifact '%s' has unexpected YAML structure — skipping config validation.",
+                image_ref,
+            )
+            return
 
         required_params: set = set()
-        for module_config in yaml_data.get("moduleConfigurations", []):
-            parameters = module_config.get("parameters", {})
-            if isinstance(parameters, dict):
-                for param_name, param_info in parameters.items():
-                    if isinstance(param_info, dict) and param_info.get("required", False):
-                        required_params.add(param_name)
+        module_configurations = yaml_data.get("moduleConfigurations") or []
+        if isinstance(module_configurations, list):
+            for module_config in module_configurations:
+                if not isinstance(module_config, dict):
+                    continue
+                parameters = module_config.get("parameters", {})
+                if isinstance(parameters, dict):
+                    for param_name, param_info in parameters.items():
+                        if isinstance(param_info, dict) and param_info.get("required", False):
+                            required_params.add(param_name)
 
         if required_params:
             configuration = graph_settings.get("configuration") or []
             provided_keys = {
                 item.get("key")
                 for item in configuration
-                if isinstance(item, dict)
-                and isinstance(item.get("key"), str)
-                and item.get("key")
-                and "value" in item
-                and item.get("value") is not None
-                and (not isinstance(item.get("value"), str) or item.get("value").strip())
+                if self._is_config_entry_provided(item)
             }
             missing = required_params - provided_keys
             if missing:

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -347,7 +347,7 @@ class DataFlowGraphs(Queryable):
                     f"expected an object, got {type(graph_settings).__name__}."
                 )
             registry_endpoint_ref = graph_settings.get("registryEndpointRef", "")
-            if not registry_endpoint_ref:
+            if not isinstance(registry_endpoint_ref, str) or not registry_endpoint_ref.strip():
                 raise InvalidArgumentValueError(
                     f"Graph node '{node.get('name')}' is missing 'graphSettings.registryEndpointRef'."
                 )
@@ -368,7 +368,7 @@ class DataFlowGraphs(Queryable):
                     f"Graph node '{node.get('name')}' artifact '{artifact}' references a misconfigured "
                     "registry endpoint: missing required 'properties.host'."
                 )
-            image_ref = f"{registry_host.strip()}/{artifact}"
+            image_ref = f"{registry_host.strip().rstrip('/')}/{artifact}"
             self._validate_graph_node_artifact_config(
                 node, graph_settings, image_ref, get_artifact_info_cached
             )
@@ -379,7 +379,7 @@ class DataFlowGraphs(Queryable):
         if not isinstance(item, dict):
             return False
         key = item.get("key")
-        if not isinstance(key, str) or not key:
+        if not isinstance(key, str) or not key.strip():
             return False
         if "value" not in item or item.get("value") is None:
             return False
@@ -411,7 +411,7 @@ class DataFlowGraphs(Queryable):
 
         try:
             yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
-        except yaml.YAMLError as ex:
+        except (yaml.YAMLError, UnicodeDecodeError) as ex:
             logger.debug(
                 "OCI artifact '%s' does not contain valid YAML — skipping config validation. %s",
                 image_ref,
@@ -434,7 +434,7 @@ class DataFlowGraphs(Queryable):
                 parameters = module_config.get("parameters", {})
                 if isinstance(parameters, dict):
                     for param_name, param_info in parameters.items():
-                        if isinstance(param_info, dict) and param_info.get("required", False):
+                        if isinstance(param_info, dict) and param_info.get("required") is True:
                             required_params.add(param_name)
 
         if required_params:

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -165,7 +165,16 @@ class DataFlowGraphs(Queryable):
                 )
             return registry_endpoint_cache[registry_endpoint_ref]
 
-        self._validate_graph_nodes(graph_nodes, get_registry_endpoint_cached)
+        artifact_info_cache: dict = {}
+
+        def get_artifact_info_cached(image_ref: str):
+            if image_ref not in artifact_info_cache:
+                artifact_info_cache[image_ref] = get_oci_client().fetch_first_layer(
+                    image_ref=image_ref, cmd=self.cmd
+                )
+            return artifact_info_cache[image_ref]
+
+        self._validate_graph_nodes(graph_nodes, get_registry_endpoint_cached, get_artifact_info_cached)
 
     def _validate_nodes(self, graph_config: dict):
         nodes = graph_config.get("nodes", [])
@@ -317,7 +326,7 @@ class DataFlowGraphs(Queryable):
                     f"{', '.join(sorted(_GRAPH_SUPPORTED_ENDPOINT_TYPES))}."
                 )
 
-    def _validate_graph_nodes(self, graph_nodes: list, get_registry_endpoint_cached):
+    def _validate_graph_nodes(self, graph_nodes: list, get_registry_endpoint_cached, get_artifact_info_cached):
         for node in graph_nodes:
             graph_settings = node.get("graphSettings", {})
             if not isinstance(graph_settings, dict):
@@ -341,7 +350,9 @@ class DataFlowGraphs(Queryable):
                     f"Graph node '{node.get('name')}' has an invalid 'graphSettings.artifact' value '{artifact}'. "
                     "Expected format: '<artifact-name>:<version>'."
                 )
-            self._validate_graph_node_artifact_config(node, graph_settings, registry_endpoint_obj, artifact)
+            self._validate_graph_node_artifact_config(
+                node, graph_settings, registry_endpoint_obj, artifact, get_artifact_info_cached
+            )
 
     def _validate_graph_node_artifact_config(
         self,
@@ -349,6 +360,7 @@ class DataFlowGraphs(Queryable):
         graph_settings: dict,
         registry_endpoint_obj: dict,
         artifact: str,
+        get_artifact_info_cached,
     ):
         """Fetch the OCI artifact YAML layer and validate that all required parameters are provided.
 
@@ -358,9 +370,18 @@ class DataFlowGraphs(Queryable):
         """
         registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
         image_ref = f"{registry_host}/{artifact}"
-        artifact_info = get_oci_client().fetch_first_layer(image_ref=image_ref, cmd=self.cmd)
+        artifact_info = get_artifact_info_cached(image_ref)
 
-        yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
+        try:
+            yaml_data = yaml.safe_load(artifact_info.content.decode("utf-8"))
+        except yaml.YAMLError as ex:
+            raise InvalidArgumentValueError(
+                f"Graph node '{node.get('name')}' artifact '{artifact}' does not contain valid YAML."
+            ) from ex
+        if not isinstance(yaml_data, dict):
+            raise InvalidArgumentValueError(
+                f"Graph node '{node.get('name')}' artifact '{artifact}' must contain a top-level YAML object."
+            )
 
         required_params: set = set()
         for module_config in yaml_data.get("moduleConfigurations", []):
@@ -372,7 +393,16 @@ class DataFlowGraphs(Queryable):
 
         if required_params:
             configuration = graph_settings.get("configuration") or []
-            provided_keys = {item.get("key") for item in configuration if isinstance(item, dict)}
+            provided_keys = {
+                item.get("key")
+                for item in configuration
+                if isinstance(item, dict)
+                and isinstance(item.get("key"), str)
+                and item.get("key")
+                and "value" in item
+                and item.get("value") is not None
+                and (not isinstance(item.get("value"), str) or item.get("value").strip())
+            }
             missing = required_params - provided_keys
             if missing:
                 raise InvalidArgumentValueError(

--- a/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflow_graphs.py
@@ -362,7 +362,7 @@ class DataFlowGraphs(Queryable):
                     f"Graph node '{node.get('name')}' has an invalid 'graphSettings.artifact' value '{artifact}'. "
                     "Expected format: '<artifact-name>:<version>'."
                 )
-            registry_host = registry_endpoint_obj.get("properties", {}).get("host", "")
+            registry_host = (registry_endpoint_obj or {}).get("properties", {}).get("host", "")
             if not isinstance(registry_host, str) or not registry_host.strip():
                 raise InvalidArgumentValueError(
                     f"Graph node '{node.get('name')}' artifact '{artifact}' references a misconfigured "
@@ -400,6 +400,10 @@ class DataFlowGraphs(Queryable):
         The YAML layer contains moduleConfigurations[*].parameters where each entry has a
         'required' field. Each required parameter must appear as a {"key": ..., "value": ...}
         entry in graphSettings.configuration.
+
+        This is a best-effort, client-side check. If the OCI artifact cannot be fetched (e.g.,
+        due to network issues, auth failure, or an invalid reference), a warning is logged and
+        validation is skipped — the apply proceeds and server-side validation will catch any issues.
         """
         artifact_info = get_artifact_info_cached(image_ref)
         if artifact_info is None:
@@ -444,9 +448,15 @@ class DataFlowGraphs(Queryable):
             }
             missing = required_params - provided_keys
             if missing:
+                artifact = graph_settings.get("artifact", "")
+                artifact_description = (
+                    f"artifact '{artifact}' (resolved image '{image_ref}')"
+                    if artifact and artifact != image_ref
+                    else f"image '{image_ref}'"
+                )
                 raise InvalidArgumentValueError(
-                    f"Graph node '{node.get('name')}' image '{image_ref}' requires configuration "
-                    f"parameter(s) {sorted(missing)} but they are not provided in "
+                    f"Graph node '{node.get('name')}' {artifact_description} requires "
+                    f"configuration parameter(s) {sorted(missing)} but they are not provided in "
                     "'graphSettings.configuration'. Each required parameter must be supplied as a "
                     '{"key": "<param-name>", "value": "<value>"} entry.'
                 )

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_int.py
@@ -130,6 +130,8 @@ def test_dataflow_graph(dataflow_graph_test_setup, tracked_resources, tracked_fi
     registry_endpoints = run(f"az iot ops registry list -g {rg} -i {instance}")
     if registry_endpoints:
         registry_ep = registry_endpoints[0]["name"]
+
+        # Sub-case 1: Graph node without configuration
         updated_nodes = nodes + [
             {
                 "name": "graph-node",
@@ -144,16 +146,49 @@ def test_dataflow_graph(dataflow_graph_test_setup, tracked_resources, tracked_fi
             {"from": {"name": "source-node"}, "to": {"name": "graph-node"}},
             {"from": {"name": "graph-node"}, "to": {"name": "dest-node"}},
         ]
-        updated_config_path = _write_graph_config(nodes=updated_nodes, node_connections=updated_connections)
-        tracked_files.append(updated_config_path)
+        config_path_no_cfg = _write_graph_config(nodes=updated_nodes, node_connections=updated_connections)
+        tracked_files.append(config_path_no_cfg)
 
         updated_graph = run(
             f"az iot ops dataflowgraph apply -n {graph_name} -g {rg} -i {instance} "
-            f"--profile {profile_name} --config-file {updated_config_path}"
+            f"--profile {profile_name} --config-file {config_path_no_cfg}"
         )
         assert_dataflow_graph(graph=updated_graph, name=graph_name, resource_group=rg)
         node_names = [n["name"] for n in updated_graph.get("properties", {}).get("nodes", [])]
         assert "graph-node" in node_names
+
+        # Sub-case 2: Graph node with configuration entries
+        nodes_with_cfg = nodes + [
+            {
+                "name": "graph-node",
+                "nodeType": "Graph",
+                "graphSettings": {
+                    "registryEndpointRef": registry_ep,
+                    "artifact": "my-module:1.0.0",
+                    "configuration": [
+                        {"key": "param1", "value": "value1"},
+                        {"key": "param2", "value": "value2"},
+                    ],
+                },
+            }
+        ]
+        config_path_with_cfg = _write_graph_config(nodes=nodes_with_cfg, node_connections=updated_connections)
+        tracked_files.append(config_path_with_cfg)
+
+        graph_with_cfg = run(
+            f"az iot ops dataflowgraph apply -n {graph_name} -g {rg} -i {instance} "
+            f"--profile {profile_name} --config-file {config_path_with_cfg}"
+        )
+        assert_dataflow_graph(graph=graph_with_cfg, name=graph_name, resource_group=rg)
+        graph_node = next(
+            (n for n in graph_with_cfg.get("properties", {}).get("nodes", []) if n["name"] == "graph-node"),
+            None,
+        )
+        assert graph_node is not None
+        cfg_entries = graph_node.get("graphSettings", {}).get("configuration", [])
+        cfg_keys = [e["key"] for e in cfg_entries]
+        assert "param1" in cfg_keys
+        assert "param2" in cfg_keys
 
     # DELETE
     run(f"az iot ops dataflowgraph delete -n {graph_name} -g {rg} -i {instance} --profile {profile_name} -y")

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -1379,7 +1379,7 @@ def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
     mocker,
     fetch_side_effect,
 ):
-    """Apply succeeds (skips config validation) when OCI artifact fetch raises ValidationError or HttpResponseError."""
+    """Apply succeeds (skips config validation) when OCI artifact fetch raises any exception."""
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -513,6 +513,34 @@ def test_dataflow_graph_apply(
             },
             "nodeConnection at index 0 must be an object",
         ),
+        # Destination node used as 'from' (source of a connection)
+        (
+            {
+                "nodes": [
+                    {"name": "src", "nodeType": "Source",
+                     "sourceSettings": {"endpointRef": "ep1", "dataSources": ["t"]}},
+                    {"name": "dst", "nodeType": "Destination",
+                     "destinationSettings": {"endpointRef": "ep2", "dataDestination": "t"}},
+                ],
+                "nodeConnections": [{"from": {"name": "dst"}, "to": {"name": "src"}}],
+            },
+            "Destination nodes are sinks and cannot be the source of a connection",
+        ),
+        # Source node used as 'to' (destination of a connection)
+        (
+            {
+                "nodes": [
+                    {"name": "src", "nodeType": "Source",
+                     "sourceSettings": {"endpointRef": "ep1", "dataSources": ["t"]}},
+                    {"name": "mid", "nodeType": "Graph",
+                     "graphSettings": {"registryEndpointRef": "reg", "artifact": "myartifact:1.0"}},
+                    {"name": "dst", "nodeType": "Destination",
+                     "destinationSettings": {"endpointRef": "ep2", "dataDestination": "t"}},
+                ],
+                "nodeConnections": [{"from": {"name": "mid"}, "to": {"name": "src"}}],
+            },
+            "Source nodes are producers and cannot be the destination of a connection",
+        ),
     ],
 )
 def test_dataflow_graph_apply_structural_error(
@@ -1075,3 +1103,282 @@ def test_dataflow_graph_apply_registry_endpoint_not_found(
 
     assert "myregistry" in exc.value.args[0]
     assert "not found in instance 'myinstance'" in exc.value.args[0]
+
+
+# ---------------------------------------------------------------------------
+# apply - artifact required configuration parameter validation
+# ---------------------------------------------------------------------------
+
+_MOCK_ARTIFACT_YAML_WITH_REQUIRED_PARAMS = (
+    "moduleConfigurations:\n"
+    "  - name: mymodule\n"
+    "    parameters:\n"
+    "      rules:\n"
+    "        name: rules\n"
+    "        required: true\n"
+    "        description: Required rules config\n"
+    "      optionalParam:\n"
+    "        name: optionalParam\n"
+    "        required: false\n"
+    "        description: Optional param\n"
+)
+
+_MOCK_ARTIFACT_YAML_NO_REQUIRED_PARAMS = (
+    "moduleConfigurations:\n"
+    "  - name: mymodule\n"
+    "    parameters:\n"
+    "      optionalParam:\n"
+    "        name: optionalParam\n"
+    "        required: false\n"
+    "        description: Optional param\n"
+)
+
+
+def _mock_oci_client(mocker, yaml_content: str):
+    """Patch get_oci_client to return a mock that serves the given YAML content."""
+    mock_artifact_info = Mock()
+    mock_artifact_info.content = yaml_content.encode("utf-8")
+    mock_oci = Mock()
+    mock_oci.fetch_first_layer.return_value = mock_artifact_info
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.dataflow_graphs.get_oci_client",
+        return_value=mock_oci,
+    )
+    return mock_oci
+
+
+def _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, registry_endpoint_name):
+    """Add HTTP mocks for the two dataflow endpoints and the registry endpoint used in Graph node tests."""
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint1",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint1",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="AIOLocalMqtt",
+            host="aio-broker",
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint2",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint2",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="CustomMqtt",
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_registry_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            registry_endpoint_name=registry_endpoint_name,
+        ),
+        json=get_mock_registry_endpoint_record(
+            registry_endpoint_name=registry_endpoint_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            host="myregistry.azurecr.io",
+        ),
+        status=200,
+    )
+
+
+@pytest.mark.parametrize(
+    "configuration, expected_error_text",
+    [
+        # No configuration field at all — required param 'rules' is missing
+        (
+            None,
+            "requires configuration parameter(s) ['rules']",
+        ),
+        # Empty configuration list — required param 'rules' is missing
+        (
+            [],
+            "requires configuration parameter(s) ['rules']",
+        ),
+        # Wrong key provided — required param 'rules' is still missing
+        (
+            [{"key": "optionalParam", "value": "something"}],
+            "requires configuration parameter(s) ['rules']",
+        ),
+    ],
+)
+def test_dataflow_graph_apply_missing_required_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+    configuration,
+    expected_error_text: str,
+):
+    import copy
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    for node in graph_properties["nodes"]:
+        if node["nodeType"] == "Graph":
+            if configuration is not None:
+                node["graphSettings"]["configuration"] = configuration
+            else:
+                node["graphSettings"].pop("configuration", None)
+
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+    _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_WITH_REQUIRED_PARAMS)
+
+    with pytest.raises(InvalidArgumentValueError) as exc:
+        apply_dataflow_graph(
+            cmd=mocked_cmd,
+            dataflow_graph_name=graph_name,
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            config_file="config.json",
+            wait_sec=0.1,
+        )
+
+    assert expected_error_text in exc.value.args[0]
+    assert "myartifact:1.0" in exc.value.args[0]
+    assert "graph-node" in exc.value.args[0]
+
+
+def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+):
+    """Graph node apply succeeds when all required configuration parameters are provided."""
+    import copy
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    for node in graph_properties["nodes"]:
+        if node["nodeType"] == "Graph":
+            node["graphSettings"]["configuration"] = [{"key": "rules", "value": "some-rules"}]
+
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+    _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_WITH_REQUIRED_PARAMS)
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload
+
+
+def test_dataflow_graph_apply_with_graph_node_no_required_params(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+):
+    """Graph node apply succeeds when the artifact has no required parameters (empty config is fine)."""
+    import copy
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    # No configuration provided in graph node — but artifact has no required params
+
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+    _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_NO_REQUIRED_PARAMS)
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import copy
 import json
 from typing import Optional
 from unittest.mock import Mock
@@ -11,7 +12,7 @@ from unittest.mock import Mock
 import pytest
 import responses
 
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azure.core.exceptions import ResourceNotFoundError
 
 from azext_edge.edge.commands_dataflowgraph import (
@@ -954,7 +955,6 @@ def test_dataflow_graph_apply_graph_node_error(
     graph_settings_override: dict,
     expected_error_text: str,
 ):
-    import copy
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1037,7 +1037,6 @@ def test_dataflow_graph_apply_registry_endpoint_not_found(
     mocked_responses: responses,
     mocked_get_file_config,
 ):
-    import copy
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1245,7 +1244,6 @@ def test_dataflow_graph_apply_missing_required_config(
     configuration,
     expected_error_text: str,
 ):
-    import copy
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1289,7 +1287,6 @@ def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
     mocker,
 ):
     """Graph node apply succeeds when all required configuration parameters are provided."""
-    import copy
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1351,8 +1348,6 @@ def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
     mocker,
 ):
     """Apply succeeds (skips config validation) when OCI artifact fetch fails."""
-    import copy
-    from azure.cli.core.azclierror import ValidationError
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1418,7 +1413,6 @@ def test_dataflow_graph_apply_with_graph_node_no_required_params(
     mocker,
 ):
     """Graph node apply succeeds when the artifact has no required parameters (empty config is fine)."""
-    import copy
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -1493,3 +1493,336 @@ def test_dataflow_graph_apply_with_graph_node_no_required_params(
     )
 
     assert result == file_payload
+
+
+@pytest.mark.parametrize(
+    "registry_endpoint_ref_value",
+    [
+        "   ",
+        "\t",
+        " \n ",
+    ],
+    ids=["spaces", "tab", "newlines"],
+)
+def test_dataflow_graph_apply_graph_node_whitespace_registry_endpoint_ref(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    registry_endpoint_ref_value: str,
+):
+    """Graph node apply raises an error when registryEndpointRef is whitespace-only."""
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    for node in graph_properties["nodes"]:
+        if node["nodeType"] == "Graph":
+            node["graphSettings"]["registryEndpointRef"] = registry_endpoint_ref_value
+
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint1",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint1",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="AIOLocalMqtt",
+            host="aio-broker",
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint2",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint2",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="CustomMqtt",
+        ),
+        status=200,
+    )
+
+    with pytest.raises(InvalidArgumentValueError) as exc:
+        apply_dataflow_graph(
+            cmd=mocked_cmd,
+            dataflow_graph_name=graph_name,
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            config_file="config.json",
+            wait_sec=0.1,
+        )
+
+    assert "is missing 'graphSettings.registryEndpointRef'" in exc.value.args[0]
+
+
+def test_dataflow_graph_apply_graph_node_registry_host_trailing_slash(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+):
+    """Graph node image_ref is built correctly when registry host has a trailing slash."""
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+
+    # Registry host has a trailing slash — image_ref must not contain double slash
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint1",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint1",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="AIOLocalMqtt",
+            host="aio-broker",
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_dataflow_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name="myendpoint2",
+        ),
+        json=get_mock_dataflow_endpoint_record(
+            dataflow_endpoint_name="myendpoint2",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            dataflow_endpoint_type="CustomMqtt",
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_registry_endpoint_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            registry_endpoint_name="myregistry",
+        ),
+        json=get_mock_registry_endpoint_record(
+            registry_endpoint_name="myregistry",
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            host="myregistry.azurecr.io/",  # trailing slash
+        ),
+        status=200,
+    )
+    _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_NO_REQUIRED_PARAMS)
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload
+    # The apply succeeded — the trailing slash was stripped correctly (no double slash in result)
+    assert "//" not in str(result)
+
+
+def test_dataflow_graph_apply_graph_node_non_utf8_artifact(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+):
+    """Graph node apply skips config validation when artifact content is not valid UTF-8."""
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+
+    # Artifact content is binary / non-UTF-8 — decode("utf-8") would raise UnicodeDecodeError
+    mock_artifact_info = Mock()
+    mock_artifact_info.content = b"\xff\xfe invalid utf-8 \x80\x81"
+    mock_oci = Mock()
+    mock_oci.fetch_first_layer.return_value = mock_artifact_info
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.dataflow_graphs.get_oci_client",
+        return_value=mock_oci,
+    )
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    # Should not raise — UnicodeDecodeError is caught and validation is skipped
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload
+
+
+@pytest.mark.parametrize(
+    "configuration, expected_provided",
+    [
+        # Whitespace-only key — should not count as provided
+        ([{"key": "   ", "value": "something"}], False),
+        # Valid key with valid value — should count as provided
+        ([{"key": "rules", "value": "something"}], True),
+    ],
+    ids=["whitespace_key", "valid_entry"],
+)
+def test_dataflow_graph_apply_config_entry_whitespace_key(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+    configuration: list,
+    expected_provided: bool,
+):
+    """_is_config_entry_provided treats whitespace-only keys as not provided."""
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    for node in graph_properties["nodes"]:
+        if node["nodeType"] == "Graph":
+            node["graphSettings"]["configuration"] = configuration
+
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+    _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_WITH_REQUIRED_PARAMS)
+
+    if expected_provided:
+        mock_instance_record = get_mock_instance_record(
+            name=instance_name, resource_group_name=resource_group_name
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=get_instance_endpoint(
+                resource_group_name=resource_group_name,
+                instance_name=instance_name,
+            ),
+            json=mock_instance_record,
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.PUT,
+            url=get_dataflow_graph_endpoint(
+                profile_name=profile_name,
+                instance_name=instance_name,
+                resource_group_name=resource_group_name,
+                graph_name=graph_name,
+            ),
+            json=file_payload,
+            status=200,
+        )
+        result = apply_dataflow_graph(
+            cmd=mocked_cmd,
+            dataflow_graph_name=graph_name,
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            config_file="config.json",
+            wait_sec=0.1,
+        )
+        assert result == file_payload
+    else:
+        with pytest.raises(InvalidArgumentValueError) as exc:
+            apply_dataflow_graph(
+                cmd=mocked_cmd,
+                dataflow_graph_name=graph_name,
+                profile_name=profile_name,
+                instance_name=instance_name,
+                resource_group_name=resource_group_name,
+                config_file="config.json",
+                wait_sec=0.1,
+            )
+        assert "requires configuration parameter(s)" in exc.value.args[0]

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -1223,37 +1223,37 @@ def _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_grou
         # No configuration field at all — required param 'rules' is missing
         (
             None,
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Empty configuration list — required param 'rules' is missing
         (
             [],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Wrong key provided — required param 'rules' is still missing
         (
             [{"key": "optionalParam", "value": "something"}],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Key present but value is None — should not count as provided
         (
             [{"key": "rules", "value": None}],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Key present but value is empty string — should not count as provided
         (
             [{"key": "rules", "value": ""}],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Key present but value is whitespace only — should not count as provided
         (
             [{"key": "rules", "value": "   "}],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
         # Entry has no value field at all — should not count as provided
         (
             [{"key": "rules"}],
-            "requires configuration parameter(s) ['rules']",
+            "requires configuration parameter(s) 'rules'",
         ),
     ],
 )
@@ -1367,8 +1367,10 @@ def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
     [
         ValidationError("registry unreachable"),
         HttpResponseError(message="connection error"),
+        ConnectionError("network timeout"),
+        Exception("unexpected error"),
     ],
-    ids=["ValidationError", "HttpResponseError"],
+    ids=["ValidationError", "HttpResponseError", "ConnectionError", "Exception"],
 )
 def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
     mocked_cmd,
@@ -1731,6 +1733,78 @@ def test_dataflow_graph_apply_graph_node_non_utf8_artifact(
     )
 
     # Should not raise — UnicodeDecodeError is caught and validation is skipped
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload
+
+
+@pytest.mark.parametrize(
+    "content_value",
+    [None, 12345, ["not", "bytes"]],
+    ids=["none", "int", "list"],
+)
+def test_dataflow_graph_apply_graph_node_invalid_artifact_content_type(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+    content_value,
+):
+    """Apply skips config validation when artifact content is None or a non-bytes type (AttributeError/TypeError)."""
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+
+    mock_artifact_info = Mock()
+    mock_artifact_info.content = content_value
+    mock_oci = Mock()
+    mock_oci.fetch_first_layer.return_value = mock_artifact_info
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.dataflow_graphs.get_oci_client",
+        return_value=mock_oci,
+    )
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    # Should not raise — AttributeError/TypeError is caught and validation is skipped
     result = apply_dataflow_graph(
         cmd=mocked_cmd,
         dataflow_graph_name=graph_name,

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -1279,7 +1279,7 @@ def test_dataflow_graph_apply_missing_required_config(
 
     assert expected_error_text in exc.value.args[0]
     assert "myartifact:1.0" in exc.value.args[0]
-    assert "graph-node" in exc.value.args[0]
+    assert "Graph node" in exc.value.args[0]
 
 
 def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
@@ -1318,6 +1318,73 @@ def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
     )
     _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
     _mock_oci_client(mocker, _MOCK_ARTIFACT_YAML_WITH_REQUIRED_PARAMS)
+
+    mocked_responses.add(
+        method=responses.PUT,
+        url=get_dataflow_graph_endpoint(
+            profile_name=profile_name,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            graph_name=graph_name,
+        ),
+        json=file_payload,
+        status=200,
+    )
+
+    result = apply_dataflow_graph(
+        cmd=mocked_cmd,
+        dataflow_graph_name=graph_name,
+        profile_name=profile_name,
+        instance_name=instance_name,
+        resource_group_name=resource_group_name,
+        config_file="config.json",
+        wait_sec=0.1,
+    )
+
+    assert result == file_payload
+
+
+def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_get_file_config,
+    mocker,
+):
+    """Apply succeeds (skips config validation) when OCI artifact fetch fails."""
+    import copy
+    from azure.cli.core.azclierror import ValidationError
+
+    graph_name = generate_random_string()
+    profile_name = generate_random_string()
+    instance_name = "myinstance"
+    resource_group_name = "myresourcegroup"
+
+    graph_properties = copy.deepcopy(_GRAPH_NODE_BASE_PROPERTIES)
+    # No configuration — but fetch will fail so validation is skipped entirely
+    file_payload = {"properties": graph_properties}
+    mocked_get_file_config.return_value = json.dumps(file_payload)
+
+    mock_instance_record = get_mock_instance_record(
+        name=instance_name, resource_group_name=resource_group_name
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=get_instance_endpoint(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+        ),
+        json=mock_instance_record,
+        status=200,
+    )
+    _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_group_name, "myregistry")
+
+    # Simulate OCI fetch failure — apply should proceed without error
+    mock_oci = mocker.MagicMock()
+    mock_oci.fetch_first_layer.side_effect = ValidationError("registry unreachable")
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.dataflow_graphs.get_oci_client",
+        return_value=mock_oci,
+    )
 
     mocked_responses.add(
         method=responses.PUT,

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -1215,6 +1215,26 @@ def _setup_graph_node_apply_mocks(mocked_responses, instance_name, resource_grou
             [{"key": "optionalParam", "value": "something"}],
             "requires configuration parameter(s) ['rules']",
         ),
+        # Key present but value is None — should not count as provided
+        (
+            [{"key": "rules", "value": None}],
+            "requires configuration parameter(s) ['rules']",
+        ),
+        # Key present but value is empty string — should not count as provided
+        (
+            [{"key": "rules", "value": ""}],
+            "requires configuration parameter(s) ['rules']",
+        ),
+        # Key present but value is whitespace only — should not count as provided
+        (
+            [{"key": "rules", "value": "   "}],
+            "requires configuration parameter(s) ['rules']",
+        ),
+        # Entry has no value field at all — should not count as provided
+        (
+            [{"key": "rules"}],
+            "requires configuration parameter(s) ['rules']",
+        ),
     ],
 )
 def test_dataflow_graph_apply_missing_required_config(

--- a/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_dataflow_graphs_unit.py
@@ -13,7 +13,7 @@ import pytest
 import responses
 
 from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
-from azure.core.exceptions import ResourceNotFoundError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
 from azext_edge.edge.commands_dataflowgraph import (
     apply_dataflow_graph,
@@ -1341,13 +1341,22 @@ def test_dataflow_graph_apply_with_graph_node_all_required_config_provided(
     assert result == file_payload
 
 
+@pytest.mark.parametrize(
+    "fetch_side_effect",
+    [
+        ValidationError("registry unreachable"),
+        HttpResponseError(message="connection error"),
+    ],
+    ids=["ValidationError", "HttpResponseError"],
+)
 def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
     mocked_cmd,
     mocked_responses: responses,
     mocked_get_file_config,
     mocker,
+    fetch_side_effect,
 ):
-    """Apply succeeds (skips config validation) when OCI artifact fetch fails."""
+    """Apply succeeds (skips config validation) when OCI artifact fetch raises ValidationError or HttpResponseError."""
 
     graph_name = generate_random_string()
     profile_name = generate_random_string()
@@ -1375,7 +1384,7 @@ def test_dataflow_graph_apply_with_graph_node_oci_fetch_failure(
 
     # Simulate OCI fetch failure — apply should proceed without error
     mock_oci = mocker.MagicMock()
-    mock_oci.fetch_first_layer.side_effect = ValidationError("registry unreachable")
+    mock_oci.fetch_first_layer.side_effect = fetch_side_effect
     mocker.patch(
         "azext_edge.edge.providers.orchestration.resources.dataflow_graphs.get_oci_client",
         return_value=mock_oci,


### PR DESCRIPTION
- Validates node connection directions: rejects graphs where a Destination node is used as from or a Source node is used as to

- Validates required graph node config params: fetches the OCI artifact YAML at apply time and errors if any required: true parameters are missing from graphSettings.configuration

- Updates dataflowgraph apply help text with a Graph node example showing the configuration key-value pair format

This is how output looks like when required param for graph node setting are not present:

<img width="1748" height="73" alt="image" src="https://github.com/user-attachments/assets/9c340a37-21e9-4445-9d62-82ac1b3bf822" />



--
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
