### PR TITLE
fix(connector-template): prevent tar slip in connector template create

### DIFF
--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -829,9 +829,9 @@ class ConnectorTemplates(Queryable):
         Safely extract all members of a tar archive into dest_dir.
 
         Prevents Tar Slip / path traversal (CWE-22) by rejecting members whose
-        resolved destination would fall outside dest_dir (e.g. absolute paths,
-        ``..`` traversal sequences, or links pointing outside the destination).
-        Special file members (FIFO/character/block devices) are also rejected.
+        resolved destination would fall outside dest_dir (e.g. absolute paths or
+        ``..`` traversal sequences). Link members (symlink/hardlink) and special
+        file members (FIFO/character/block devices) are also rejected.
 
         Args:
             tar: An open tarfile.TarFile to extract.
@@ -856,19 +856,18 @@ class ConnectorTemplates(Queryable):
             if member.isdev() or member.isfifo():
                 raise ValidationError(
                     f"Refusing to extract unsupported tar member from artifact: '{member.name}'. "
-                    "Only regular files, directories, and contained links are allowed."
+                    "Only regular files and directories are allowed."
                 )
 
-            # Reject links (symlink/hardlink) that resolve outside the destination.
+            # Links (symlink/hardlink) are unnecessary for metadata extraction and are easy to misuse for
+            # path traversal-style attacks, so reject them entirely.
             if member.islnk() or member.issym():
-                link_target = os.path.realpath(os.path.join(os.path.dirname(member_path), member.linkname))
-                if not self._is_within_directory(dest_root, link_target):
-                    raise ValidationError(
-                        f"Refusing to extract unsafe link from artifact: '{member.name}'. "
-                        "The archive contains a link pointing outside the extraction directory."
-                    )
+                raise ValidationError(
+                    f"Refusing to extract link from artifact: '{member.name}'. "
+                    "Link members are not supported."
+                )
 
-        tar.extractall(dest_root)
+        tar.extractall(dest_root, members=[m for m in tar.getmembers() if m.isdir() or m.isreg()])
 
     @staticmethod
     def _is_within_directory(directory: str, target: str) -> bool:

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -843,7 +843,8 @@ class ConnectorTemplates(Queryable):
         """
         dest_root = os.path.realpath(dest_dir)
 
-        for member in tar.getmembers():
+        members = tar.getmembers()
+        for member in members:
             member_path = os.path.realpath(os.path.join(dest_root, member.name))
             if not self._is_within_directory(dest_root, member_path):
                 raise ValidationError(
@@ -867,7 +868,7 @@ class ConnectorTemplates(Queryable):
                     "Link members are not supported."
                 )
 
-        tar.extractall(dest_root, members=[m for m in tar.getmembers() if m.isdir() or m.isreg()])
+        tar.extractall(dest_root, members=[m for m in members if m.isdir() or m.isreg()])
 
     @staticmethod
     def _is_within_directory(directory: str, target: str) -> bool:

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -824,6 +824,49 @@ class ConnectorTemplates(Queryable):
                 f"Failed to fetch connector metadata from {metadata_ref}: {str(e)}"
             )
 
+    def _safe_extractall(self, tar: tarfile.TarFile, dest_dir: str) -> None:
+        """
+        Safely extract all members of a tar archive into dest_dir.
+
+        Prevents Tar Slip / path traversal (CWE-22) by rejecting members whose
+        resolved destination would fall outside dest_dir (e.g. absolute paths,
+        ``..`` traversal sequences, or links pointing outside the destination).
+
+        Args:
+            tar: An open tarfile.TarFile to extract.
+            dest_dir: The directory into which members must be extracted.
+
+        Raises:
+            ValidationError: If any member would be written outside dest_dir.
+        """
+        dest_root = os.path.realpath(dest_dir)
+
+        for member in tar.getmembers():
+            member_path = os.path.realpath(os.path.join(dest_root, member.name))
+            if not self._is_within_directory(dest_root, member_path):
+                raise ValidationError(
+                    f"Refusing to extract unsafe path from artifact: '{member.name}'. "
+                    "The archive attempts to write outside the extraction directory."
+                )
+
+            # Reject links (symlink/hardlink) that resolve outside the destination.
+            if member.islnk() or member.issym():
+                link_target = os.path.realpath(os.path.join(os.path.dirname(member_path), member.linkname))
+                if not self._is_within_directory(dest_root, link_target):
+                    raise ValidationError(
+                        f"Refusing to extract unsafe link from artifact: '{member.name}'. "
+                        "The archive contains a link pointing outside the extraction directory."
+                    )
+
+        tar.extractall(dest_root)
+
+    @staticmethod
+    def _is_within_directory(directory: str, target: str) -> bool:
+        """Return True if ``target`` is located within ``directory``."""
+        directory = os.path.realpath(directory)
+        target = os.path.realpath(target)
+        return os.path.commonpath([directory]) == os.path.commonpath([directory, target])
+
     def _parse_metadata_blob(self, blob_content: bytes, metadata_ref: str) -> dict:
         """
         Parse connector metadata from blob content.
@@ -859,13 +902,13 @@ class ConnectorTemplates(Queryable):
             try:
                 logger.debug("Attempting to extract as tar.gz")
                 with tarfile.open(fileobj=io.BytesIO(blob_content), mode="r:gz") as tar:
-                    tar.extractall(temp_dir)
+                    self._safe_extractall(tar, temp_dir)
             except (tarfile.ReadError, OSError):
                 # Try as plain tar
                 try:
                     logger.debug("tar.gz failed, attempting to extract as plain tar")
                     with tarfile.open(fileobj=io.BytesIO(blob_content), mode="r") as tar:
-                        tar.extractall(temp_dir)
+                        self._safe_extractall(tar, temp_dir)
                 except (tarfile.ReadError, OSError) as e:
                     raise CLIInternalError(
                         f"Failed to extract artifact from {metadata_ref}. "

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -824,7 +824,8 @@ class ConnectorTemplates(Queryable):
                 f"Failed to fetch connector metadata from {metadata_ref}: {str(e)}"
             )
 
-    def _safe_extractall(self, tar: tarfile.TarFile, dest_dir: str) -> None:
+    @staticmethod
+    def _safe_extractall(tar: tarfile.TarFile, dest_dir: str) -> None:
         """
         Safely extract all members of a tar archive into dest_dir.
 
@@ -846,7 +847,7 @@ class ConnectorTemplates(Queryable):
         members = tar.getmembers()
         for member in members:
             member_path = os.path.realpath(os.path.join(dest_root, member.name))
-            if not self._is_within_directory(dest_root, member_path):
+            if not ConnectorTemplates._is_within_directory(dest_root, member_path):
                 raise ValidationError(
                     f"Refusing to extract unsafe path from artifact: '{member.name}'. "
                     "The archive attempts to write outside the extraction directory."

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -831,13 +831,15 @@ class ConnectorTemplates(Queryable):
         Prevents Tar Slip / path traversal (CWE-22) by rejecting members whose
         resolved destination would fall outside dest_dir (e.g. absolute paths,
         ``..`` traversal sequences, or links pointing outside the destination).
+        Special file members (FIFO/character/block devices) are also rejected.
 
         Args:
             tar: An open tarfile.TarFile to extract.
             dest_dir: The directory into which members must be extracted.
 
         Raises:
-            ValidationError: If any member would be written outside dest_dir.
+            ValidationError: If any member would be written outside dest_dir or
+                is an unsupported special file type.
         """
         dest_root = os.path.realpath(dest_dir)
 
@@ -847,6 +849,14 @@ class ConnectorTemplates(Queryable):
                 raise ValidationError(
                     f"Refusing to extract unsafe path from artifact: '{member.name}'. "
                     "The archive attempts to write outside the extraction directory."
+                )
+
+            # Reject special file types (FIFO/character/block devices). They are unnecessary for
+            # metadata extraction and could cause the later open() to block or have unsafe side effects.
+            if member.isdev() or member.isfifo():
+                raise ValidationError(
+                    f"Refusing to extract unsupported tar member from artifact: '{member.name}'. "
+                    "Only regular files, directories, and contained links are allowed."
                 )
 
             # Reject links (symlink/hardlink) that resolve outside the destination.
@@ -865,7 +875,12 @@ class ConnectorTemplates(Queryable):
         """Return True if ``target`` is located within ``directory``."""
         directory = os.path.realpath(directory)
         target = os.path.realpath(target)
-        return os.path.commonpath([directory]) == os.path.commonpath([directory, target])
+        try:
+            return os.path.commonpath([directory]) == os.path.commonpath([directory, target])
+        except ValueError:
+            # Raised when paths are on different drives (Windows) or mix absolute/relative;
+            # such a target cannot be within the directory, so treat it as unsafe.
+            return False
 
     def _parse_metadata_blob(self, blob_content: bytes, metadata_ref: str) -> dict:
         """

--- a/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
@@ -167,21 +167,22 @@ def test_safe_extract_blocks_absolute_path(tmp_path):
     assert not os.path.exists(marker)
 
 
-def test_safe_extract_blocks_symlink_escape(tmp_path):
-    link = tarfile.TarInfo(name="link")
-    link.type = tarfile.SYMTYPE
-    link.linkname = "../../etc/passwd"
-    blob = _build_tar_blob([(link, None)])
-
-    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
-        with pytest.raises(ValidationError):
-            _provider()._safe_extractall(tar, str(tmp_path))
-
-
-def test_safe_extract_blocks_special_files(tmp_path):
-    fifo = tarfile.TarInfo(name="connector-metadata.json")
-    fifo.type = tarfile.FIFOTYPE
-    blob = _build_tar_blob([(fifo, None)])
+@pytest.mark.parametrize(
+    "member_type",
+    [
+        tarfile.SYMTYPE,
+        tarfile.LNKTYPE,
+        tarfile.FIFOTYPE,
+        tarfile.CHRTYPE,
+        tarfile.BLKTYPE,
+    ],
+)
+def test_safe_extract_blocks_unsupported_members(member_type, tmp_path):
+    member = tarfile.TarInfo(name="connector-metadata.json")
+    member.type = member_type
+    if member_type in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+        member.linkname = "../../etc/passwd"
+    blob = _build_tar_blob([(member, None)])
 
     with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
         with pytest.raises(ValidationError):

--- a/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
@@ -150,7 +150,8 @@ def test_safe_extract_blocks_relative_traversal(malicious_name, tmp_path):
             _provider()._safe_extractall(tar, str(tmp_path))
 
     # Ensure nothing was written outside the destination directory.
-    assert not (tmp_path.parent / "malicious.txt").exists()
+    outside_path = os.path.realpath(os.path.join(str(tmp_path), malicious_name))
+    assert not os.path.exists(outside_path)
 
 
 def test_safe_extract_blocks_absolute_path(tmp_path):

--- a/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
@@ -155,7 +155,8 @@ def test_safe_extract_blocks_relative_traversal(malicious_name, tmp_path):
 
 def test_safe_extract_blocks_absolute_path(tmp_path):
     # An absolute member name escapes the destination via os.path.join and must be rejected.
-    marker = f"/tmp/{generate_random_string()}.txt"
+    marker = str(tmp_path.parent / f"{generate_random_string()}.txt")
+    assert not os.path.exists(marker)
     blob = _build_tar_blob([_file_member(marker, generate_random_string().encode("utf-8"))])
 
     with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:

--- a/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
@@ -176,6 +176,16 @@ def test_safe_extract_blocks_symlink_escape(tmp_path):
             _provider()._safe_extractall(tar, str(tmp_path))
 
 
+def test_safe_extract_blocks_special_files(tmp_path):
+    fifo = tarfile.TarInfo(name="connector-metadata.json")
+    fifo.type = tarfile.FIFOTYPE
+    blob = _build_tar_blob([(fifo, None)])
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        with pytest.raises(ValidationError):
+            _provider()._safe_extractall(tar, str(tmp_path))
+
+
 def test_is_within_directory(tmp_path):
     inside = os.path.join(str(tmp_path), "sub", "file.txt")
     outside = os.path.join(str(tmp_path), "..", "file.txt")

--- a/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/connector/akri/test_connector_templates_unit.py
@@ -4,8 +4,20 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import io
+import json
+import os
+import tarfile
 from typing import Optional
 
+import pytest
+from azure.cli.core.azclierror import ValidationError
+
+from azext_edge.edge.providers.orchestration.resources.connector_templates import (
+    ConnectorTemplates,
+)
+
+from ......generators import generate_random_string
 from ...conftest import (
     INSTANCES_API_VERSION,
     RESOURCE_PROVIDER,
@@ -84,3 +96,89 @@ def get_mock_connector_template_record(
         **optional_kwargs,
     )
     return record
+
+
+def _provider() -> ConnectorTemplates:
+    # Bypass __init__ (which requires a command context) since the extraction
+    # helpers under test do not rely on any instance state.
+    return object.__new__(ConnectorTemplates)
+
+
+def _file_member(name: str, data: bytes) -> tuple:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    return info, data
+
+
+def _build_tar_blob(members: list, gzip: bool = True) -> bytes:
+    """Build a tar(.gz) blob from a list of (TarInfo, data) members."""
+    buffer = io.BytesIO()
+    mode = "w:gz" if gzip else "w"
+    with tarfile.open(fileobj=buffer, mode=mode) as tar:
+        for info, data in members:
+            tar.addfile(info, io.BytesIO(data) if data is not None else None)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize("gzip", [True, False])
+def test_safe_extract_valid_archive(gzip, tmp_path):
+    connector_name = generate_random_string()
+    payload = json.dumps({"name": connector_name}).encode("utf-8")
+    blob = _build_tar_blob([_file_member("connector-metadata.json", payload)], gzip=gzip)
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz" if gzip else "r") as tar:
+        _provider()._safe_extractall(tar, str(tmp_path))
+
+    extracted = tmp_path / "connector-metadata.json"
+    assert extracted.exists()
+    assert json.loads(extracted.read_text())["name"] == connector_name
+
+
+@pytest.mark.parametrize(
+    "malicious_name",
+    [
+        "../malicious.txt",
+        "../../malicious.txt",
+        "foo/../../malicious.txt",
+    ],
+)
+def test_safe_extract_blocks_relative_traversal(malicious_name, tmp_path):
+    blob = _build_tar_blob([_file_member(malicious_name, generate_random_string().encode("utf-8"))])
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        with pytest.raises(ValidationError):
+            _provider()._safe_extractall(tar, str(tmp_path))
+
+    # Ensure nothing was written outside the destination directory.
+    assert not (tmp_path.parent / "malicious.txt").exists()
+
+
+def test_safe_extract_blocks_absolute_path(tmp_path):
+    # An absolute member name escapes the destination via os.path.join and must be rejected.
+    marker = f"/tmp/{generate_random_string()}.txt"
+    blob = _build_tar_blob([_file_member(marker, generate_random_string().encode("utf-8"))])
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        with pytest.raises(ValidationError):
+            _provider()._safe_extractall(tar, str(tmp_path))
+
+    assert not os.path.exists(marker)
+
+
+def test_safe_extract_blocks_symlink_escape(tmp_path):
+    link = tarfile.TarInfo(name="link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "../../etc/passwd"
+    blob = _build_tar_blob([(link, None)])
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        with pytest.raises(ValidationError):
+            _provider()._safe_extractall(tar, str(tmp_path))
+
+
+def test_is_within_directory(tmp_path):
+    inside = os.path.join(str(tmp_path), "sub", "file.txt")
+    outside = os.path.join(str(tmp_path), "..", "file.txt")
+
+    assert _provider()._is_within_directory(str(tmp_path), inside) is True
+    assert _provider()._is_within_directory(str(tmp_path), outside) is False


### PR DESCRIPTION
- Hardens _parse_metadata_blob() in connector template create/update by adding _safe_extractall(), which validates every tar member before extraction and rejects path-traversal sequences, absolute paths, and links resolving outside the temp directory (raising ValidationError).

- Fixes the Tar Slip / arbitrary file write vulnerability (CWE-22) reachable via az iot ops connector template create against a malicious OCI artifact.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
