### PR TITLE
build: version increments for 2605 release

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.6.0a1"
+VERSION = "2.6.0"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.6.0a2"
+VERSION = "2.6.0"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.6.0"
+VERSION = "2.6.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -1448,7 +1448,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
         },
         "variables": {
             "VERSIONS": {"iotOperations": "1.3.105"},
-            "TRAINS": {"iotOperations": "integration"},
+            "TRAINS": {"iotOperations": "stable"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "CUSTOM_LOCATION_NAMESPACE": "[parameters('clusterNamespace')]",

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -54,7 +54,7 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
-        "metadata": {"_generator": {"name": "bicep", "version": "0.36.1.42791", "templateHash": "15536803533032806041"}},
+        "metadata": {"_generator": {"name": "bicep", "version": "0.43.8.12551", "templateHash": "10429247713227659883"}},
         "definitions": {
             "_1.AdvancedConfig": {
                 "type": "object",
@@ -760,7 +760,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.36.1.42791", "templateHash": "5076302837080998602"}
+            "_generator": {"name": "bicep", "version": "0.43.8.12551", "templateHash": "5208211492871219312"}
         },
         "definitions": {
             "_1.AdvancedConfig": {

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -49,12 +49,12 @@ class TemplateBlueprint(NamedTuple):
 
 
 TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
-    commit_id="cb318bfe4bc1fcc887fb3f902436110a713fe797",
+    commit_id="c0eedd7b4a50a5e4bc83cd43d3bda34be6e5e19d",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
-        "metadata": {"_generator": {"name": "bicep", "version": "0.42.1.51946", "templateHash": "10665750777960080296"}},
+        "metadata": {"_generator": {"name": "bicep", "version": "0.36.1.42791", "templateHash": "15536803533032806041"}},
         "definitions": {
             "_1.AdvancedConfig": {
                 "type": "object",
@@ -676,7 +676,7 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"certManager": "0.11.0", "secretStore": "1.4.0"},
+            "VERSIONS": {"certManager": "0.12.0", "secretStore": "1.4.1"},
             "TRAINS": {"certManager": "stable", "secretStore": "stable"},
         },
         "resources": {
@@ -754,13 +754,13 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
 )
 
 TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
-    commit_id="f3f0f91039428f78b382b6ef9bdf194a51d8e684",
+    commit_id="10b8355545af3a29f48fafd6e936ef120e4f74c8",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.42.1.51946", "templateHash": "11558826619663515380"}
+            "_generator": {"name": "bicep", "version": "0.36.1.42791", "templateHash": "5076302837080998602"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -1447,8 +1447,8 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.3.70"},
-            "TRAINS": {"iotOperations": "stable"},
+            "VERSIONS": {"iotOperations": "1.3.105"},
+            "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "CUSTOM_LOCATION_NAMESPACE": "[parameters('clusterNamespace')]",

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -154,7 +154,7 @@ EXTENSION_CONFIGS = {
         (EXTENSION_TYPE_SSC, "1.4.1", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.3.105", "integration"),
+        (EXTENSION_TYPE_OPS, "1.3.105", "stable"),
     ],
 }
 

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -150,11 +150,11 @@ def test_template_blueprint(content: dict):
 
 EXTENSION_CONFIGS = {
     "enablement": [
-        (EXTENSION_TYPE_CM, "0.11.0", "stable"),
-        (EXTENSION_TYPE_SSC, "1.4.0", "stable"),
+        (EXTENSION_TYPE_CM, "0.12.0", "stable"),
+        (EXTENSION_TYPE_SSC, "1.4.1", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.3.70", "stable"),
+        (EXTENSION_TYPE_OPS, "1.3.105", "integration"),
     ],
 }
 


### PR DESCRIPTION
## Version Increments
- `VERSION`: `2.5.0` → `2.6.0` (will be updated again until stable train)
- `AIO_RELEASE`: `2604` → `2605`

## Template Updates
**Enablement** (`azure-iot-operations-enablement.bicep`)
- `commit_id`: `cb318bfe4bc1fcc887fb3f902436110a713fe797` → `c0eedd7b4a50a5e4bc83cd43d3bda34be6e5e19d`
- `_generator.version`: `0.42.1.51946` → `0.43.8.12551`
- `_generator.templateHash`: `10665750777960080296` → `10429247713227659883`
- `VERSIONS.certManager`: `0.11.0` → `0.12.0`
- `VERSIONS.secretStore`: `1.4.0` → `1.4.1`
- `TRAINS`: unchanged (`certManager: stable`, `secretStore: stable`)

**Instance** (`azure-iot-operations-instance.bicep`)
- `commit_id`: `f3f0f91039428f78b382b6ef9bdf194a51d8e684` → `10b8355545af3a29f48fafd6e936ef120e4f74c8`
- `_generator.version`: `0.42.1.51946` → `0.43.8.12551`
- `_generator.templateHash`: `11558826619663515380` → `5208211492871219312`
- `VERSIONS.iotOperations`: `1.3.70` → `1.3.105`
- `TRAINS.iotOperations`: `stable`
