### PR TITLE
feat: add workflow to trigger dashboard refresh after integration tests

### DIFF
--- a/.github/workflows/refresh_dashboard.yml
+++ b/.github/workflows/refresh_dashboard.yml
@@ -9,18 +9,9 @@ jobs:
   notify-dashboard:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DASHBOARD_APP_ID }}
-          private-key: ${{ secrets.DASHBOARD_APP_PRIVATE_KEY }}
-          owner: Azure
-          repositories: azure-iot-cli-extension
-
       - name: Trigger dashboard refresh
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.DASHBOARD_PAT }}
         run: |
           gh api \
             --method POST \

--- a/.github/workflows/refresh_dashboard.yml
+++ b/.github/workflows/refresh_dashboard.yml
@@ -1,0 +1,30 @@
+name: Refresh Dashboard
+
+on:
+  workflow_run:
+    workflows: ["Integration tests"]
+    types: [completed]
+
+jobs:
+  notify-dashboard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DASHBOARD_APP_ID }}
+          private-key: ${{ secrets.DASHBOARD_APP_PRIVATE_KEY }}
+          owner: Azure
+          repositories: azure-iot-cli-extension
+
+      - name: Trigger dashboard refresh
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            /repos/Azure/azure-iot-cli-extension/dispatches \
+            -f "event_type=refresh-dashboard" \
+            -f "client_payload[source]=azure-iot-ops-cli-extension"

--- a/.github/workflows/refresh_dashboard.yml
+++ b/.github/workflows/refresh_dashboard.yml
@@ -9,9 +9,18 @@ jobs:
   notify-dashboard:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DASHBOARD_APP_ID }}
+          private-key: ${{ secrets.DASHBOARD_APP_PRIVATE_KEY }}
+          owner: Azure
+          repositories: azure-iot-cli-extension
+
       - name: Trigger dashboard refresh
         env:
-          GH_TOKEN: ${{ secrets.DASHBOARD_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api \
             --method POST \


### PR DESCRIPTION
## Summary
Adds a workflow that triggers the Azure IoT CLI Dashboard refresh after integration tests complete in this repo.

### What's included
- `.github/workflows/refresh_dashboard.yml` — Sends `repository_dispatch` to `azure-iot-cli-extension` after integration tests complete

### Auth
Uses `iot-dashboard-bot` GitHub App token (no PAT required). Secrets: `DASHBOARD_APP_ID`, `DASHBOARD_APP_PRIVATE_KEY`.

### Related
- CLI extension PR: https://github.com/Azure/azure-iot-cli-extension/pull/838