### PR TITLE
feat(adr): mark generalized asset and endpoint commands as preview and bump version

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.7.0a1"
+VERSION = "2.7.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -307,7 +307,7 @@ def load_iotops_commands(self, _):
     ) as cmd_group:
         cmd_group.command("list", "list_inbound_device_endpoints")
         cmd_group.command("remove", "remove_inbound_device_endpoints")
-        cmd_group.command("apply", "apply_inbound_device_endpoint")
+        cmd_group.command("apply", "apply_inbound_device_endpoint", is_preview=True)
 
     with self.command_group(
         "iot ops ns device endpoint inbound add",
@@ -325,8 +325,8 @@ def load_iotops_commands(self, _):
         "iot ops ns asset",
         command_type=namespace_resource_ops,
     ) as cmd_group:
-        cmd_group.command("create", "create_namespace_asset")
-        cmd_group.command("update", "update_namespace_asset")
+        cmd_group.command("create", "create_namespace_asset", is_preview=True)
+        cmd_group.command("update", "update_namespace_asset", is_preview=True)
         cmd_group.command("delete", "delete_namespace_asset")
         cmd_group.command("query", "query_namespace_assets")
         cmd_group.show_command("show", "show_namespace_asset")
@@ -345,24 +345,24 @@ def load_iotops_commands(self, _):
         "iot ops ns asset dataset",
         command_type=namespace_resource_ops,
     ) as cmd_group:
-        cmd_group.command("add", "add_namespace_asset_dataset")
-        cmd_group.command("export", "export_namespace_asset_dataset")
-        cmd_group.command("import", "import_namespace_asset_dataset")
-        cmd_group.command("list", "list_namespace_asset_datasets")
-        cmd_group.command("remove", "remove_namespace_asset_dataset")
-        cmd_group.show_command("show", "show_namespace_asset_dataset")
-        cmd_group.command("update", "update_namespace_asset_dataset")
+        cmd_group.command("add", "add_namespace_asset_dataset", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_dataset", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_dataset", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_datasets", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_dataset", is_preview=True)
+        cmd_group.show_command("show", "show_namespace_asset_dataset", is_preview=True)
+        cmd_group.command("update", "update_namespace_asset_dataset", is_preview=True)
 
     # generalized datapoint group (connector-agnostic)
     with self.command_group(
         "iot ops ns asset datapoint",
         command_type=namespace_resource_ops,
     ) as cmd_group:
-        cmd_group.command("add", "add_namespace_asset_dataset_point")
-        cmd_group.command("export", "export_namespace_asset_dataset_point")
-        cmd_group.command("import", "import_namespace_asset_dataset_point")
-        cmd_group.command("list", "list_namespace_asset_dataset_points")
-        cmd_group.command("remove", "remove_namespace_asset_dataset_point")
+        cmd_group.command("add", "add_namespace_asset_dataset_point", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_dataset_point", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_dataset_point", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_dataset_points", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_dataset_point", is_preview=True)
 
     # dataset
     for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
