### PR TITLE
feat(adr): generalize asset data (dataset and datapoint) comands

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -330,6 +330,30 @@ def load_iotops_commands(self, _):
             cmd_group.command("create", f"create_namespace_{asset_type}_asset")
             cmd_group.command("update", f"update_namespace_{asset_type}_asset")
 
+    # generalized dataset group (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset dataset",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_dataset")
+        cmd_group.command("export", "export_namespace_asset_dataset")
+        cmd_group.command("import", "import_namespace_asset_dataset")
+        cmd_group.command("list", "list_namespace_asset_datasets")
+        cmd_group.command("remove", "remove_namespace_asset_dataset")
+        cmd_group.show_command("show", "show_namespace_asset_dataset")
+        cmd_group.command("update", "update_namespace_asset_dataset")
+
+    # generalized datapoint group (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset datapoint",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_dataset_point")
+        cmd_group.command("export", "export_namespace_asset_dataset_point")
+        cmd_group.command("import", "import_namespace_asset_dataset_point")
+        cmd_group.command("list", "list_namespace_asset_dataset_points")
+        cmd_group.command("remove", "remove_namespace_asset_dataset_point")
+
     # dataset
     for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -3087,3 +3087,98 @@ export_namespace_custom_asset_management_group_action = _make_mgmt_action_export
 export_namespace_opcua_asset_management_group_action = _make_mgmt_action_export_func("export_management_group_actions")
 import_namespace_custom_asset_management_group_action = _make_mgmt_action_import_func("import_management_group_actions")
 import_namespace_opcua_asset_management_group_action = _make_mgmt_action_import_func("import_management_group_actions")
+
+
+# GENERALIZED DATASET COMMANDS
+
+
+def add_namespace_asset_dataset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_name: str,
+    data_source: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    dataset_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).add_dataset_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        replace=replace,
+        dataset_config=dataset_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+def update_namespace_asset_dataset(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_name: str,
+    data_source: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    dataset_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update_dataset_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        dataset_config=dataset_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_dataset = _make_export_func("export_datasets")
+import_namespace_asset_dataset = _make_import_func("import_datasets")
+
+
+# GENERALIZED DATAPOINT COMMANDS
+
+
+def add_namespace_asset_dataset_point(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    dataset_name: str,
+    datapoint_name: str,
+    data_source: str,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    datapoint_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> List[dict]:
+    return NamespaceAssets(cmd).add_dataset_datapoint_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        datapoint_name=datapoint_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        replace=replace,
+        datapoint_config=datapoint_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_dataset_point = _make_datapoint_export_func("export_dataset_datapoints")
+import_namespace_asset_dataset_point = _make_datapoint_import_func("import_dataset_datapoints")

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -2117,6 +2117,112 @@ def load_iotops_arguments(self, _):
             "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
         )
 
+    with self.argument_context("iot ops ns asset dataset") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "dataset_name",
+            options_list=["--name", "-n"],
+            help="Dataset name.",
+        )
+        context.argument(
+            "data_source",
+            options_list=["--data-source", "--ds"],
+            help="Data source for the dataset.",
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "dataset_config",
+            options_list=["--dataset-config", "--dc"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific dataset configuration and/or destinations. Accepted keys are "
+            "'datasetConfiguration' (connector-specific config object) and 'destinations' (list of "
+            "destination objects). Use --show-template to discover the supported keys and schema "
+            "for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter dataset configuration template for the asset's connector type and "
+            "exit without modifying the dataset. The connector type is read from the existing asset. "
+            "config: fields shown with their default values (null if no default); output is "
+            "directly usable as --dataset-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset dataset add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the dataset if another dataset with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset datapoint") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "dataset_name",
+            options_list=["--dataset", "-d"],
+            help="Dataset name.",
+        )
+        context.argument(
+            "datapoint_name",
+            options_list=["--name", "-n"],
+            help="Data point name.",
+        )
+        context.argument(
+            "data_source",
+            options_list=["--data-source", "--ds"],
+            help="Data source for the data point.",
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "datapoint_config",
+            options_list=["--datapoint-config", "--dpc"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific datapoint configuration. Accepted key is 'datapointConfiguration' "
+            "(connector-specific config object). Use --show-template to discover the supported keys "
+            "and schema for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter datapoint configuration template for the asset's connector type "
+            "and exit without modifying the datapoint. The connector type is read from the existing "
+            "asset. config: fields shown with their default values (null if no default); output is "
+            "directly usable as --datapoint-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset datapoint add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the data point if another point with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
     with self.argument_context("iot ops clone") as context:
         context.argument(
             "summary_mode",

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -2171,27 +2171,27 @@ def load_iotops_arguments(self, _):
     with self.argument_context("iot ops ns asset dataset export") as context:
         context.argument(
             "extension",
-            options_list=["--format", "--ext"],
-            arg_type=get_enum_type(FileType),
-            help="File format to export the datasets to.",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type([FileType.json.value, FileType.yaml.value], default=FileType.json.value),
+            help="Export file format (JSON or YAML).",
         )
         context.argument(
             "output_dir",
             options_list=["--output-dir", "--od"],
-            help="Directory to export the datasets file to. Defaults to the current directory.",
+            help="Output directory for export.",
         )
         context.argument(
             "replace",
             options_list=["--replace"],
-            help="Overwrite the export file if it already exists.",
+            help="Replace the local file if present.",
             arg_type=get_three_state_flag(),
         )
 
     with self.argument_context("iot ops ns asset dataset import") as context:
         context.argument(
             "file_path",
-            options_list=["--file-path", "--fp"],
-            help="Path to the file (.json, .yaml, .yml) containing the datasets to import.",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON or YAML).",
         )
         context.argument(
             "replace",
@@ -2258,27 +2258,27 @@ def load_iotops_arguments(self, _):
     with self.argument_context("iot ops ns asset datapoint export") as context:
         context.argument(
             "extension",
-            options_list=["--format", "--ext"],
-            arg_type=get_enum_type(FileType),
-            help="File format to export the data points to.",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type(FileType, default=FileType.json.value),
+            help="Export file format.",
         )
         context.argument(
             "output_dir",
             options_list=["--output-dir", "--od"],
-            help="Directory to export the data points file to. Defaults to the current directory.",
+            help="Output directory for export.",
         )
         context.argument(
             "replace",
             options_list=["--replace"],
-            help="Overwrite the export file if it already exists.",
+            help="Replace the local file if present.",
             arg_type=get_three_state_flag(),
         )
 
     with self.argument_context("iot ops ns asset datapoint import") as context:
         context.argument(
             "file_path",
-            options_list=["--file-path", "--fp"],
-            help="Path to the file (.json, .yaml, .yml) containing the data points to import.",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON, YAML, or CSV).",
         )
         context.argument(
             "replace",

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -49,7 +49,7 @@ from .providers.orchestration.common import (
     TlsKeyAlgo,
     TlsKeyRotation,
 )
-from .providers.adr.common import EndpointTemplateMode
+from .providers.adr.common import EndpointTemplateMode, FileType
 
 
 def load_iotops_arguments(self, _):
@@ -2168,6 +2168,38 @@ def load_iotops_arguments(self, _):
             arg_type=get_three_state_flag(),
         )
 
+    with self.argument_context("iot ops ns asset dataset export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "--ext"],
+            arg_type=get_enum_type(FileType),
+            help="File format to export the datasets to.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Directory to export the datasets file to. Defaults to the current directory.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Overwrite the export file if it already exists.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset dataset import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--file-path", "--fp"],
+            help="Path to the file (.json, .yaml, .yml) containing the datasets to import.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing datasets that share a name with an imported dataset.",
+            arg_type=get_three_state_flag(),
+        )
+
     with self.argument_context("iot ops ns asset datapoint") as context:
         context.argument(
             "asset_name",
@@ -2220,6 +2252,38 @@ def load_iotops_arguments(self, _):
             "replace",
             options_list=["--replace"],
             help="Replace the data point if another point with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset datapoint export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "--ext"],
+            arg_type=get_enum_type(FileType),
+            help="File format to export the data points to.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Directory to export the data points file to. Defaults to the current directory.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Overwrite the export file if it already exists.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset datapoint import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--file-path", "--fp"],
+            help="Path to the file (.json, .yaml, .yml) containing the data points to import.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing data points that share a name with an imported data point.",
             arg_type=get_three_state_flag(),
         )
 

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -169,7 +169,7 @@ def load_iotops_adr_help():
     ] = """
         type: command
         short-summary: Add a datapoint to an asset dataset.
-        long-summary: If no datasets exist yet, this will create a new dataset. Currently, only one dataset is supported with the name "default".
+        long-summary: If no datasets exist yet, this will create a new dataset.
 
         examples:
         - name: Add a datapoint to an asset.
@@ -1090,6 +1090,13 @@ def load_iotops_adr_help():
     ] = """
         type: command
         short-summary: Update a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Use --asset-config to supply connector-specific configuration (defaultDatasetsConfiguration,
+            defaultEventsConfiguration, etc.). Use --show-template config to see the current asset
+            configuration pre-filled with existing values (ready to edit and pass back via
+            --asset-config). Use --show-template schema to see the full connector schema with types
+            and constraints.
 
         examples:
         - name: Update an asset's basic properties
@@ -1113,10 +1120,15 @@ def load_iotops_adr_help():
             --asset-config path/to/config.yaml --description "Updated factory sensor" --display-name "My Asset v2"
             --manufacturer "Contoso" --model "SensorX1" --serial-number "SN-001"
 
-        - name: Show the configuration template for the asset's connector type without updating
+        - name: Show current asset config pre-filled with existing values (for editing before update)
           text: >
             az iot ops ns asset update --name myasset --instance myInstance -g myInstanceResourceGroup
             --show-template config
+
+        - name: Show the full connector schema structure with types and constraints
+          text: >
+            az iot ops ns asset update --name myasset --instance myInstance -g myInstanceResourceGroup
+            --show-template schema
     """
 
     helps[
@@ -1199,7 +1211,6 @@ def load_iotops_adr_help():
     ] = """
         type: group
         short-summary: Manage datasets for custom namespaced assets in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
     """
 
     helps[
@@ -2376,11 +2387,271 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset dataset"
+    ] = """
+        type: group
+        short-summary: Manage datasets for namespaced assets in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --dataset-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset dataset add"
+    ] = """
+        type: command
+        short-summary: Add a dataset to a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration (publishing interval, queue size, etc.) can
+            be supplied via --dataset-config. Use --show-template to discover the supported config
+            schema. For non-OPC UA connectors, a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic dataset to any asset type
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --data-source "ns=2;s=Temperature"
+
+        - name: Show the dataset config template for the asset's connector type
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --show-template config
+
+        - name: Add a dataset with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default
+            --dataset-config '{"datasetConfiguration": {"publishingInterval": 1000, "samplingInterval": 500}}'
+
+        - name: Add a dataset with configuration from a file
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --dataset-config ./dataset_config.json
+
+        - name: Add a dataset with an MQTT destination
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default
+            --dataset-config '{"destinations": [{"target": "Mqtt", "configuration": {"topic": "factory/data", "retain": "Keep", "qos": "Qos1", "ttl": 3600}}]}'
+
+        - name: Replace an existing dataset
+          text: >
+            az iot ops ns asset dataset add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --replace
+    """
+
+    helps[
+        "iot ops ns asset dataset update"
+    ] = """
+        type: command
+        short-summary: Update a dataset for a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Use --dataset-config to supply connector-specific configuration.
+            Use --show-template config to see current dataset values pre-filled in the full schema
+            structure (ready to edit and pass back via --dataset-config).
+            Use --show-template schema to see the full connector schema with types and constraints.
+
+        examples:
+        - name: Show current dataset config pre-filled with existing values (for editing before update)
+          text: >
+            az iot ops ns asset dataset update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --show-template config
+
+        - name: Show the dataset config schema with types and constraints
+          text: >
+            az iot ops ns asset dataset update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --show-template schema
+
+        - name: Update dataset configuration from inline JSON
+          text: >
+            az iot ops ns asset dataset update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default
+            --dataset-config '{"datasetConfiguration": {"publishingInterval": 2000}}'
+
+        - name: Update dataset data source
+          text: >
+            az iot ops ns asset dataset update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default --data-source "ns=3;s=UpdatedSensor"
+    """
+
+    helps[
+        "iot ops ns asset dataset list"
+    ] = """
+        type: command
+        short-summary: List datasets for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: List all datasets for an asset
+          text: >
+            az iot ops ns asset dataset list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset dataset remove"
+    ] = """
+        type: command
+        short-summary: Remove a dataset from a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Remove a dataset from an asset
+          text: >
+            az iot ops ns asset dataset remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default
+    """
+
+    helps[
+        "iot ops ns asset dataset show"
+    ] = """
+        type: command
+        short-summary: Show details of a dataset for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Show dataset details
+          text: >
+            az iot ops ns asset dataset show --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name default
+    """
+
+    helps[
+        "iot ops ns asset dataset export"
+    ] = """
+        type: command
+        short-summary: Export datasets to file.
+
+        examples:
+        - name: Export datasets to JSON
+          text: >
+            az iot ops ns asset dataset export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset dataset import"
+    ] = """
+        type: command
+        short-summary: Import datasets from file.
+
+        examples:
+        - name: Import datasets from a JSON file
+          text: >
+            az iot ops ns asset dataset import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --input-file ./datasets.json
+    """
+
+    helps[
+        "iot ops ns asset datapoint"
+    ] = """
+        type: group
+        short-summary: Manage data points for asset datasets in IoT Operations namespaces.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --datapoint-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset datapoint add"
+    ] = """
+        type: command
+        short-summary: Add a datapoint to an asset dataset in an IoT Operations namespace.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration (queue size, sampling interval, etc.)
+            can be supplied via --datapoint-config. Use --show-template to discover the supported
+            config schema. For non-OPC UA connectors, a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic datapoint to any asset type
+          text: >
+            az iot ops ns asset datapoint add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "ns=2;s=Temp1"
+
+        - name: Show the datapoint config template for the asset's connector type
+          text: >
+            az iot ops ns asset datapoint add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "ns=2;s=Temp1"
+            --show-template config
+
+        - name: Add a datapoint with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset datapoint add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "ns=2;s=Temp1"
+            --datapoint-config '{"datapointConfiguration": {"samplingInterval": 1000, "queueSize": 5}}'
+
+        - name: Add a datapoint with configuration from a file
+          text: >
+            az iot ops ns asset datapoint add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "ns=2;s=Temp1"
+            --datapoint-config ./datapoint_config.json
+
+        - name: Replace an existing datapoint
+          text: >
+            az iot ops ns asset datapoint add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1 --data-source "ns=3;s=NewTemp"
+            --replace
+    """
+
+    helps[
+        "iot ops ns asset datapoint list"
+    ] = """
+        type: command
+        short-summary: List data points for an asset dataset in an IoT Operations namespace.
+
+        examples:
+        - name: List all data points for a dataset
+          text: >
+            az iot ops ns asset datapoint list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default
+    """
+
+    helps[
+        "iot ops ns asset datapoint remove"
+    ] = """
+        type: command
+        short-summary: Remove a datapoint from an asset dataset in an IoT Operations namespace.
+
+        examples:
+        - name: Remove a datapoint from a dataset
+          text: >
+            az iot ops ns asset datapoint remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --name temp1
+    """
+
+    helps[
+        "iot ops ns asset datapoint export"
+    ] = """
+        type: command
+        short-summary: Export datapoints to file.
+
+        examples:
+        - name: Export datapoints to JSON
+          text: >
+            az iot ops ns asset datapoint export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default
+    """
+
+    helps[
+        "iot ops ns asset datapoint import"
+    ] = """
+        type: command
+        short-summary: Import datapoints from file.
+
+        examples:
+        - name: Import datapoints from a JSON file
+          text: >
+            az iot ops ns asset datapoint import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --dataset default --input-file ./datapoints.json
+    """
+
+    helps[
         "iot ops ns asset opcua dataset"
     ] = """
         type: group
         short-summary: Manage datasets for OPC UA namespaced assets in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
     """
 
     helps[
@@ -2990,7 +3261,6 @@ def load_iotops_adr_help():
     ] = """
         type: group
         short-summary: Manage datasets for REST namespaced assets in an IoT Operations instance.
-        long-summary: Currently, only one dataset with the name "default" is supported for assets.
     """
 
     helps[

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -165,6 +165,10 @@ def get_default_dataset(asset: dict, dataset_name: str, create_if_none: bool = F
     asset["properties"]["datasets"] = asset["properties"].get("datasets", [])
     datasets = asset["properties"]["datasets"]
     matched_datasets = [dset for dset in datasets if dset["name"] == dataset_name]
+    # backward compat: assets created during the transition period may have a single
+    # dataset with an empty name that represents the "default" dataset
+    if not matched_datasets and dataset_name == "default":
+        matched_datasets = [dset for dset in datasets if dset["name"] == ""]
     if not matched_datasets and create_if_none:
         matched_datasets = [{}]
         datasets.extend(matched_datasets)

--- a/azext_edge/edge/providers/adr/helpers.py
+++ b/azext_edge/edge/providers/adr/helpers.py
@@ -155,31 +155,21 @@ def get_query(param_mapping: Dict[str, str], params: Dict[str, Union[str, bool]]
 
 def get_default_dataset(asset: dict, dataset_name: str, create_if_none: bool = False):
     """
-    Temporary helper function to get a dataset from an asset.
+    Helper function to get or create a dataset from an asset by name.
 
-    If the dataset is not found but it has the name 'default' and create_if_none is True,
-    it will create a new dataset with that name that is added to the asset's datasets.
+    If the dataset is not found and create_if_none is True, a new empty dataset
+    with the given name is created and appended to the asset's datasets list.
 
-    Will raise errors if the dataset is not found and create_if_none is False, or
-    if the dataset name is not 'default' and create_if_none is True.
+    Raises an error if the dataset is not found and create_if_none is False.
     """
-    # ensure datasets will get populated if not there
     asset["properties"]["datasets"] = asset["properties"].get("datasets", [])
     datasets = asset["properties"]["datasets"]
     matched_datasets = [dset for dset in datasets if dset["name"] == dataset_name]
-    # Temporary convert empty names to default
-    if not matched_datasets and dataset_name == "default":
-        matched_datasets = [dset for dset in datasets if dset["name"] == ""]
-    # create if add or import (and no datasets yet)
     if not matched_datasets and create_if_none:
-        if dataset_name != "default":
-            raise InvalidArgumentValueError("Currently only one dataset with the name default is supported.")
         matched_datasets = [{}]
         datasets.extend(matched_datasets)
     elif not matched_datasets:
         raise InvalidArgumentValueError(f"Dataset {dataset_name} not found in asset {asset['name']}.")
-    # note: right now we can have datasets with the same name but this will not be allowed later
-    # part of the temporary convert
     matched_datasets[0]["name"] = dataset_name
     return matched_datasets[0]
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -345,8 +345,7 @@ class NamespaceAssets(Queryable):
 
         OPC UA uses bundled metadata; all other types fetch from OCI via the connector template.
         """
-        from .namespace_devices import DeviceEndpointType as _DEType
-        from .helpers import load_opcua_metadata_file as _load_opcua_metadata_file, _slim_schema, _consolidate_warnings
+        from .helpers import _slim_schema, _consolidate_warnings
         from .common import EndpointTemplateMode
 
         if asset_config:
@@ -355,47 +354,11 @@ class NamespaceAssets(Queryable):
                 "--show-template displays the template and exits without creating an asset."
             )
 
-        is_opcua = connector_type.lower() == _DEType.OPCUA.value.lower()
-
-        if is_opcua:
-            from azure.core.exceptions import ResourceNotFoundError as _AzureNotFoundError
-            from .helpers import get_opcua_info as _get_opcua_info
-            metadata = None
-            if instance_name and instance_resource_group:
-                try:
-                    metadata = _get_opcua_info(self.cmd, instance_name, instance_resource_group)
-                except _AzureNotFoundError:
-                    pass  # instance / resource-group not found – use bundled metadata
-            if metadata is None:
-                metadata = _load_opcua_metadata_file()
-        else:
-            from ..orchestration.resources.connector_templates import ConnectorTemplates
-            connector_templates = ConnectorTemplates(cmd=self.cmd)
-            template = connector_templates.get_connector_template_for_type(
-                instance_name=instance_name,
-                instance_resource_group=instance_resource_group,
-                connector_type=connector_type,
-            )
-            if template is None:
-                from azure.cli.core.azclierror import ResourceNotFoundError
-                raise ResourceNotFoundError(
-                    f"No connector template found for connector type '{connector_type}' "
-                    f"in instance '{instance_name}'.\n"
-                    "Create one with: az iot ops connector template create ..."
-                )
-            connector_metadata_ref = template.get("properties", {}).get("connectorMetadataRef")
-            if not connector_metadata_ref:
-                from azure.cli.core.azclierror import ValidationError
-                raise ValidationError(
-                    f"Connector template for '{connector_type}' is missing connectorMetadataRef."
-                )
-            from ...util.oci_client import get_oci_client
-            oci_client = get_oci_client()
-            artifact = oci_client.fetch_first_layer(
-                image_ref=connector_metadata_ref,
-                cmd=self.cmd,
-            )
-            metadata = json.loads(artifact.content.decode("utf-8"))
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
 
         endpoint = _get_metadata_endpoint(metadata, connector_type)
 
@@ -648,13 +611,48 @@ class NamespaceAssets(Queryable):
                     "--show-template and --asset-config cannot be used together. "
                     "--show-template displays the template and exits without updating the asset."
                 )
-            return self._handle_asset_show_template(
-                connector_type=connector_type,
-                instance_name=instance_name,
-                instance_resource_group=instance_resource_group,
-                template_mode=show_template.lower(),
-                asset_config=None,
-            )
+            from .common import EndpointTemplateMode
+            template_mode = show_template.lower()
+            if template_mode == EndpointTemplateMode.CONFIG.value:
+                # For config mode on update: show the full connector schema structure (same as create)
+                # but with existing ARM values pre-filled so the user can see all fields and
+                # only edit what they want.
+                template_result = self._handle_asset_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    asset_config=None,
+                )
+                asset_config_tmpl = template_result.get("assetConfig", {})
+                existing_props = existing_asset.get("properties", {})
+                for _, _, config_prop, _, dest_prop in _ASSET_SCHEMA_SECTIONS:
+                    raw = existing_props.get(config_prop)
+                    if raw is not None:
+                        existing_config = json.loads(raw) if isinstance(raw, str) else raw
+                        tmpl_val = asset_config_tmpl.get(config_prop)
+                        asset_config_tmpl[config_prop] = (
+                            _deep_merge_template(tmpl_val, existing_config)
+                            if isinstance(tmpl_val, dict)
+                            else existing_config
+                        )
+                    if dest_prop is not None:
+                        existing_dests = existing_props.get(dest_prop, [])
+                        if existing_dests:
+                            tmpl_dests = asset_config_tmpl.get(dest_prop, [])
+                            asset_config_tmpl[dest_prop] = _merge_destinations_template(
+                                tmpl_dests, existing_dests
+                            )
+                return {"connectorType": connector_type, "assetConfig": asset_config_tmpl}
+            else:
+                # For schema mode, show connector metadata schema structure (same as create)
+                return self._handle_asset_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    asset_config=None,
+                )
 
         # namespace_from_asset already contains the resource_group and name derived from the asset
         # ARM id — no need for a separate get_namespace_for_instance HTTP call.
@@ -712,6 +710,656 @@ class NamespaceAssets(Queryable):
                 resource_group=namespace["resource_group"],
             )
 
+    def _get_connector_type_from_asset(self, asset: dict) -> str:
+        """Extract the connector type from an existing asset via its device endpoint type."""
+        device_ref = asset.get("properties", {}).get("deviceRef", {})
+        device_name = device_ref.get("deviceName", "")
+        endpoint_name = device_ref.get("endpointName", "")
+        namespace = parse_resource_id(asset["id"])
+
+        device = self.device_ops.get(
+            resource_group_name=namespace["resource_group"],
+            namespace_name=namespace["name"],
+            device_name=device_name,
+        )
+        endpoint = (
+            device.get("properties", {})
+            .get("endpoints", {})
+            .get("inbound", {})
+            .get(endpoint_name, {})
+        )
+        connector_type = endpoint.get("endpointType", "")
+        if not connector_type:
+            raise InvalidArgumentValueError(
+                f"Cannot determine connector type for asset '{asset.get('name', '')}'. "
+                f"Device '{device_name}' endpoint '{endpoint_name}' is missing 'endpointType'. "
+                "Verify the device endpoint was created correctly."
+            )
+        return connector_type
+
+    def _get_connector_metadata(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load and return connector metadata for the given connector type.
+
+        For OPC UA: uses bundled metadata (with optional live lookup when instance info is available).
+        For other types: fetches from OCI via connector template, which must exist in the instance.
+        Raises ResourceNotFoundError if a non-OPC UA connector template is not found.
+        """
+        from .namespace_devices import DeviceEndpointType as _DEType
+        from .helpers import load_opcua_metadata_file as _load_opcua_metadata_file
+
+        is_opcua = connector_type.lower() == _DEType.OPCUA.value.lower()
+        if is_opcua:
+            from azure.core.exceptions import ResourceNotFoundError as _AzureNotFoundError
+            from .helpers import get_opcua_info as _get_opcua_info
+
+            metadata = None
+            if instance_name and instance_resource_group:
+                try:
+                    metadata = _get_opcua_info(self.cmd, instance_name, instance_resource_group)
+                except _AzureNotFoundError:
+                    pass
+            if metadata is None:
+                metadata = _load_opcua_metadata_file()
+            return metadata
+
+        from ..orchestration.resources.connector_templates import ConnectorTemplates
+        connector_templates = ConnectorTemplates(cmd=self.cmd)
+        template = connector_templates.get_connector_template_for_type(
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            connector_type=connector_type,
+        )
+        if template is None:
+            from azure.cli.core.azclierror import ResourceNotFoundError
+            raise ResourceNotFoundError(
+                f"No connector template found for connector type '{connector_type}' "
+                f"in instance '{instance_name}'.\n"
+                f"A connector template is required for connector type '{connector_type}'.\n"
+                "Create one with: az iot ops connector template create ..."
+            )
+        connector_metadata_ref = template.get("properties", {}).get("connectorMetadataRef")
+        if not connector_metadata_ref:
+            raise ValidationError(
+                f"Connector template for '{connector_type}' is missing connectorMetadataRef. "
+                "Cannot proceed."
+            )
+        from ...util.oci_client import get_oci_client
+        oci_client = get_oci_client()
+        artifact = oci_client.fetch_first_layer(
+            image_ref=connector_metadata_ref,
+            cmd=self.cmd,
+        )
+        return json.loads(artifact.content.decode("utf-8"))
+
+    def _handle_dataset_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        dataset_config: Optional[str],
+    ) -> dict:
+        """Return a dataset config/schema template for --show-template and exit early.
+
+        Discovers the datasetConfigurationSchema and supported destinations from connector
+        metadata and returns a slimmed template. OPC UA uses bundled metadata; all other types
+        require a connector template in the instance.
+        """
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        if dataset_config:
+            raise InvalidArgumentValueError(
+                "--show-template and --dataset-config cannot be used together. "
+                "--show-template displays the template and exits without modifying the dataset."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        dataset_section = endpoint.get("datasets", {})
+        schema = dataset_section.get("datasetConfigurationSchema")
+
+        dataset_config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            dataset_config_template["datasetConfiguration"] = slimmed
+
+        dest_section = dataset_section.get("destinations", {})
+        supported = dest_section.get("supportedDestinations", []) if isinstance(dest_section, dict) else []
+        if supported:
+            dataset_config_template["destinations"] = _build_destination_template(
+                supported_destinations=supported,
+                default_destination=dest_section.get("defaultDestination"),
+                mode=template_mode,
+            )
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, "datasetConfig": dataset_config_template}
+
+    def _load_and_validate_dataset_config(
+        self,
+        dataset_config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load dataset config from file/inline JSON, validate against connector schema, and return
+        ARM-ready values.
+
+        Input JSON is expected to be the 'datasetConfig' dict (output of --show-template), e.g.:
+          {
+            "datasetConfiguration": {...},
+            "destinations": [...]
+          }
+        Or the full --show-template output with 'connectorType' and 'datasetConfig' keys,
+        which is auto-unwrapped.
+
+        Returns a dict with:
+          - "datasetConfiguration": serialized JSON string (if present)
+          - "destinations": list of destination dicts (if present)
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        raw = process_additional_configuration(
+            additional_configuration=dataset_config,
+            config_type="dataset",
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and "datasetConfig" in parsed and "connectorType" in parsed:
+            parsed = parsed["datasetConfig"]
+
+        if not isinstance(parsed, dict):
+            raise InvalidArgumentValueError(
+                "--dataset-config must be a JSON object with 'datasetConfiguration' "
+                "and/or 'destinations' keys."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        dataset_section = endpoint.get("datasets", {}) if endpoint else {}
+
+        result = {}
+
+        config_data_raw = parsed.get("datasetConfiguration")
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = dataset_section.get("datasetConfigurationSchema") if dataset_section else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping datasetConfiguration validation: %s", skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name="datasetConfiguration")
+            result["datasetConfiguration"] = json.dumps(config_data)
+
+        dest_raw = parsed.get("destinations")
+        if dest_raw is not None:
+            dest_data = _strip_nulls(dest_raw)
+            if isinstance(dest_data, list):
+                dest_data = [
+                    item for item in dest_data
+                    if not isinstance(item, dict) or item.get("configuration")
+                ]
+            if dest_data:
+                dest_section = dataset_section.get("destinations", {}) if dataset_section else {}
+                supported = (
+                    dest_section.get("supportedDestinations", [])
+                    if isinstance(dest_section, dict) else []
+                )
+                if supported and isinstance(dest_data, list):
+                    for dest_item in dest_data:
+                        target = dest_item.get("target") if isinstance(dest_item, dict) else None
+                        if target and target not in supported:
+                            raise InvalidArgumentValueError(
+                                f"Destination target '{target}' is not supported for datasets. "
+                                f"Supported: {supported}."
+                            )
+                result["destinations"] = dest_data
+
+        return result
+
+    def _handle_datapoint_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        datapoint_config: Optional[str],
+    ) -> dict:
+        """Return a datapoint config/schema template for --show-template and exit early."""
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        if datapoint_config:
+            raise InvalidArgumentValueError(
+                "--show-template and --datapoint-config cannot be used together. "
+                "--show-template displays the template and exits without modifying the datapoint."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        dataset_section = endpoint.get("datasets", {})
+        dp_section = dataset_section.get("dataPoints", {})
+        schema = dp_section.get("dataPointConfigurationSchema")
+
+        datapoint_config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            datapoint_config_template["datapointConfiguration"] = slimmed
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, "datapointConfig": datapoint_config_template}
+
+    def _load_and_validate_datapoint_config(
+        self,
+        datapoint_config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load datapoint config from file/inline JSON, validate against connector schema.
+
+        Input JSON is expected to be the 'datapointConfig' dict (output of --show-template), e.g.:
+          {
+            "datapointConfiguration": {...}
+          }
+        Or the full --show-template output with 'connectorType' and 'datapointConfig' keys,
+        which is auto-unwrapped.
+
+        Returns a dict with:
+          - "datapointConfiguration": serialized JSON string (if present)
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        raw = process_additional_configuration(
+            additional_configuration=datapoint_config,
+            config_type="datapoint",
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and "datapointConfig" in parsed and "connectorType" in parsed:
+            parsed = parsed["datapointConfig"]
+
+        if not isinstance(parsed, dict):
+            raise InvalidArgumentValueError(
+                "--datapoint-config must be a JSON object with a 'datapointConfiguration' key."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        dataset_section = endpoint.get("datasets", {}) if endpoint else {}
+        dp_section = dataset_section.get("dataPoints", {}) if dataset_section else {}
+
+        result = {}
+
+        config_data_raw = parsed.get("datapointConfiguration")
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = dp_section.get("dataPointConfigurationSchema") if dp_section else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping datapointConfiguration validation: %s", skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name="datapointConfiguration")
+            result["datapointConfiguration"] = json.dumps(config_data)
+
+        return result
+
+    def add_dataset_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        dataset_name: str,
+        data_source: Optional[str] = None,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        dataset_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized add-dataset that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --dataset-config for
+        JSON or file-based connector-specific dataset configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            return self._handle_dataset_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                dataset_config=dataset_config,
+            )
+
+        # Cluster connectivity check
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        datasets = asset["properties"].get("datasets", [])
+        unmatched_datasets = [ds for ds in datasets if ds["name"] != dataset_name]
+        if len(unmatched_datasets) < len(datasets) and not replace:
+            raise InvalidArgumentValueError(
+                f"Dataset '{dataset_name}' already exists in asset '{asset_name}'. "
+                "Use --replace to overwrite the existing dataset."
+            )
+
+        new_dataset: dict = {
+            "name": dataset_name,
+            "datasetConfiguration": None,
+            "destinations": [],
+            "dataPoints": [],
+            "typeRef": type_ref,
+        }
+        if data_source:
+            new_dataset["dataSource"] = data_source
+
+        if dataset_config:
+            config_result = self._load_and_validate_dataset_config(
+                dataset_config=dataset_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "datasetConfiguration" in config_result:
+                new_dataset["datasetConfiguration"] = config_result["datasetConfiguration"]
+            if "destinations" in config_result:
+                new_dataset["destinations"] = config_result["destinations"]
+
+        unmatched_datasets.append(new_dataset)
+        update_payload = {"properties": {"datasets": unmatched_datasets}}
+
+        with console.status(f"Adding dataset {dataset_name} to asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            datasets = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )["properties"]["datasets"]
+            result = next((dset for dset in datasets if dset["name"] == dataset_name), None)
+            if result is None:
+                raise CLIInternalError(
+                    f"Dataset '{dataset_name}' was not found in asset '{asset_name}' after update."
+                )
+            return result
+
+    def update_dataset_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        dataset_name: str,
+        data_source: Optional[str] = None,
+        type_ref: Optional[str] = None,
+        dataset_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized update-dataset that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --dataset-config for
+        JSON or file-based connector-specific dataset configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            from .common import EndpointTemplateMode
+            template_mode = show_template.lower()
+            if template_mode == EndpointTemplateMode.CONFIG.value:
+                # For config mode on update: show the full connector schema structure (same as add)
+                # but with existing ARM values pre-filled so the user can see all fields and
+                # only edit what they want.
+                if dataset_config:
+                    raise InvalidArgumentValueError(
+                        "--show-template and --dataset-config cannot be used together. "
+                        "--show-template displays the template and exits without modifying the dataset."
+                    )
+                datasets_existing = asset["properties"].get("datasets", [])
+                existing = next((d for d in datasets_existing if d["name"] == dataset_name), None)
+                if existing is None:
+                    raise InvalidArgumentValueError(
+                        f"Dataset '{dataset_name}' not found in asset '{asset_name}'."
+                    )
+                # Get the full schema template (nulls for all fields)
+                template_result = self._handle_dataset_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    dataset_config=None,
+                )
+                dataset_config_tmpl = template_result.get("datasetConfig", {})
+                # Pre-fill datasetConfiguration from ARM
+                raw_config = existing.get("datasetConfiguration")
+                if raw_config:
+                    existing_config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+                    tmpl_dc = dataset_config_tmpl.get("datasetConfiguration")
+                    dataset_config_tmpl["datasetConfiguration"] = (
+                        _deep_merge_template(tmpl_dc, existing_config)
+                        if isinstance(tmpl_dc, dict)
+                        else existing_config
+                    )
+                # Pre-fill destinations from ARM
+                existing_dests = existing.get("destinations", [])
+                if existing_dests:
+                    tmpl_dests = dataset_config_tmpl.get("destinations", [])
+                    dataset_config_tmpl["destinations"] = _merge_destinations_template(
+                        tmpl_dests, existing_dests
+                    )
+                return {"connectorType": connector_type, "datasetConfig": dataset_config_tmpl}
+            else:
+                # For schema mode, show connector metadata schema structure (same as add)
+                return self._handle_dataset_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    dataset_config=dataset_config,
+                )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        datasets = asset["properties"].get("datasets", [])
+        dataset_list = [dset for dset in datasets if dset["name"] == dataset_name]
+        if not dataset_list:
+            raise InvalidArgumentValueError(
+                f"Dataset '{dataset_name}' not found in asset '{asset_name}'."
+            )
+        dataset = dataset_list[0]
+
+        if dataset_config:
+            config_result = self._load_and_validate_dataset_config(
+                dataset_config=dataset_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "datasetConfiguration" in config_result:
+                dataset["datasetConfiguration"] = config_result["datasetConfiguration"]
+            if "destinations" in config_result:
+                dataset["destinations"] = config_result["destinations"]
+
+        if data_source:
+            dataset["dataSource"] = data_source
+        if type_ref:
+            dataset["typeRef"] = type_ref
+
+        update_payload = {"properties": {"datasets": datasets}}
+        with console.status(f"Updating dataset {dataset_name} in asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            datasets = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )["properties"]["datasets"]
+            result = next((dset for dset in datasets if dset["name"] == dataset_name), None)
+            if result is None:
+                raise CLIInternalError(
+                    f"Dataset '{dataset_name}' was not found in asset '{asset_name}' after update."
+                )
+            return result
+
+    def add_dataset_datapoint_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        dataset_name: str,
+        datapoint_name: str,
+        data_source: str,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        datapoint_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> List[dict]:
+        """Generalized add-datapoint that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --datapoint-config for
+        JSON or file-based connector-specific datapoint configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            return self._handle_datapoint_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                datapoint_config=datapoint_config,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
+        datapoints = dataset["dataPoints"]
+        non_matched_points = [point for point in datapoints if point["name"] != datapoint_name]
+        if len(non_matched_points) < len(datapoints) and not replace:
+            raise InvalidArgumentValueError(
+                f"Datapoint '{datapoint_name}' already exists in dataset '{dataset_name}' "
+                f"of asset '{asset_name}'. Use --replace to overwrite the existing datapoint."
+            )
+
+        datapoint: dict = {"name": datapoint_name, "dataSource": data_source}
+        if type_ref:
+            datapoint["typeRef"] = type_ref
+
+        if datapoint_config:
+            config_result = self._load_and_validate_datapoint_config(
+                datapoint_config=datapoint_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "datapointConfiguration" in config_result:
+                datapoint["dataPointConfiguration"] = config_result["datapointConfiguration"]
+
+        non_matched_points.append(datapoint)
+        dataset["dataPoints"] = non_matched_points
+
+        update_payload = {"properties": {"datasets": asset["properties"]["datasets"]}}
+        with console.status(f"Updating asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, dataset_name, property_key="datasets")["dataPoints"]
+
     def _load_and_validate_asset_config(
         self,
         asset_config: str,
@@ -733,8 +1381,7 @@ class NamespaceAssets(Queryable):
         Configuration properties are returned as serialized JSON strings, while destination
         properties (e.g. defaultDatasetsDestinations) are returned as native Python lists.
         """
-        from .namespace_devices import DeviceEndpointType as _DEType
-        from .helpers import load_opcua_metadata_file as _load_opcua_metadata_file, strip_nulls as _strip_nulls
+        from .helpers import strip_nulls as _strip_nulls
 
         raw = process_additional_configuration(
             additional_configuration=asset_config,
@@ -753,37 +1400,11 @@ class NamespaceAssets(Queryable):
             )
 
         # Load metadata for schema validation
-        is_opcua = connector_type.lower() == _DEType.OPCUA.value.lower()
-        if is_opcua:
-            metadata = _load_opcua_metadata_file()
-        else:
-            from ..orchestration.resources.connector_templates import ConnectorTemplates
-            connector_templates = ConnectorTemplates(cmd=self.cmd)
-            template = connector_templates.get_connector_template_for_type(
-                instance_name=instance_name,
-                instance_resource_group=instance_resource_group,
-                connector_type=connector_type,
-            )
-            if not template:
-                from azure.cli.core.azclierror import ValidationError
-                raise ValidationError(
-                    f"No connector template found for connector type '{connector_type}'. "
-                    "Cannot validate asset config."
-                )
-            connector_metadata_ref = template.get("properties", {}).get("connectorMetadataRef")
-            if not connector_metadata_ref:
-                from azure.cli.core.azclierror import ValidationError
-                raise ValidationError(
-                    f"Connector template for type '{connector_type}' is missing 'connectorMetadataRef'. "
-                    "Cannot validate asset config."
-                )
-            from ...util.oci_client import get_oci_client
-            oci_client = get_oci_client()
-            artifact = oci_client.fetch_first_layer(
-                image_ref=connector_metadata_ref,
-                cmd=self.cmd,
-            )
-            metadata = json.loads(artifact.content.decode("utf-8"))
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
 
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
 
@@ -3130,6 +3751,39 @@ class NamespaceAssets(Queryable):
             )
 
         return (asset if asset_name else device, namespace)
+
+
+def _deep_merge_template(template, existing):
+    """Recursively merge existing values into a schema template dict.
+
+    Template keys that are None (nulls from --show-template config) are replaced by the
+    existing value.  Keys present in existing but absent from template are added as-is.
+    """
+    if not isinstance(template, dict) or not isinstance(existing, dict):
+        return existing if existing is not None else template
+    result = dict(template)
+    for key, existing_val in existing.items():
+        if key in result:
+            result[key] = _deep_merge_template(result[key], existing_val)
+        else:
+            result[key] = existing_val
+    return result
+
+
+def _merge_destinations_template(template_dests: list, existing_dests: list) -> list:
+    """Pre-fill template destinations with existing ARM values, matched by target name."""
+    if not existing_dests:
+        return template_dests
+    existing_by_target = {d.get("target"): d for d in existing_dests if d.get("target")}
+    result = []
+    for tmpl_dest in template_dests:
+        target = tmpl_dest.get("target")
+        existing_dest = existing_by_target.get(target)
+        if existing_dest:
+            result.append(_deep_merge_template(tmpl_dest, existing_dest))
+        else:
+            result.append(tmpl_dest)
+    return result
 
 
 # Mapping from connector metadata section names to ARM property names and destination paths.

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -235,7 +235,8 @@ class NamespaceAssets(Queryable):
                 f"{resource_label} validation skipped: could not load connector metadata ({e}). "
                 "This can occur when the connector metadata version is ahead of the bundled schema "
                 "or the cluster is not reachable. "
-                f"The {resource_label.lower()} will be imported but may fail at runtime."
+                f"The {resource_label.lower()} will be imported but may fail at runtime.",
+                exc_info=True,
             )
             return
 
@@ -3787,18 +3788,27 @@ def _deep_merge_template(template, existing):
 
 
 def _merge_destinations_template(template_dests: list, existing_dests: list) -> list:
-    """Pre-fill template destinations with existing ARM values, matched by target name."""
+    """Pre-fill template destinations with existing ARM values, matched by target name.
+
+    Existing destinations whose target is not present in the template are appended as-is so that
+    current configuration is preserved and the template stays round-trippable.
+    """
     if not existing_dests:
         return template_dests
-    existing_by_target = {d.get("target"): d for d in existing_dests if d.get("target")}
+    existing_by_target = {d.get("target"): d for d in existing_dests if isinstance(d, dict) and d.get("target")}
+    matched_targets = set()
     result = []
     for tmpl_dest in template_dests:
-        target = tmpl_dest.get("target")
+        target = tmpl_dest.get("target") if isinstance(tmpl_dest, dict) else None
         existing_dest = existing_by_target.get(target)
         if existing_dest:
+            matched_targets.add(target)
             result.append(_deep_merge_template(tmpl_dest, existing_dest))
         else:
             result.append(tmpl_dest)
+    for target, existing_dest in existing_by_target.items():
+        if target not in matched_targets:
+            result.append(existing_dest)
     return result
 
 

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -933,20 +933,33 @@ class NamespaceAssets(Queryable):
         dest_raw = parsed.get("destinations")
         if dest_raw is not None:
             dest_data = _strip_nulls(dest_raw)
-            if isinstance(dest_data, list):
-                dest_data = [
-                    item for item in dest_data
-                    if not isinstance(item, dict) or item.get("configuration")
-                ]
+            if not isinstance(dest_data, list):
+                raise InvalidArgumentValueError(
+                    "--dataset-config 'destinations' must be a JSON array of destination objects."
+                )
+            filtered: List[dict] = []
+            for item in dest_data:
+                if not isinstance(item, dict):
+                    raise InvalidArgumentValueError(
+                        "--dataset-config 'destinations' entries must be JSON objects."
+                    )
+                if not item.get("configuration"):
+                    logger.warning(
+                        "Ignoring destination '%s' because its configuration is empty.",
+                        item.get("target"),
+                    )
+                    continue
+                filtered.append(item)
+            dest_data = filtered
             if dest_data:
                 dest_section = dataset_section.get("destinations", {}) if dataset_section else {}
                 supported = (
                     dest_section.get("supportedDestinations", [])
                     if isinstance(dest_section, dict) else []
                 )
-                if supported and isinstance(dest_data, list):
+                if supported:
                     for dest_item in dest_data:
-                        target = dest_item.get("target") if isinstance(dest_item, dict) else None
+                        target = dest_item.get("target")
                         if target and target not in supported:
                             raise InvalidArgumentValueError(
                                 f"Destination target '{target}' is not supported for datasets. "

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -3770,8 +3770,10 @@ class NamespaceAssets(Queryable):
 def _deep_merge_template(template, existing):
     """Recursively merge existing values into a schema template dict.
 
-    Template keys that are None (nulls from --show-template config) are replaced by the
-    existing value.  Keys present in existing but absent from template are added as-is.
+    Existing values take precedence over template values. When both values are dicts,
+    merge recursively; otherwise return the existing value (unless it is None, in which
+    case the template value is kept). Keys present in existing but absent from template
+    are added as-is.
     """
     if not isinstance(template, dict) or not isinstance(existing, dict):
         return existing if existing is not None else template

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -1265,7 +1265,7 @@ class NamespaceAssets(Queryable):
             )
         dataset = dataset_list[0]
 
-        if dataset_config:
+        if dataset_config is not None:
             config_result = self._load_and_validate_dataset_config(
                 dataset_config=dataset_config,
                 connector_type=connector_type,
@@ -1277,9 +1277,9 @@ class NamespaceAssets(Queryable):
             if "destinations" in config_result:
                 dataset["destinations"] = config_result["destinations"]
 
-        if data_source:
+        if data_source is not None:
             dataset["dataSource"] = data_source
-        if type_ref:
+        if type_ref is not None:
             dataset["typeRef"] = type_ref
 
         update_payload = {"properties": {"datasets": datasets}}

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -217,7 +217,12 @@ class NamespaceAssets(Queryable):
         instance_name: str,
         instance_resource_group: str,
     ):
-        """Run connector-metadata validation on items, with graceful fallback."""
+        """Run connector-metadata validation on items, with graceful fallback.
+
+        Metadata fetch/schema failures (e.g. connector metadata with fields not yet recognised by
+        the bundled schema) are treated as warnings so import can proceed. Only item-level
+        ValidationErrors (user data does not conform to the connector's own schema) are hard errors.
+        """
         try:
             validator = ConnectorMetadataValidator.from_asset(
                 cmd=self.cmd,
@@ -225,6 +230,16 @@ class NamespaceAssets(Queryable):
                 instance_name=instance_name,
                 instance_resource_group=instance_resource_group,
             )
+        except Exception as e:
+            logger.warning(
+                f"{resource_label} validation skipped: could not load connector metadata ({e}). "
+                "This can occur when the connector metadata version is ahead of the bundled schema "
+                "or the cluster is not reachable. "
+                f"The {resource_label.lower()} will be imported but may fail at runtime."
+            )
+            return
+
+        try:
             for item in items:
                 validate_fn(validator, item)
             logger.info(f"{resource_label} validated successfully.")
@@ -233,7 +248,6 @@ class NamespaceAssets(Queryable):
         except Exception as e:
             logger.warning(
                 f"{resource_label} validation skipped: {e}. "
-                "This may occur if the connector is not deployed or the cluster is not connected. "
                 f"The {resource_label.lower()} will be imported but may fail at runtime."
             )
 

--- a/azext_edge/edge/providers/adr/schemas/connector_metadata_schema.json
+++ b/azext_edge/edge/providers/adr/schemas/connector_metadata_schema.json
@@ -1,833 +1,686 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://json.schemastore.org/aio-connector-metadata-9.0-preview.json",
-    "type": "object",
-    "title": "JSON schema for Azure IoT Operations Connector Metadata 9.0-preview",
-    "description": "Schema that defines how to write a connector metadata document when writing connectors for Azure IoT Operations solutions",
-    "definitions": {
-        "modelLimits": {
-            "type": "object",
-            "description": "Describes the limits to this model type that this connector supports. For instance, a connector may support between 0 to 5 datasets.",
-            "properties": {
-                "maximum": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "description": "The maximum number of this model type that this connector supports. If not specified, the default is whatever limits the ADR service itself has."
-                },
-                "minimum": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "The minimum number of this model type that this connector supports."
-                }
-            },
-            "additionalProperties": false
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/aio-connector-metadata-9.0-preview.json",
+  "type": "object",
+  "title": "JSON schema for Azure IoT Operations Connector Metadata 9.0-preview",
+  "description": "Schema that defines how to write a connector metadata document when writing connectors for Azure IoT Operations solutions",
+  "definitions": {
+    "modelLimits": {
+      "type": "object",
+      "description": "Describes the limits to this model type that this connector supports. For instance, a connector may support between 0 to 5 datasets.",
+      "properties": {
+        "maximum": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum number of this model type that this connector supports. If not specified, the default is whatever limits the ADR service itself has."
         },
-        "mqttDestinationDefaults": {
-            "type": "object",
-            "description": "The specific default values that will be used by the connector when publishing telemetry to the MQTT broker.",
-            "properties": {
-                "destination": {
-                    "type": "string",
-                    "enum": [
-                        "Mqtt"
-                    ],
-                    "default": "Mqtt"
-                },
-                "topic": {
-                    "type": "string",
-                    "description": "The default MQTT topic that will be published to. Values are allowed to contain deploy-time parameters like 'mqtt/{deviceName}/{inboundEndpointName}/myMessages'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
-                },
-                "qos": {
-                    "type": "integer",
-                    "description": "The default MQTT quality of service that MQTT messages will be published with",
-                    "enum": [
-                        0,
-                        1
-                    ]
-                },
-                "ttl": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "The default time to live that MQTT messages will be published with."
-                },
-                "retain": {
-                    "type": "string",
-                    "description": "The default retain flag value that MQTT messages will be published with.",
-                    "enum": [
-                        "keep",
-                        "never"
-                    ]
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "destination",
-                "topic",
-                "qos",
-                "ttl",
-                "retain"
-            ]
-        },
-        "brokerStateStoreDestinationDefaults": {
-            "type": "object",
-            "description": "The broker state store-specific default values that will be used by the connector if not otherwise specified.",
-            "properties": {
-                "destination": {
-                    "type": "string",
-                    "enum": [
-                        "BrokerStateStore"
-                    ],
-                    "default": "BrokerStateStore"
-                },
-                "key": {
-                    "type": "string",
-                    "description": "The default broker state store key that will be published to. Values are allowed to contain deploy-time parameters like 'dss/{deviceName}/{inboundEndpointName}'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "destination",
-                "key"
-            ]
-        },
-        "storageDestinationDefaults": {
-            "type": "object",
-            "description": "The storage-specific default values that will be used by the connector if not otherwise specified.",
-            "properties": {
-                "destination": {
-                    "type": "string",
-                    "enum": [
-                        "Storage"
-                    ],
-                    "default": "Storage"
-                },
-                "path": {
-                    "type": "string",
-                    "description": "The default path that storage will use. Values are allowed to contain deploy-time parameters like 'storage/{deviceName}/{inboundEndpointName}'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "destination",
-                "path"
-            ]
-        },
-        "alternativeTypeName": {
-            "type": "object",
-            "description": "The alternative name of this type. For example, OPC UA knows \"datapoints\" as \"tags\"",
-            "properties": {
-                "singular": {
-                    "type": "string",
-                    "description": "The singular form of the name of this type"
-                },
-                "plural": {
-                    "type": "string",
-                    "description": "The plural form of the name of this type"
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "singular",
-                "plural"
-            ]
-        },
-        "fieldNecessity": {
-            "type": "object",
-            "description": "Details about if a field is required or not and what shape its value should take",
-            "properties": {
-                "input": {
-                    "type": "string",
-                    "description": "If this field is relevant to this connector or not. If required, the connector cannot function without this field being provided in the specified shape. If unsupported, the connector will ignore any value provided for this field. If optional, the connector can function with or without this field being provided, but the behavior may vary depending on it.",
-                    "enum": [
-                        "required",
-                        "unsupported",
-                        "optional"
-                    ]
-                },
-                "regex": {
-                    "type": "array",
-                    "description": "The set of regex that this field's value should adhere to.",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "exampleValue": {
-                    "type": "string",
-                    "description": "An example value for this field that fits the expected format"
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Additional user-readable context for this field. May explain how the field is used or explain the validation rules around it."
-                }
-            },
-            "required": [
-                "input"
-            ]
+        "minimum": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "The minimum number of this model type that this connector supports."
         }
+      },
+      "additionalProperties": false
     },
-    "properties": {
-        "$schema": {
-            "type": "string",
-            "description": "The address of the AIO connector metadata schema that this connector metadata file adheres to.",
-            "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-9.0-preview.json"
+    "mqttDestinationDefaults": {
+      "type": "object",
+      "description": "The specific default values that will be used by the connector when publishing telemetry to the MQTT broker.",
+      "properties": {
+        "destination": {
+          "type": "string",
+          "enum": ["Mqtt"],
+          "default": "Mqtt"
         },
-        "name": {
-            "type": "string",
-            "description": "The name of the connector."
+        "topic": {
+          "type": "string",
+          "description": "The default MQTT topic that will be published to. Values are allowed to contain deploy-time parameters like 'mqtt/{deviceName}/{inboundEndpointName}/myMessages'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventGroupName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/eventGroup/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
+        },
+        "qos": {
+          "type": "integer",
+          "description": "The default MQTT quality of service that MQTT messages will be published with",
+          "enum": [0, 1]
+        },
+        "ttl": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The default time to live that MQTT messages will be published with."
+        },
+        "retain": {
+          "type": "string",
+          "description": "The default retain flag value that MQTT messages will be published with.",
+          "enum": ["keep", "never"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["destination", "topic", "qos", "ttl", "retain"]
+    },
+    "brokerStateStoreDestinationDefaults": {
+      "type": "object",
+      "description": "The broker state store-specific default values that will be used by the connector if not otherwise specified.",
+      "properties": {
+        "destination": {
+          "type": "string",
+          "enum": ["BrokerStateStore"],
+          "default": "BrokerStateStore"
+        },
+        "key": {
+          "type": "string",
+          "description": "The default broker state store key that will be published to. Values are allowed to contain deploy-time parameters like 'dss/{deviceName}/{inboundEndpointName}'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventGroupName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/eventGroup/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["destination", "key"]
+    },
+    "storageDestinationDefaults": {
+      "type": "object",
+      "description": "The storage-specific default values that will be used by the connector if not otherwise specified.",
+      "properties": {
+        "destination": {
+          "type": "string",
+          "enum": ["Storage"],
+          "default": "Storage"
+        },
+        "path": {
+          "type": "string",
+          "description": "The default path that storage will use. Values are allowed to contain deploy-time parameters like 'storage/{deviceName}/{inboundEndpointName}'.  The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {datasetName}, {eventGroupName}, {eventName}, {streamName}, and {kubernetesNamespace}. Dataset/eventGroup/event/stream name tokens are only allowed if the configured destination is for a dataset/event/stream."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["destination", "path"]
+    },
+    "alternativeTypeName": {
+      "type": "object",
+      "description": "The alternative name of this type. For example, OPC UA knows \"datapoints\" as \"tags\"",
+      "properties": {
+        "singular": {
+          "type": "string",
+          "description": "The singular form of the name of this type"
+        },
+        "plural": {
+          "type": "string",
+          "description": "The plural form of the name of this type"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["singular", "plural"]
+    },
+    "fieldNecessity": {
+      "type": "object",
+      "description": "Details about if a field is required or not and what shape its value should take",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "If this field is relevant to this connector or not. If required, the connector cannot function without this field being provided in the specified shape. If unsupported, the connector will ignore any value provided for this field. If optional, the connector can function with or without this field being provided, but the behavior may vary depending on it.",
+          "enum": ["required", "unsupported", "optional"]
+        },
+        "regex": {
+          "type": "array",
+          "description": "The set of regex that this field's value should adhere to.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exampleValue": {
+          "type": "string",
+          "description": "An example value for this field that fits the expected format"
         },
         "description": {
-            "type": "string",
-            "description": "A brief (human-readable) description of the connector (preferably in English). This is seen when browsing connectors in the portal."
+          "type": "string",
+          "description": "Additional user-readable context for this field. May explain how the field is used or explain the validation rules around it."
+        }
+      },
+      "required": ["input"]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "The address of the AIO connector metadata schema that this connector metadata file adheres to.",
+      "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-9.0-preview.json"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the connector."
+    },
+    "description": {
+      "type": "string",
+      "description": "A brief (human-readable) description of the connector (preferably in English). This is seen when browsing connectors in the portal."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of this connector. This must use semantic versioning such as '1.2.3'",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "default": "1.0.0"
+    },
+    "isPreview": {
+      "type": "boolean",
+      "description": "True if this connector is considered a preview version.",
+      "default": "false"
+    },
+    "maintainer": {
+      "type": "string",
+      "description": "A name and/or email of the maintainer of this connector."
+    },
+    "vendor": {
+      "type": "string",
+      "description": "A name and/or email of the vendor that distributes this connector."
+    },
+    "imageConfigurationSettings": {
+      "type": "object",
+      "description": "The container image details for this connector image.",
+      "oneOf": [
+        {
+          "properties": {
+            "imageName": {
+              "type": "string",
+              "description": "The container image name for the connector. For example: 'myconnector'"
+            },
+            "tag": {
+              "type": "string",
+              "description": "The tag of the container image for this connector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["imageName", "tag"]
         },
-        "version": {
+        {
+          "properties": {
+            "imageName": {
+              "type": "string",
+              "description": "The container image name for the connector. For example: 'myconnector'"
+            },
+            "digest": {
+              "type": "string",
+              "description": "The digest of the container image for this connector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["imageName", "digest"]
+        }
+      ]
+    },
+    "secrets": {
+      "type": "array",
+      "description": "The array of secrets that are required for the connector application to work. The secret will be mounted onto all connector instances deployed for this connector application",
+      "items": {
+        "type": "object",
+        "description": "A single secret that will be mounted onto all connector instances.",
+        "properties": {
+          "secretAlias": {
             "type": "string",
-            "description": "The version of this connector. This must use semantic versioning such as '1.2.3'",
-            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-            "default": "1.0.0"
-        },
-        "isPreview": {
+            "description": "The application-defined alias for the secret"
+          },
+          "secretDescription": {
+            "type": "string",
+            "description": "The description for this secret alias"
+          },
+          "isOptional": {
             "type": "boolean",
-            "description": "True if this connector is considered a preview version.",
-            "default": "false"
+            "description": "If the secret is optional or mandatory",
+            "default": false
+          }
         },
-        "maintainer": {
+        "additionalProperties": false,
+        "required": ["secretAlias"]
+      },
+      "minItems": 1
+    },
+    "storageVolumes": {
+      "type": "array",
+      "description": "The array of storage volumes that are required for the connector application to work.",
+      "items": {
+        "type": "object",
+        "description": "A single storage volume is needed.",
+        "properties": {
+          "description": {
             "type": "string",
-            "description": "A name and/or email of the maintainer of this connector."
-        },
-        "vendor": {
+            "description": "The description for this storage volume"
+          },
+          "mountPath": {
             "type": "string",
-            "description": "A name and/or email of the vendor that distributes this connector."
+            "description": "The mount path for this storage volume"
+          }
         },
-        "imageConfigurationSettings": {
+        "additionalProperties": false,
+        "required": ["mountPath"]
+      },
+      "minItems": 1
+    },
+    "supportedArchitectures": {
+      "type": "array",
+      "description": "The CPU architectures that this connector image was built for. At least one must be specified.",
+      "items": {
+        "type": "string",
+        "description": "One of the CPU architectures this connector image was built for. For example: 'linux/amd64', 'linux/arm64', or 'windows/amd64'"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "sourceCode": {
+      "type": "object",
+      "description": "Details about the source code that compiled this connector",
+      "properties": {
+        "language": {
+          "type": "string",
+          "description": "The programming language used to write this connector"
+        },
+        "languageVersion": {
+          "type": "string",
+          "description": "The version of the programming language used to write this connector"
+        },
+        "sdks": {
+          "type": "object",
+          "description": "Details about the versions of the AIO SDKs used to write this connector (if they were used)",
+          "properties": {
+            "mqttPackageVersion": {
+              "type": "string",
+              "description": "The version of the Azure IoT Operations MQTT package"
+            },
+            "protocolPackageVersion": {
+              "type": "string",
+              "description": "The version of the Azure IoT Operations protocol package"
+            },
+            "servicesPackageVersion": {
+              "type": "string",
+              "description": "The version of the Azure IoT Operations services package"
+            },
+            "connectorPackageVersion": {
+              "type": "string",
+              "description": "The version of the Azure IoT Operations connector package"
+            }
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["language", "languageVersion"]
+    },
+    "aioMetadata": {
+      "type": "object",
+      "description": "The AIO requirements to run this connector",
+      "properties": {
+        "aioMinVersion": {
+          "type": "string",
+          "description": "The minimal (inclusive) version that can run this connector."
+        },
+        "aioMaxVersion": {
+          "type": "string",
+          "description": "The maximal (inclusive) version that can run this connector. If there is no known exact version, wildcards can be used such as '1.*.*'. Alternatively, not specifying an aioMaxVersion signals no upper bound"
+        }
+      },
+      "additionalProperties": false
+    },
+    "connectorConfigurationKeys": {
+      "type": "array",
+      "description": "The array of keys in the connector configuration",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "description": "A key in the connector configuration key/value map.",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of this key.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["key"]
+      },
+      "minItems": 1
+    },
+    "inboundEndpointAlternativeTypeName": {
+      "$ref": "#/definitions/alternativeTypeName",
+      "description": "The alternative name to the type \"inboundEndpoint\" in a device"
+    },
+    "endpointsEnabledByDefault": {
+      "type": "boolean",
+      "description": "If true, inbound endpoints are enabled by default. Users may still specify in the deployed device definition if each endpoint is enabled or not and that value will override this value."
+    },
+    "inboundEndpoints": {
+      "type": "array",
+      "description": "The array of inbound endpoints in a device that this connector will be deployed for.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "A human readable description of this inbound endpoint",
+            "type": "string"
+          },
+          "endpointType": {
+            "description": "Type of connection endpoint. Formatted as ABC.XYZ. For example, 'Microsoft.Media'",
+            "pattern": "^[a-zA-Z]+\\.[a-zA-Z]+",
+            "type": "string"
+          },
+          "supportedAuthenticationTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The set of authentication types that this connector supports. For example, [\"usernamePassword\", \"anonymous\"]"
+          },
+          "fields": {
             "type": "object",
-            "description": "The container image details for this connector image.",
-            "oneOf": [
-                {
-                    "properties": {
-                        "imageName": {
-                            "type": "string",
-                            "description": "The container image name for the connector. For example: 'myconnector'"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "description": "The tag of the container image for this connector"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "imageName",
-                        "tag"
-                    ]
-                },
-                {
-                    "properties": {
-                        "imageName": {
-                            "type": "string",
-                            "description": "The container image name for the connector. For example: 'myconnector'"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "The digest of the container image for this connector"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "imageName",
-                        "digest"
-                    ]
-                }
-            ]
-        },
-        "secrets": {
-            "type": "array",
-            "description": "The array of secrets that are required for the connector application to work. The secret will be mounted onto all connector instances deployed for this connector application",
-            "items": {
-                "type": "object",
-                "description": "A single secret that will be mounted onto all connector instances.",
-                "properties": {
-                    "secretAlias": {
-                        "type": "string",
-                        "description": "The application-defined alias for the secret"
-                    },
-                    "secretDescription": {
-                        "type": "string",
-                        "description": "The description for this secret alias"
-                    },
-                    "isOptional": {
-                        "type": "boolean",
-                        "description": "If the secret is optional or mandatory",
-                        "default": false
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "secretAlias"
-                ]
-            },
-            "minItems": 1
-        },
-        "storageVolumes": {
-            "type": "array",
-            "description": "The array of storage volumes that are required for the connector application to work.",
-            "items": {
-                "type": "object",
-                "description": "A single storage volume is needed.",
-                "properties": {
-                    "description": {
-                        "type": "string",
-                        "description": "The description for this storage volume"
-                    },
-                    "mountPath": {
-                        "type": "string",
-                        "description": "The mount path for this storage volume"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "mountPath"
-                ]
-            },
-            "minItems": 1
-        },
-        "supportedArchitectures": {
-            "type": "array",
-            "description": "The CPU architectures that this connector image was built for. At least one must be specified.",
-            "items": {
-                "type": "string",
-                "description": "One of the CPU architectures this connector image was built for. For example: 'linux/amd64', 'linux/arm64', or 'windows/amd64'"
-            },
-            "minItems": 1,
-            "uniqueItems": true
-        },
-        "sourceCode": {
-            "type": "object",
-            "description": "Details about the source code that compiled this connector",
+            "description": "Describes if this connector expects these fields to be provided in the device definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
             "properties": {
-                "language": {
-                    "type": "string",
-                    "description": "The programming language used to write this connector"
-                },
-                "languageVersion": {
-                    "type": "string",
-                    "description": "The version of the programming language used to write this connector"
-                },
-                "sdks": {
+              "address": { "$ref": "#/definitions/fieldNecessity" }
+            },
+            "required": ["address"],
+            "additionalProperties": false
+          },
+          "assetsEnabledByDefault": {
+            "type": "boolean",
+            "description": "If true, assets are enabled by default. Users may still specify in the deployed asset definition if each asset is enabled or not and that value will override this value."
+          },
+          "additionalConfigurationSchema": {
+            "$ref": "http://json-schema.org/draft-07/schema#"
+          },
+          "version": {
+            "type": "string",
+            "description": "The version of the protocol of this inbound endpoint."
+          },
+          "eventGroups": {
+            "type": "object",
+            "description": "If present, this connector supports using event groups.",
+            "properties": {
+              "limits": { "$ref": "#/definitions/modelLimits" },
+              "events": {
+                "type": "object",
+                "description": "If present, this connector supports using events.",
+                "properties": {
+                  "limits": { "$ref": "#/definitions/modelLimits" },
+                  "eventConfigurationSchema": {
+                    "$ref": "http://json-schema.org/draft-07/schema#",
+                    "description": "The JSON schema for the \"eventConfiguration\" field on an event group's event."
+                  },
+                  "alternativeTypeName": {
+                    "$ref": "#/definitions/alternativeTypeName",
+                    "description": "The alternative name to the type \"event\" within an event group"
+                  },
+                  "fields": {
                     "type": "object",
-                    "description": "Details about the versions of the AIO SDKs used to write this connector (if they were used)",
+                    "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
                     "properties": {
-                        "mqttPackageVersion": {
-                            "type": "string",
-                            "description": "The version of the Azure IoT Operations MQTT package"
-                        },
-                        "protocolPackageVersion": {
-                            "type": "string",
-                            "description": "The version of the Azure IoT Operations protocol package"
-                        },
-                        "servicesPackageVersion": {
-                            "type": "string",
-                            "description": "The version of the Azure IoT Operations services package"
-                        },
-                        "connectorPackageVersion": {
-                            "type": "string",
-                            "description": "The version of the Azure IoT Operations connector package"
-                        }
+                      "dataSource": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      },
+                      "typeRef": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      }
                     },
+                    "required": ["dataSource", "typeRef"],
                     "additionalProperties": false
-                }
+                  },
+                  "destinations": {
+                    "type": "object",
+                    "description": "Information about the supported and default destinations for asset events",
+                    "properties": {
+                      "supportedDestinations": {
+                        "type": "array",
+                        "description": "The array of destinations that this asset's events supports.",
+                        "items": {
+                          "type": "string",
+                          "enum": ["Mqtt", "Storage"]
+                        }
+                      },
+                      "defaultDestination": {
+                        "description": "The destination that this asset's events will go to by default unless specified otherwise in the asset or the event.",
+                        "oneOf": [
+                          { "$ref": "#/definitions/mqttDestinationDefaults" },
+                          {
+                            "$ref": "#/definitions/storageDestinationDefaults"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["supportedDestinations"]
+                  }
+                },
+                "required": ["fields", "limits"]
+              },
+              "alternativeTypeName": {
+                "$ref": "#/definitions/alternativeTypeName",
+                "description": "The alternative name to the type \"eventGroups\" within an asset"
+              },
+              "eventGroupConfigurationSchema": {
+                "$ref": "http://json-schema.org/draft-07/schema#",
+                "description": "The JSON schema for the \"eventGroupConfiguration\" field on an event group."
+              },
+              "fields": {
+                "type": "object",
+                "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                "properties": {
+                  "dataSource": {
+                    "$ref": "#/definitions/fieldNecessity"
+                  },
+                  "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                },
+                "required": ["dataSource", "typeRef"],
+                "additionalProperties": false
+              }
             },
             "additionalProperties": false,
-            "required": [
-                "language",
-                "languageVersion"
-            ]
-        },
-        "aioMetadata": {
+            "required": ["limits", "fields"]
+          },
+          "datasets": {
             "type": "object",
-            "description": "The AIO requirements to run this connector",
+            "description": "If present, this connector supports using datasets.",
             "properties": {
-                "aioMinVersion": {
-                    "type": "string",
-                    "description": "The minimal (inclusive) version that can run this connector."
-                },
-                "aioMaxVersion": {
-                    "type": "string",
-                    "description": "The maximal (inclusive) version that can run this connector. If there is no known exact version, wildcards can be used such as '1.*.*'. Alternatively, not specifying an aioMaxVersion signals no upper bound"
+              "limits": { "$ref": "#/definitions/modelLimits" },
+              "datasetConfigurationSchema": {
+                "$ref": "http://json-schema.org/draft-07/schema#",
+                "description": "The JSON schema for the \"datasetConfiguration\" field on a dataset."
+              },
+              "dataPoints": {
+                "type": "object",
+                "description": "If present, this connector supports using dataset datapoints.",
+                "properties": {
+                  "limits": { "$ref": "#/definitions/modelLimits" },
+                  "dataPointConfigurationSchema": {
+                    "$ref": "http://json-schema.org/draft-07/schema#",
+                    "description": "The JSON schema for the \"dataPointConfiguration\" field on a dataset's datapoint."
+                  },
+                  "alternativeTypeName": {
+                    "$ref": "#/definitions/alternativeTypeName",
+                    "description": "The alternative name to the type \"dataPoints\" within a dataset"
+                  },
+                  "fields": {
+                    "type": "object",
+                    "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                    "properties": {
+                      "dataSource": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      },
+                      "typeRef": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      }
+                    },
+                    "required": ["dataSource", "typeRef"],
+                    "additionalProperties": false
+                  }
                 }
-            },
-            "additionalProperties": false
-        },
-        "connectorConfigurationKeys": {
-            "type": "array",
-            "description": "The array of keys in the connector configuration",
-            "items": {
+              },
+              "alternativeTypeName": {
+                "$ref": "#/definitions/alternativeTypeName",
+                "description": "The alternative name to the type \"datasets\" within an asset"
+              },
+              "fields": {
                 "type": "object",
+                "description": "Describes if this connector expects these fields to be provided in the dataset definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
                 "properties": {
-                    "key": {
-                        "description": "A key in the connector configuration key/value map.",
-                        "type": "string"
-                    },
-                    "description": {
-                        "description": "The description of this key.",
-                        "type": "string"
+                  "dataSource": {
+                    "$ref": "#/definitions/fieldNecessity"
+                  },
+                  "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                },
+                "required": ["dataSource", "typeRef"],
+                "additionalProperties": false
+              },
+              "destinations": {
+                "type": "object",
+                "description": "Information about the supported and default destinations for asset datasets",
+                "properties": {
+                  "supportedDestinations": {
+                    "type": "array",
+                    "description": "The array of destinations that this asset's datasets supports.",
+                    "items": {
+                      "type": "string",
+                      "enum": ["Mqtt", "BrokerStateStore", "Storage"]
                     }
+                  },
+                  "defaultDestination": {
+                    "description": "The destination that this asset's datasets will go to by default unless specified otherwise in the asset or the dataset.",
+                    "oneOf": [
+                      { "$ref": "#/definitions/mqttDestinationDefaults" },
+                      {
+                        "$ref": "#/definitions/storageDestinationDefaults"
+                      },
+                      {
+                        "$ref": "#/definitions/brokerStateStoreDestinationDefaults"
+                      }
+                    ]
+                  }
                 },
                 "additionalProperties": false,
-                "required": [
-                    "key"
-                ]
+                "required": ["supportedDestinations"]
+              }
             },
-            "minItems": 1
-        },
-        "inboundEndpointAlternativeTypeName": {
-            "$ref": "#/definitions/alternativeTypeName",
-            "description": "The alternative name to the type \"inboundEndpoint\" in a device"
-        },
-        "endpointsEnabledByDefault": {
-            "type": "boolean",
-            "description": "If true, inbound endpoints are enabled by default. Users may still specify in the deployed device definition if each endpoint is enabled or not and that value will override this value."
-        },
-        "inboundEndpoints": {
-            "type": "array",
-            "description": "The array of inbound endpoints in a device that this connector will be deployed for.",
-            "items": {
+            "additionalProperties": false,
+            "required": ["limits", "fields"]
+          },
+          "managementGroups": {
+            "type": "object",
+            "description": "If present, this connector supports using management groups.",
+            "properties": {
+              "limits": { "$ref": "#/definitions/modelLimits" },
+              "managementGroupConfigurationSchema": {
+                "$ref": "http://json-schema.org/draft-07/schema#",
+                "description": "The JSON schema for the \"managementGroupConfiguration\" field on a management group."
+              },
+              "alternativeTypeName": {
+                "$ref": "#/definitions/alternativeTypeName",
+                "description": "The alternative name to the type \"managementGroups\" within an asset"
+              },
+              "managementGroupActions": {
                 "type": "object",
+                "description": "If present, this connector supports using management group actions.",
                 "properties": {
-                    "description": {
-                        "description": "A human readable description of this inbound endpoint",
-                        "type": "string"
+                  "limits": { "$ref": "#/definitions/modelLimits" },
+                  "actionConfigurationSchema": {
+                    "$ref": "http://json-schema.org/draft-07/schema#",
+                    "description": "The JSON schema for the \"actionConfiguration\" field on a management group's action."
+                  },
+                  "alternativeTypeName": {
+                    "$ref": "#/definitions/alternativeTypeName",
+                    "description": "The alternative name to the type \"actions\" within a management group"
+                  },
+                  "fields": {
+                    "type": "object",
+                    "description": "Describes if this connector expects these fields to be provided in the management group action definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                    "properties": {
+                      "targetUri": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      },
+                      "typeRef": {
+                        "$ref": "#/definitions/fieldNecessity"
+                      }
                     },
-                    "endpointType": {
-                        "description": "Type of connection endpoint. Formatted as ABC.XYZ. For example, 'Microsoft.Media'",
-                        "pattern": "^[a-zA-Z]+\\.[a-zA-Z]+",
-                        "type": "string"
-                    },
-                    "supportedAuthenticationTypes": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "description": "The set of authentication types that this connector supports. For example, [\"usernamePassword\", \"anonymous\"]"
-                    },
-                    "fields": {
-                        "type": "object",
-                        "description": "Describes if this connector expects these fields to be provided in the device definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                        "properties": {
-                            "address": {
-                                "$ref": "#/definitions/fieldNecessity"
-                            }
-                        },
-                        "required": [
-                            "address"
-                        ],
-                        "additionalProperties": false
-                    },
-                    "assetsEnabledByDefault": {
-                        "type": "boolean",
-                        "description": "If true, assets are enabled by default. Users may still specify in the deployed asset definition if each asset is enabled or not and that value will override this value."
-                    },
-                    "additionalConfigurationSchema": {
-                        "$ref": "http://json-schema.org/draft-07/schema#"
-                    },
-                    "version": {
-                        "type": "string",
-                        "description": "The version of the protocol of this inbound endpoint."
-                    },
-                    "eventGroups": {
-                        "type": "object",
-                        "description": "If present, this connector supports using event groups.",
-                        "properties": {
-                            "limits": {
-                                "$ref": "#/definitions/modelLimits"
-                            },
-                            "events": {
-                                "type": "object",
-                                "description": "If present, this connector supports using events.",
-                                "properties": {
-                                    "limits": {
-                                        "$ref": "#/definitions/modelLimits"
-                                    },
-                                    "eventConfigurationSchema": {
-                                        "$ref": "http://json-schema.org/draft-07/schema#",
-                                        "description": "The JSON schema for the \"eventConfiguration\" field on an event group's event."
-                                    },
-                                    "alternativeTypeName": {
-                                        "$ref": "#/definitions/alternativeTypeName",
-                                        "description": "The alternative name to the type \"event\" within an event group"
-                                    },
-                                    "fields": {
-                                        "type": "object",
-                                        "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                        "properties": {
-                                            "dataSource": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            },
-                                            "typeRef": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            }
-                                        },
-                                        "required": [
-                                            "dataSource",
-                                            "typeRef"
-                                        ],
-                                        "additionalProperties": false
-                                    },
-                                    "destinations": {
-                                        "type": "object",
-                                        "description": "Information about the supported and default destinations for asset events",
-                                        "properties": {
-                                            "supportedDestinations": {
-                                                "type": "array",
-                                                "description": "The array of destinations that this asset's events supports.",
-                                                "items": {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "Mqtt",
-                                                        "Storage"
-                                                    ]
-                                                }
-                                            },
-                                            "defaultDestination": {
-                                                "description": "The destination that this asset's events will go to by default unless specified otherwise in the asset or the event.",
-                                                "oneOf": [
-                                                    {
-                                                        "$ref": "#/definitions/mqttDestinationDefaults"
-                                                    },
-                                                    {
-                                                        "$ref": "#/definitions/storageDestinationDefaults"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        "additionalProperties": false,
-                                        "required": [
-                                            "supportedDestinations"
-                                        ]
-                                    }
-                                },
-                                "required": [
-                                    "fields",
-                                    "limits"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "alternativeTypeName": {
-                                "$ref": "#/definitions/alternativeTypeName",
-                                "description": "The alternative name to the type \"eventGroups\" within an asset"
-                            },
-                            "eventGroupConfigurationSchema": {
-                                "$ref": "http://json-schema.org/draft-07/schema#",
-                                "description": "The JSON schema for the \"eventGroupConfiguration\" field on an event group."
-                            },
-                            "fields": {
-                                "type": "object",
-                                "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                "properties": {
-                                    "dataSource": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    },
-                                    "typeRef": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    }
-                                },
-                                "required": [
-                                    "dataSource",
-                                    "typeRef"
-                                ],
-                                "additionalProperties": false
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "limits",
-                            "fields"
-                        ]
-                    },
-                    "datasets": {
-                        "type": "object",
-                        "description": "If present, this connector supports using datasets.",
-                        "properties": {
-                            "limits": {
-                                "$ref": "#/definitions/modelLimits"
-                            },
-                            "datasetConfigurationSchema": {
-                                "$ref": "http://json-schema.org/draft-07/schema#",
-                                "description": "The JSON schema for the \"datasetConfiguration\" field on a dataset."
-                            },
-                            "dataPoints": {
-                                "type": "object",
-                                "description": "If present, this connector supports using dataset datapoints.",
-                                "properties": {
-                                    "limits": {
-                                        "$ref": "#/definitions/modelLimits"
-                                    },
-                                    "dataPointConfigurationSchema": {
-                                        "$ref": "http://json-schema.org/draft-07/schema#",
-                                        "description": "The JSON schema for the \"dataPointConfiguration\" field on a dataset's datapoint."
-                                    },
-                                    "alternativeTypeName": {
-                                        "$ref": "#/definitions/alternativeTypeName",
-                                        "description": "The alternative name to the type \"dataPoints\" within a dataset"
-                                    },
-                                    "fields": {
-                                        "type": "object",
-                                        "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                        "properties": {
-                                            "dataSource": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            },
-                                            "typeRef": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            }
-                                        },
-                                        "required": [
-                                            "dataSource",
-                                            "typeRef"
-                                        ],
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "required": [
-                                    "limits",
-                                    "fields"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "alternativeTypeName": {
-                                "$ref": "#/definitions/alternativeTypeName",
-                                "description": "The alternative name to the type \"datasets\" within an asset"
-                            },
-                            "fields": {
-                                "type": "object",
-                                "description": "Describes if this connector expects these fields to be provided in the dataset definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                "properties": {
-                                    "dataSource": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    },
-                                    "typeRef": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    }
-                                },
-                                "required": [
-                                    "dataSource",
-                                    "typeRef"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "destinations": {
-                                "type": "object",
-                                "description": "Information about the supported and default destinations for asset datasets",
-                                "properties": {
-                                    "supportedDestinations": {
-                                        "type": "array",
-                                        "description": "The array of destinations that this asset's datasets supports.",
-                                        "items": {
-                                            "type": "string",
-                                            "enum": [
-                                                "Mqtt",
-                                                "BrokerStateStore",
-                                                "Storage"
-                                            ]
-                                        }
-                                    },
-                                    "defaultDestination": {
-                                        "description": "The destination that this asset's datasets will go to by default unless specified otherwise in the asset or the dataset.",
-                                        "oneOf": [
-                                            {
-                                                "$ref": "#/definitions/mqttDestinationDefaults"
-                                            },
-                                            {
-                                                "$ref": "#/definitions/storageDestinationDefaults"
-                                            },
-                                            {
-                                                "$ref": "#/definitions/brokerStateStoreDestinationDefaults"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "supportedDestinations"
-                                ]
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "limits",
-                            "fields"
-                        ]
-                    },
-                    "managementGroups": {
-                        "type": "object",
-                        "description": "If present, this connector supports using management groups.",
-                        "properties": {
-                            "limits": {
-                                "$ref": "#/definitions/modelLimits"
-                            },
-                            "managementGroupConfigurationSchema": {
-                                "$ref": "http://json-schema.org/draft-07/schema#",
-                                "description": "The JSON schema for the \"managementGroupConfiguration\" field on a management group."
-                            },
-                            "alternativeTypeName": {
-                                "$ref": "#/definitions/alternativeTypeName",
-                                "description": "The alternative name to the type \"managementGroups\" within an asset"
-                            },
-                            "managementGroupActions": {
-                                "type": "object",
-                                "description": "If present, this connector supports using management group actions.",
-                                "properties": {
-                                    "limits": {
-                                        "$ref": "#/definitions/modelLimits"
-                                    },
-                                    "actionConfigurationSchema": {
-                                        "$ref": "http://json-schema.org/draft-07/schema#",
-                                        "description": "The JSON schema for the \"actionConfiguration\" field on a management group's action."
-                                    },
-                                    "alternativeTypeName": {
-                                        "$ref": "#/definitions/alternativeTypeName",
-                                        "description": "The alternative name to the type \"actions\" within a management group"
-                                    },
-                                    "fields": {
-                                        "type": "object",
-                                        "description": "Describes if this connector expects these fields to be provided in the management group action definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                        "properties": {
-                                            "targetUri": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            },
-                                            "typeRef": {
-                                                "$ref": "#/definitions/fieldNecessity"
-                                            }
-                                        },
-                                        "required": [
-                                            "targetUri",
-                                            "typeRef"
-                                        ],
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "limits",
-                                    "fields"
-                                ]
-                            },
-                            "fields": {
-                                "type": "object",
-                                "description": "Describes if this connector expects these fields to be provided in the management group definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                "properties": {
-                                    "typeRef": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    },
-                                    "dataSource": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    }
-                                },
-                                "required": [
-                                    "typeRef"
-                                ],
-                                "additionalProperties": false
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "limits",
-                            "fields"
-                        ]
-                    },
-                    "streams": {
-                        "type": "object",
-                        "description": "If present, this connector supports using streams.",
-                        "properties": {
-                            "limits": {
-                                "$ref": "#/definitions/modelLimits"
-                            },
-                            "streamConfigurationSchema": {
-                                "$ref": "http://json-schema.org/draft-07/schema#",
-                                "description": "The JSON schema for the \"streamConfiguration\" field on a stream."
-                            },
-                            "alternativeTypeName": {
-                                "$ref": "#/definitions/alternativeTypeName",
-                                "description": "The alternative name to the type \"stream\" within an asset"
-                            },
-                            "fields": {
-                                "type": "object",
-                                "description": "Describes if this connector expects these fields to be provided in the stream definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                                "properties": {
-                                    "typeRef": {
-                                        "$ref": "#/definitions/fieldNecessity"
-                                    }
-                                },
-                                "required": [
-                                    "typeRef"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "destinations": {
-                                "type": "object",
-                                "description": "Information about the supported and default destinations for asset streams",
-                                "properties": {
-                                    "supportedDestinations": {
-                                        "type": "array",
-                                        "description": "The array of destinations that this asset's streams supports.",
-                                        "items": {
-                                            "type": "string",
-                                            "enum": [
-                                                "Mqtt",
-                                                "Storage"
-                                            ]
-                                        }
-                                    },
-                                    "defaultDestination": {
-                                        "description": "The destination that this asset's streams will go to by default unless unless specified otherwise in the asset or the stream.",
-                                        "oneOf": [
-                                            {
-                                                "$ref": "#/definitions/mqttDestinationDefaults"
-                                            },
-                                            {
-                                                "$ref": "#/definitions/storageDestinationDefaults"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                    "supportedDestinations"
-                                ]
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                            "fields",
-                            "limits"
-                        ]
-                    }
+                    "required": ["targetUri", "typeRef"],
+                    "additionalProperties": false
+                  }
                 },
                 "additionalProperties": false,
-                "required": [
-                    "endpointType",
-                    "fields"
-                ]
+                "required": ["limits", "fields"]
+              },
+              "fields": {
+                "type": "object",
+                "description": "Describes if this connector expects these fields to be provided in the management group definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                "properties": {
+                  "typeRef": { "$ref": "#/definitions/fieldNecessity" },
+                  "dataSource": { "$ref": "#/definitions/fieldNecessity" }
+                },
+                "required": ["typeRef"],
+                "additionalProperties": false
+              }
             },
-            "minItems": 1
+            "additionalProperties": false,
+            "required": ["limits", "fields"]
+          },
+          "streams": {
+            "type": "object",
+            "description": "If present, this connector supports using streams.",
+            "properties": {
+              "limits": { "$ref": "#/definitions/modelLimits" },
+              "streamConfigurationSchema": {
+                "$ref": "http://json-schema.org/draft-07/schema#",
+                "description": "The JSON schema for the \"streamConfiguration\" field on a stream."
+              },
+              "alternativeTypeName": {
+                "$ref": "#/definitions/alternativeTypeName",
+                "description": "The alternative name to the type \"stream\" within an asset"
+              },
+              "fields": {
+                "type": "object",
+                "description": "Describes if this connector expects these fields to be provided in the stream definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                "properties": {
+                  "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                },
+                "required": ["typeRef"],
+                "additionalProperties": false
+              },
+              "destinations": {
+                "type": "object",
+                "description": "Information about the supported and default destinations for asset streams",
+                "properties": {
+                  "supportedDestinations": {
+                    "type": "array",
+                    "description": "The array of destinations that this asset's streams supports.",
+                    "items": {
+                      "type": "string",
+                      "enum": ["Mqtt", "Storage"]
+                    }
+                  },
+                  "defaultDestination": {
+                    "description": "The destination that this asset's streams will go to by default unless unless specified otherwise in the asset or the stream.",
+                    "oneOf": [
+                      { "$ref": "#/definitions/mqttDestinationDefaults" },
+                      {
+                        "$ref": "#/definitions/storageDestinationDefaults"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["supportedDestinations"]
+              }
+            },
+            "required": ["fields", "limits"]
+          }
         },
-        "recommendedAllocationPolicy": {
-            "type": "string",
-            "description": "The recommended configuration to use for allocating device inbound endpoints for the connector instances. Only 'bucketized' is currently supported.",
-            "enum": [
-                "bucketized"
-            ]
-        },
-        "recommendedReplicas": {
-            "type": "integer",
-            "description": "The recommended number of replicas to deploy for this connector.",
-            "minimum": 1
-        }
+        "additionalProperties": false,
+        "required": ["endpointType", "fields"]
+      },
+      "minItems": 1
     },
-    "required": [
-        "name",
-        "version",
-        "supportedArchitectures",
-        "inboundEndpoints",
-        "imageConfigurationSettings"
-    ],
-    "additionalProperties": false
+    "recommendedAllocationPolicy": {
+      "type": "string",
+      "description": "The recommended configuration to use for allocating device inbound endpoints for the connector instances. Only 'bucketized' is currently supported.",
+      "enum": ["bucketized"]
+    },
+    "recommendedReplicas": {
+      "type": "integer",
+      "description": "The recommended number of replicas to deploy for this connector.",
+      "minimum": 1
+    }
+  },
+  "required": [
+    "name",
+    "version",
+    "supportedArchitectures",
+    "inboundEndpoints",
+    "imageConfigurationSettings"
+  ],
+  "additionalProperties": false
 }

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -4,11 +4,14 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import json
 import pytest
 from typing import List
 
+from azure.cli.core.azclierror import CLIInternalError
+
 from ...generators import generate_random_string
-from ...helpers import run, wait_for_expected_count
+from ...helpers import create_file, run, wait_for_expected_count
 from .namespace_helpers import create_config_file, assert_point_properties, assert_dataset_properties
 
 
@@ -117,7 +120,7 @@ def test_namespace_custom_asset_dataset_lifecycle_operations(
     dataset = run(
         f"az iot ops ns asset custom dataset add --asset {asset_name} "
         f"--instance {instance_name} -g {resource_group} --name {dataset_name_2} "
-        f"--data-source {data_source} "
+        f"--data-source '{data_source}' "
         f"--config {custom_config_path} --replace"
     )
 
@@ -843,3 +846,310 @@ def test_namespace_mqtt_asset_dataset_lifecycle_operations(asset_factory):
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
     assert dataset_name_1 not in remaining_dataset_names
+
+
+# ---------------------------------------------------------------------------
+# Helpers for generalized (connector-agnostic) tests
+# ---------------------------------------------------------------------------
+
+def _save_json_to_file(content: dict, tracked_files: List[str]) -> str:
+    """Serialize content to a temp JSON file and return its path."""
+    return create_file(
+        file_name=f"template_{generate_random_string(6)}.json",
+        module_file=__file__,
+        tracked_files=tracked_files,
+        content=json.dumps(content),
+    )
+
+
+def _try_show_template(cmd: str) -> dict:
+    """Run a --show-template command and return the parsed result.
+
+    Returns an empty dict if the command fails (e.g. no connector template installed).
+    """
+    try:
+        return run(cmd) or {}
+    except CLIInternalError:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Generalized dataset / datapoint commands — OPC UA (bundled metadata)
+# ---------------------------------------------------------------------------
+
+def test_generalized_dataset_lifecycle_opcua(asset_factory, tracked_files: List[str]):
+    """Full lifecycle of generalized dataset + datapoint commands on an OPC UA asset.
+
+    Flow:
+      1. --show-template config  →  discover schema
+      2. Fill connector-specific values in the returned template
+      3. Use filled template as --dataset-config / --datapoint-config
+      4. CRUD: add / show / list / update / remove
+      5. Export round-trip
+    """
+    info = asset_factory("opcua")
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    dataset_name = f"gen-ds-{generate_random_string(6, force_lower=True)}"
+    dataset_name_2 = f"gen-ds2-{generate_random_string(6, force_lower=True)}"
+    datapoint_name = f"gen-dp-{generate_random_string(6, force_lower=True)}"
+    data_source = "ns=2;s=Temperature"
+    dp_data_source = "ns=2;s=Temperature.Value"
+
+    # 1. SHOW-TEMPLATE – dataset
+    dataset_template = run(
+        f"az iot ops ns asset dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {dataset_name} --show-template config"
+    )
+    assert isinstance(dataset_template, dict)
+    assert "connectorType" in dataset_template
+    assert "datasetConfig" in dataset_template
+
+    dataset_config = dataset_template.copy()
+    dataset_config["datasetConfig"]["datasetConfiguration"] = {
+        "publishingInterval": 1000,
+        "samplingInterval": 500,
+        "queueSize": 5,
+    }
+    dataset_config["datasetConfig"].pop("destinations", None)
+    dataset_config_file = _save_json_to_file(dataset_config, tracked_files)
+
+    # 2. ADD dataset with config
+    added_dataset = run(
+        f"az iot ops ns asset dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {dataset_name} --data-source '{data_source}' "
+        f"--dataset-config {dataset_config_file}"
+    )
+    assert_dataset_properties(
+        added_dataset, name=dataset_name, data_source=data_source,
+        opcua_configuration={"publishingInterval": 1000},
+    )
+
+    # 3. SHOW dataset
+    shown_dataset = run(
+        f"az iot ops ns asset dataset show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {dataset_name}"
+    )
+    assert_dataset_properties(shown_dataset, name=dataset_name, data_source=data_source)
+
+    # 4. LIST datasets
+    datasets_list = run(
+        f"az iot ops ns asset dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert any(d["name"] == dataset_name for d in datasets_list)
+
+    # 5. ADD a second dataset
+    added_dataset_2 = run(
+        f"az iot ops ns asset dataset add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {dataset_name_2} --data-source '{data_source}'"
+    )
+    assert_dataset_properties(added_dataset_2, name=dataset_name_2)
+    dataset_names = [d["name"] for d in run(
+        f"az iot ops ns asset dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )]
+    assert dataset_name in dataset_names and dataset_name_2 in dataset_names
+
+    # 6. UPDATE dataset
+    updated_source = "ns=2;s=Temperature.Updated"
+    dataset_config["datasetConfig"]["datasetConfiguration"]["publishingInterval"] = 2000
+    updated_config_file = _save_json_to_file(dataset_config, tracked_files)
+    updated_dataset = run(
+        f"az iot ops ns asset dataset update --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {dataset_name} --data-source '{updated_source}' "
+        f"--dataset-config {updated_config_file}"
+    )
+    assert_dataset_properties(
+        updated_dataset, name=dataset_name, data_source=updated_source,
+        opcua_configuration={"publishingInterval": 2000},
+    )
+
+    # 7. SHOW-TEMPLATE – datapoint
+    datapoint_template = run(
+        f"az iot ops ns asset datapoint add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--dataset {dataset_name} --name {datapoint_name} "
+        f"--data-source '{dp_data_source}' --show-template config"
+    )
+    assert isinstance(datapoint_template, dict)
+    assert "connectorType" in datapoint_template
+    assert "datapointConfig" in datapoint_template
+
+    datapoint_config = datapoint_template.copy()
+    datapoint_config["datapointConfig"]["datapointConfiguration"] = {
+        "samplingInterval": 200,
+        "queueSize": 3,
+    }
+    datapoint_config_file = _save_json_to_file(datapoint_config, tracked_files)
+
+    # 8. ADD datapoint with config
+    added_datapoints = run(
+        f"az iot ops ns asset datapoint add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--dataset {dataset_name} --name {datapoint_name} "
+        f"--data-source '{dp_data_source}' --datapoint-config {datapoint_config_file}"
+    )
+    assert_point_properties(added_datapoints, name=datapoint_name, data_source=dp_data_source)
+
+    # 9. LIST datapoints
+    dp_list = run(
+        f"az iot ops ns asset datapoint list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+    )
+    assert any(dp["name"] == datapoint_name for dp in dp_list)
+
+    # 10. REPLACE datapoint
+    replaced_dp_source = "ns=2;s=Temperature.Replaced"
+    replaced_datapoints = run(
+        f"az iot ops ns asset datapoint add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--dataset {dataset_name} --name {datapoint_name} "
+        f"--data-source '{replaced_dp_source}' --replace"
+    )
+    assert_point_properties(replaced_datapoints, name=datapoint_name, data_source=replaced_dp_source)
+
+    # 11. EXPORT datasets
+    export_result = run(
+        f"az iot ops ns asset dataset export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --output-dir /tmp --replace"
+    )
+    assert export_result["dataset_count"] >= 1
+    tracked_files.append(export_result["file_path"])
+
+    # 12. EXPORT datapoints
+    dp_export_result = run(
+        f"az iot ops ns asset datapoint export --asset {asset_name} "
+        f"--dataset {dataset_name} --instance {instance_name} -g {resource_group} "
+        f"--output-dir /tmp --replace"
+    )
+    assert dp_export_result["datapoint_count"] >= 1
+    tracked_files.append(dp_export_result["file_path"])
+
+    # 13. REMOVE datapoint
+    run(
+        f"az iot ops ns asset datapoint remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--dataset {dataset_name} --name {datapoint_name}"
+    )
+    dp_list_after = run(
+        f"az iot ops ns asset datapoint list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --dataset {dataset_name}"
+    )
+    assert not any(dp["name"] == datapoint_name for dp in (dp_list_after or []))
+
+    # 14. REMOVE datasets
+    for ds in [dataset_name, dataset_name_2]:
+        run(
+            f"az iot ops ns asset dataset remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {ds}"
+        )
+    remaining = [d["name"] for d in (run(
+        f"az iot ops ns asset dataset list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    ) or [])]
+    assert dataset_name not in remaining and dataset_name_2 not in remaining
+
+
+# ---------------------------------------------------------------------------
+# Generalized dataset / datapoint commands — MQTT (connector template required)
+# ---------------------------------------------------------------------------
+
+def test_generalized_dataset_lifecycle_mqtt(asset_factory, tracked_files: List[str]):
+    """Generalized dataset + datapoint lifecycle on an MQTT asset.
+
+    --show-template is attempted first. If no connector template is installed,
+    the template step is skipped and basic add/update/remove is tested without config.
+    """
+    info = asset_factory("mqtt")
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    dataset_name = f"gen-ds-{generate_random_string(6, force_lower=True)}"
+    datapoint_name = f"gen-dp-{generate_random_string(6, force_lower=True)}"
+    data_source = "mqtt/temperature"
+    dp_data_source = "mqtt/temperature/value"
+
+    base_cmd = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
+
+    # 1. SHOW-TEMPLATE – dataset (best-effort)
+    dataset_config_file = None
+    dataset_template = _try_show_template(
+        f"az iot ops ns asset dataset add {base_cmd} "
+        f"--name {dataset_name} --show-template config"
+    )
+    if dataset_template:
+        assert "connectorType" in dataset_template
+        assert "datasetConfig" in dataset_template
+        dataset_config_file = _save_json_to_file(dataset_template, tracked_files)
+
+    # 2. ADD dataset
+    add_cmd = (
+        f"az iot ops ns asset dataset add {base_cmd} "
+        f"--name {dataset_name} --data-source '{data_source}'"
+    )
+    if dataset_config_file:
+        add_cmd += f" --dataset-config {dataset_config_file}"
+    added_dataset = run(add_cmd)
+    assert_dataset_properties(added_dataset, name=dataset_name, data_source=data_source)
+
+    # 3. SHOW dataset
+    shown = run(f"az iot ops ns asset dataset show {base_cmd} --name {dataset_name}")
+    assert_dataset_properties(shown, name=dataset_name)
+
+    # 4. LIST datasets
+    datasets_list = run(f"az iot ops ns asset dataset list {base_cmd}")
+    assert any(d["name"] == dataset_name for d in datasets_list)
+
+    # 5. UPDATE dataset
+    updated_source = "mqtt/temperature/updated"
+    updated_dataset = run(
+        f"az iot ops ns asset dataset update {base_cmd} "
+        f"--name {dataset_name} --data-source {updated_source}"
+    )
+    assert_dataset_properties(updated_dataset, name=dataset_name, data_source=updated_source)
+
+    # 6. SHOW-TEMPLATE – datapoint (best-effort)
+    datapoint_config_file = None
+    datapoint_template = _try_show_template(
+        f"az iot ops ns asset datapoint add {base_cmd} "
+        f"--dataset {dataset_name} --name {datapoint_name} "
+        f"--data-source '{dp_data_source}' --show-template config"
+    )
+    if datapoint_template:
+        assert "connectorType" in datapoint_template
+        assert "datapointConfig" in datapoint_template
+        datapoint_config_file = _save_json_to_file(datapoint_template, tracked_files)
+
+    # 7. ADD datapoint
+    dp_add_cmd = (
+        f"az iot ops ns asset datapoint add {base_cmd} "
+        f"--dataset {dataset_name} --name {datapoint_name} "
+        f"--data-source '{dp_data_source}'"
+    )
+    if datapoint_config_file:
+        dp_add_cmd += f" --datapoint-config {datapoint_config_file}"
+    added_datapoints = run(dp_add_cmd)
+    assert_point_properties(added_datapoints, name=datapoint_name, data_source=dp_data_source)
+
+    # 8. LIST datapoints
+    dp_list = run(f"az iot ops ns asset datapoint list {base_cmd} --dataset {dataset_name}")
+    assert any(dp["name"] == datapoint_name for dp in dp_list)
+
+    # 9. REMOVE datapoint
+    run(
+        f"az iot ops ns asset datapoint remove {base_cmd} "
+        f"--dataset {dataset_name} --name {datapoint_name}"
+    )
+    dp_list_after = run(f"az iot ops ns asset datapoint list {base_cmd} --dataset {dataset_name}")
+    assert not any(dp["name"] == datapoint_name for dp in (dp_list_after or []))
+
+    # 10. REMOVE dataset
+    run(f"az iot ops ns asset dataset remove {base_cmd} --name {dataset_name}")
+    datasets_after = run(f"az iot ops ns asset dataset list {base_cmd}")
+    assert not any(d["name"] == dataset_name for d in (datasets_after or []))

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -36,6 +36,15 @@ from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
 )
 from ...generators import generate_random_string
+from azext_edge.edge.commands_namespaces import (
+    add_namespace_asset_dataset,
+    update_namespace_asset_dataset,
+    add_namespace_asset_dataset_point,
+)
+from azext_edge.edge.providers.adr.namespace_assets import (
+    _deep_merge_template,
+    _merge_destinations_template,
+)
 
 
 def generate_dataset(dataset_name: Optional[str] = None, num_data_points: int = 0) -> dict:
@@ -2241,3 +2250,629 @@ def test_import_namespace_asset_event_group_events(
     # Verify result is a list of events
     assert isinstance(result, list)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# _deep_merge_template unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template, existing, expected", [
+    # Null values in template replaced by existing scalars
+    ({"a": None, "b": 10}, {"a": 5}, {"a": 5, "b": 10}),
+    # Existing keys not in template are added
+    ({"a": None}, {"a": 1, "extra": "hello"}, {"a": 1, "extra": "hello"}),
+    # Nested dict: existing values override nulls recursively
+    ({"nested": {"x": None, "y": 2}}, {"nested": {"x": 99}}, {"nested": {"x": 99, "y": 2}}),
+    # Non-dict existing value for a dict template key: existing wins
+    ({"cfg": {"x": None}}, {"cfg": "raw_string"}, {"cfg": "raw_string"}),
+    # Existing always wins over template (pre-fill semantics: ARM values take precedence)
+    ({"a": 42, "b": None}, {"a": 7, "b": 3}, {"a": 7, "b": 3}),
+    # Empty template: all existing keys are added
+    ({}, {"x": 1, "y": 2}, {"x": 1, "y": 2}),
+])
+def test_deep_merge_template(template, existing, expected):
+    result = _deep_merge_template(template, existing)
+    assert result == expected
+
+
+def test_deep_merge_template_returns_existing_when_template_none():
+    assert _deep_merge_template(None, {"a": 1}) == {"a": 1}
+
+
+def test_deep_merge_template_returns_template_when_existing_none():
+    assert _deep_merge_template({"a": None}, None) == {"a": None}
+
+
+# ---------------------------------------------------------------------------
+# _merge_destinations_template unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_destinations_template_fills_existing_values():
+    template = [
+        {"target": "Mqtt", "configuration": {"topic": None, "qos": None}},
+        {"target": "BrokerStateStore", "configuration": {"key": None}},
+    ]
+    existing = [
+        {"target": "Mqtt", "configuration": {"topic": "my/topic", "qos": "Qos1"}},
+    ]
+    result = _merge_destinations_template(template, existing)
+    mqtt_entry = next(e for e in result if e["target"] == "Mqtt")
+    assert mqtt_entry["configuration"]["topic"] == "my/topic"
+    assert mqtt_entry["configuration"]["qos"] == "Qos1"
+    # Unmatched destination stays as-is (nulls)
+    bss_entry = next(e for e in result if e["target"] == "BrokerStateStore")
+    assert bss_entry["configuration"]["key"] is None
+
+
+def test_merge_destinations_template_no_match_preserves_template():
+    template = [{"target": "Mqtt", "configuration": {"topic": None}}]
+    existing = [{"target": "BrokerStateStore", "configuration": {"key": "k1"}}]
+    result = _merge_destinations_template(template, existing)
+    assert result[0]["configuration"]["topic"] is None
+
+
+def test_merge_destinations_template_empty_existing():
+    template = [{"target": "Mqtt", "configuration": {"topic": None}}]
+    result = _merge_destinations_template(template, [])
+    assert result == template
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_dataset (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+def _build_asset_with_connector(
+    asset_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    connector_type: str = "Custom.Test",
+    datasets: Optional[list] = None,
+) -> dict:
+    """Build a mock asset record pre-wired for the generalized path."""
+    asset = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    asset["properties"]["datasets"] = datasets or []
+    return asset
+
+
+def _add_device_get_for_generalized(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    connector_type: str,
+) -> None:
+    """Register GET device mock needed by _get_connector_type_from_asset and _check_device_props."""
+    device_name = asset["properties"]["deviceRef"]["deviceName"]
+    endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
+    add_device_get_call(
+        mocked_responses,
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        endpoint_name=endpoint_name,
+        endpoint_type=connector_type,
+    )
+
+
+@pytest.mark.parametrize("has_dataset_config", [False, True])
+@pytest.mark.parametrize("replace, pre_existing", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_add_namespace_asset_dataset_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_dataset_config: bool,
+    replace: bool,
+    pre_existing: bool,
+):
+    asset_name = "gen-asset"
+    instance_name = "testInstance"
+    instance_resource_group = "testRG"
+    dataset_name = f"ds-{generate_random_string()}"
+    connector_type = "Custom.Test"
+
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    dataset_config_json = json.dumps({
+        "datasetConfiguration": {"publishingInterval": 1000},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "t/test"}}],
+    })
+
+    # Build asset with optional pre-existing dataset
+    existing_datasets = [generate_dataset(dataset_name=dataset_name)] if pre_existing else []
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=existing_datasets,
+    )
+
+    # _get_connector_type_from_asset: GET asset + GET device
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    # _check_device_props(asset_name=...): GET asset + GET device
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    # Mock _get_connector_metadata if dataset_config provided (called in _load_and_validate_dataset_config)
+    if has_dataset_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value={
+                "inboundEndpoints": [{
+                    "endpointType": f"Microsoft.{connector_type}",
+                    "datasets": {
+                        "datasetConfigurationSchema": None,
+                        "destinations": {"supportedDestinations": ["Mqtt"]},
+                    },
+                }]
+            },
+        )
+
+    # PATCH + final GET
+    updated_asset = deepcopy(asset)
+    updated_asset["properties"]["datasets"] = [{"name": dataset_name, "dataSource": "src/test", "dataPoints": []}]
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_dataset(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        dataset_name=dataset_name,
+        data_source="src/test",
+        replace=replace,
+        dataset_config=dataset_config_json if has_dataset_config else None,
+        wait_sec=0,
+    )
+
+    assert result["name"] == dataset_name
+
+
+def test_add_namespace_asset_dataset_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    dataset_name = "existing-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[generate_dataset(dataset_name=dataset_name)],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_dataset(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            replace=False,
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_namespace_asset_dataset (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_namespace_asset_dataset_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_ds = {
+        "name": dataset_name,
+        "dataSource": "orig/src",
+        "datasetConfiguration": json.dumps({"publishingInterval": 1000}),
+        "destinations": [],
+        "dataPoints": [],
+    }
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[existing_ds],
+    )
+
+    dataset_config_json = json.dumps({
+        "datasetConfiguration": {"publishingInterval": 5000},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}],
+    })
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value={
+            "inboundEndpoints": [{
+                "endpointType": f"Microsoft.{connector_type}",
+                "datasets": {"datasetConfigurationSchema": None, "destinations": {"supportedDestinations": ["Mqtt"]}},
+            }]
+        },
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_ds = deepcopy(existing_ds)
+    updated_ds["datasetConfiguration"] = json.dumps({"publishingInterval": 5000})
+    updated_ds["destinations"] = [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}]
+    updated_asset["properties"]["datasets"] = [updated_ds]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_dataset(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        dataset_name=dataset_name,
+        dataset_config=dataset_config_json,
+        wait_sec=0,
+    )
+
+    assert result["name"] == dataset_name
+    assert json.loads(result["datasetConfiguration"])["publishingInterval"] == 5000
+
+
+def test_update_namespace_asset_dataset_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on update should pre-fill existing ARM values into the template."""
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_ds = {
+        "name": dataset_name,
+        "dataSource": "orig/src",
+        "datasetConfiguration": json.dumps({"publishingInterval": 3000, "bufferSize": 5}),
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "live/topic", "qos": "Qos1"}}],
+        "dataPoints": [],
+    }
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[existing_ds],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value={
+            "inboundEndpoints": [{
+                "endpointType": f"Microsoft.{connector_type}",
+                "datasets": {
+                    "datasetConfigurationSchema": {
+                        "type": "object",
+                        "properties": {
+                            "publishingInterval": {"type": "integer", "default": 1000},
+                            "bufferSize": {"type": "integer", "default": 10},
+                        }
+                    },
+                    "destinations": {"supportedDestinations": ["Mqtt"]},
+                    "limits": {},
+                    "fields": {"dataSource": {"input": "optional"}, "typeRef": {"input": "unsupported"}},
+                },
+            }]
+        },
+    )
+
+    result = update_namespace_asset_dataset(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        dataset_name=dataset_name,
+        show_template="config",
+        wait_sec=0,
+    )
+
+    # connectorType wrapper present (device mock adds Microsoft. prefix)
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    ds_cfg = result["datasetConfig"]["datasetConfiguration"]
+    # Existing ARM values should be pre-filled
+    assert ds_cfg["publishingInterval"] == 3000
+    assert ds_cfg["bufferSize"] == 5
+    # Existing destination topic should be pre-filled
+    dests = result["datasetConfig"]["destinations"]
+    mqtt_dest = next((d for d in dests if d["target"] == "Mqtt"), None)
+    assert mqtt_dest is not None
+    assert mqtt_dest["configuration"]["topic"] == "live/topic"
+
+
+def test_update_namespace_asset_dataset_generalized_raises_if_not_found(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="not found"):
+        update_namespace_asset_dataset(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name="missing-ds",
+            show_template="config",
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_dataset_point (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_datapoint_config", [False, True])
+def test_add_namespace_asset_dataset_point_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_datapoint_config: bool,
+):
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    datapoint_name = "temp-dp"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_ds = {
+        "name": dataset_name,
+        "dataSource": "s/src",
+        "dataPoints": [],
+    }
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[existing_ds],
+    )
+
+    datapoint_config_json = json.dumps({
+        "datapointConfiguration": {"samplingInterval": 250, "deadBand": 0.5, "enabled": True}
+    })
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    if has_datapoint_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value={
+                "inboundEndpoints": [{
+                    "endpointType": f"Microsoft.{connector_type}",
+                    "datasets": {
+                        "dataPoints": {"dataPointConfigurationSchema": None},
+                    },
+                }]
+            },
+        )
+
+    updated_asset = deepcopy(asset)
+    added_dp = {"name": datapoint_name, "dataSource": "sensors/temp"}
+    if has_datapoint_config:
+        added_dp["dataPointConfiguration"] = json.dumps({"samplingInterval": 250, "deadBand": 0.5, "enabled": True})
+    updated_asset["properties"]["datasets"][0]["dataPoints"] = [added_dp]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_dataset_point(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        dataset_name=dataset_name,
+        datapoint_name=datapoint_name,
+        data_source="sensors/temp",
+        replace=False,
+        datapoint_config=datapoint_config_json if has_datapoint_config else None,
+        wait_sec=0,
+    )
+
+    assert isinstance(result, list)
+    dp = next((p for p in result if p["name"] == datapoint_name), None)
+    assert dp is not None
+    assert dp["dataSource"] == "sensors/temp"
+    if has_datapoint_config:
+        cfg = json.loads(dp["dataPointConfiguration"])
+        assert cfg["samplingInterval"] == 250
+        assert cfg["deadBand"] == 0.5
+
+
+def test_add_namespace_asset_dataset_point_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    datapoint_name = "existing-dp"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_ds = {
+        "name": dataset_name,
+        "dataSource": "s/src",
+        "dataPoints": [{"name": datapoint_name, "dataSource": "sensors/old"}],
+    }
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[existing_ds],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_dataset_point(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            datapoint_name=datapoint_name,
+            data_source="sensors/new",
+            replace=False,
+            wait_sec=0,
+        )


### PR DESCRIPTION
- Adds generalized `az iot ops ns asset dataset` and `az iot ops ns asset datapoint` commands (add, update, show, list, remove, export, import) that auto-detect connector type from the asset — no need to use connector-specific subgroups (opcua, mqtt, etc.)

- --show-template config/schema on add returns the connector's dataset/datapoint configuration schema; on update it additionally pre-fills existing ARM values so users only need to edit what changed

- --dataset-config / --datapoint-config accepts inline JSON or a file path, enabling a discover-fill-apply workflow that works uniformly across all connector types

- Refreshes bundled connector_metadata_schema.json from SchemaStore upstream and adds unit + integration test coverage for the new commands

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
