### PR TITLE
feat: add multi-cloud support for Azure Government and China

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.7.0"
+VERSION = "2.8.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -33,7 +33,6 @@ from .common import (
     MGMT_ACTIONS_DEFAULT_EG_CLIENT_GROUP,
     MGMT_ACTIONS_DEFAULT_MQTT_ENDPOINT,
     MGMT_ACTIONS_DEFAULT_REGISTRY_ENDPOINT,
-    MGMT_ACTIONS_EG_AUDIENCE,
     MGMT_ACTIONS_GRAPH_ARTIFACT,
     MGMT_ACTIONS_GRAPH_RULES_VERSION,
     MGMT_ACTIONS_REQUEST_TOPIC_TEMPLATE,
@@ -258,6 +257,13 @@ class MgmtActions(Queryable):
         Bootstraps the management actions infrastructure across Event Grid, ADR, and AIO domains.
         """
         from ...util.machinery import scoped_semver_import
+        from ...util.cloud_config import CloudConfig
+
+        if not CloudConfig(self.cmd).supports_eventgrid_mqtt:
+            raise ValidationError(
+                "Management actions are not available in this cloud environment. This feature relies on "
+                "Event Grid Namespaces with MQTT, which is not supported in the active cloud."
+            )
 
         semver = scoped_semver_import()
 
@@ -1665,22 +1671,24 @@ class MgmtActions(Queryable):
         )
         return {"name": endpoint_name, "authentication": desired_authentication, "exists": False}
 
-    @staticmethod
-    def _build_eg_endpoint_auth(mi_resource: Optional[Dict] = None) -> Dict:
+    def _build_eg_endpoint_auth(self, mi_resource: Optional[Dict] = None) -> Dict:
         """Build the authentication block for the EG MQTT dataflow endpoint."""
+        from ...util.cloud_config import CloudConfig
+
+        eg_audience = CloudConfig(self.cmd).eventgrid_audience
         if mi_resource:
             return {
                 "method": "UserAssignedManagedIdentity",
                 "userAssignedManagedIdentitySettings": {
                     "clientId": mi_resource["properties"]["clientId"],
                     "tenantId": mi_resource["properties"]["tenantId"],
-                    "scope": f"{MGMT_ACTIONS_EG_AUDIENCE}/.default",
+                    "scope": f"{eg_audience}/.default",
                 },
             }
         return {
             "method": "SystemAssignedManagedIdentity",
             "systemAssignedManagedIdentitySettings": {
-                "audience": MGMT_ACTIONS_EG_AUDIENCE,
+                "audience": eg_audience,
             },
         }
 

--- a/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector/opcua/certs.py
@@ -22,6 +22,7 @@ from ...instances import SECRET_SYNC_RESOURCE_TYPE, Instances
 from .....orchestration.upgrade2 import calculate_config_delta
 from ......util.file_operations import read_file_content, validate_file_extension
 from ......util.queryable import Queryable
+from ......util.cloud_config import CloudConfig
 from ......util.az_client import (
     get_keyvault_client,
     get_ssc_mgmt_client,
@@ -59,6 +60,7 @@ class OpcUACerts(Queryable):
         )
         self.keyvault_client = get_keyvault_client(
             subscription_id=self.default_subscription_id,
+            keyvault_scope=CloudConfig(self.cmd).keyvault_scope,
         )
         self.instance_name = instance_name
         self.resource_group_name = resource_group_name

--- a/azext_edge/edge/providers/orchestration/resources/dataflows.py
+++ b/azext_edge/edge/providers/orchestration/resources/dataflows.py
@@ -14,6 +14,7 @@ from azure.core.exceptions import ResourceNotFoundError
 
 from ....util.common import should_continue_prompt
 from ....util.az_client import wait_for_terminal_state
+from ....util.cloud_config import CloudConfig
 from ....util.queryable import Queryable
 from ..common import (
     ADLS_ENDPOINT_USER_ASSIGNED_DEFAULT_SCOPE,
@@ -571,6 +572,7 @@ class DataFlowEndpoints(Queryable):
         port: Optional[str] = None,
         **_
     ) -> str:
+        cloud_config = CloudConfig(self.cmd)
         processed_host = ""
         if endpoint_type in [
             DataflowEndpointType.DATAEXPLORER.value,
@@ -578,11 +580,16 @@ class DataFlowEndpoints(Queryable):
         ]:
             processed_host = host
         elif endpoint_type == DataflowEndpointType.DATALAKESTORAGE.value:
-            processed_host = f"https://{storage_account_name}.blob.core.windows.net"
+            processed_host = f"https://{storage_account_name}.blob.{cloud_config.storage_suffix}"
         elif endpoint_type == DataflowEndpointType.FABRICONELAKE.value:
+            if not cloud_config.supports_fabric_onelake:
+                raise InvalidArgumentValueError(
+                    "Fabric OneLake dataflow endpoints are not available in this cloud environment. "
+                    "This feature is only supported in Azure Public Cloud."
+                )
             processed_host = "https://onelake.dfs.fabric.microsoft.com"
         elif endpoint_type == DataflowEndpointType.EVENTHUB.value:
-            processed_host = f"{eventhub_namespace}.servicebus.windows.net:9093"
+            processed_host = f"{eventhub_namespace}.{cloud_config.servicebus_suffix}:9093"
         elif endpoint_type in [
             DataflowEndpointType.CUSTOMKAFKA.value,
             DataflowEndpointType.AIOLOCALMQTT.value,

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -36,6 +36,7 @@ from ....util.common import (
     url_safe_hash_phrase,
 )
 from ....util.queryable import Queryable
+from ....util.cloud_config import CloudConfig
 from ....util.resource_graph import ResourceGraph
 from ..common import (
     AZURE_DEVICE_REGISTRY_ADMINISTRATOR_ROLE_ID,
@@ -571,7 +572,10 @@ class Instances(Queryable):
             vault_url = kv_result["vaultUri"]
             kv_subscription_id = kv_result["subscriptionId"]
 
-            keyvault_client = get_keyvault_client(subscription_id=kv_subscription_id)
+            keyvault_client = get_keyvault_client(
+                subscription_id=kv_subscription_id,
+                keyvault_scope=CloudConfig(self.cmd).keyvault_scope,
+            )
             for mapping in secret_mappings:
                 try:
                     secret_response = keyvault_client.get_secret(

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -281,15 +281,14 @@ def get_authz_client(subscription_id: str, **kwargs) -> "AuthorizationManagement
     )
 
 
-def get_keyvault_client(subscription_id: str, **kwargs) -> "KeyVaultClient":
+def get_keyvault_client(subscription_id: str, keyvault_scope: Optional[str] = None, **kwargs) -> "KeyVaultClient":
     from ..vendor.clients.keyvault import KeyVaultClient
 
-    # TODO: this only supports azure public cloud for now
     client = KeyVaultClient(
         credential=AZURE_CLI_CREDENTIAL,
         subscription_id=subscription_id,
         user_agent_policy=UserAgentPolicy(user_agent=USER_AGENT),
-        credential_scopes=["https://vault.azure.net/.default"],
+        credential_scopes=[keyvault_scope or "https://vault.azure.net/.default"],
         **kwargs,
     )
 

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -66,17 +66,11 @@ class CloudConfig:
         return self._cloud.endpoints.resource_manager
 
     @property
-    def arm_scope(self) -> str:
-        """ARM token scope from active_directory_resource_id (e.g. https://management.core.windows.net/.default)."""
-        return f"{self._cloud.endpoints.active_directory_resource_id.rstrip('/')}/.default"
-
-    @property
     def arm_endpoint_scope(self) -> str:
         """ARM resource manager endpoint token scope (e.g. https://management.azure.com/.default).
 
-        Unlike ``arm_scope`` (derived from ``active_directory_resource_id``), this is derived from
-        the ARM endpoint itself. Required by flows such as ACR's oauth2/exchange that expect a token
-        for the resource manager audience (``https://management.<cloud>/``).
+        Derived from the ARM endpoint itself. Required by flows such as ACR's oauth2/exchange that
+        expect a token for the resource manager audience (``https://management.<cloud>/``).
         """
         return f"{self._cloud.endpoints.resource_manager.rstrip('/')}/.default"
 

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -67,7 +67,7 @@ class CloudConfig:
 
     @property
     def arm_scope(self) -> str:
-        """ARM token scope derived from active_directory_resource_id (e.g. https://management.core.windows.net/.default)."""
+        """ARM token scope from active_directory_resource_id (e.g. https://management.core.windows.net/.default)."""
         return f"{self._cloud.endpoints.active_directory_resource_id.rstrip('/')}/.default"
 
     @property

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
 # Known cloud names as reported by ``cmd.cli_ctx.cloud.name``.
 CLOUD_AZURE_PUBLIC = "AzureCloud"
 CLOUD_AZURE_US_GOVERNMENT = "AzureUSGovernment"
+# NOTE: Azure China (Mooncake) is NOT functional today — the Azure IoT Operations service
+# does not have server-side support in Mooncake, so end-to-end flows cannot be validated
+# there yet. The China endpoint/suffix mappings below are intentionally retained so that
+# support is already in place if/when Mooncake gains server-side support in the future.
+# Until then, treat AzureChinaCloud as best-effort / untested.
 CLOUD_AZURE_CHINA = "AzureChinaCloud"
 
 # Service Bus FQDN suffix per cloud. Not provided by the Azure CLI cloud framework.

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -67,7 +67,7 @@ class CloudConfig:
 
     @property
     def arm_scope(self) -> str:
-        """ARM token scope (e.g. https://management.azure.com/.default)."""
+        """ARM token scope derived from active_directory_resource_id (e.g. https://management.core.windows.net/.default)."""
         return f"{self._cloud.endpoints.active_directory_resource_id.rstrip('/')}/.default"
 
     @property

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -71,6 +71,16 @@ class CloudConfig:
         return f"{self._cloud.endpoints.active_directory_resource_id.rstrip('/')}/.default"
 
     @property
+    def arm_endpoint_scope(self) -> str:
+        """ARM resource manager endpoint token scope (e.g. https://management.azure.com/.default).
+
+        Unlike ``arm_scope`` (derived from ``active_directory_resource_id``), this is derived from
+        the ARM endpoint itself. Required by flows such as ACR's oauth2/exchange that expect a token
+        for the resource manager audience (``https://management.<cloud>/``).
+        """
+        return f"{self._cloud.endpoints.resource_manager.rstrip('/')}/.default"
+
+    @property
     def graph_endpoint(self) -> str:
         """Microsoft Graph endpoint with trailing slash (e.g. https://graph.microsoft.com/)."""
         endpoint = self._cloud.endpoints.microsoft_graph_resource_id

--- a/azext_edge/edge/util/cloud_config.py
+++ b/azext_edge/edge/util/cloud_config.py
@@ -1,0 +1,124 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""
+Centralized cloud configuration.
+
+Single source of truth for cloud-specific endpoints, suffixes, and token scopes.
+Values that the Azure CLI cloud framework provides (ARM, Microsoft Graph, Key Vault,
+Storage, ACR) are read at runtime from ``cmd.cli_ctx.cloud``. Values the framework does
+not provide (Service Bus suffix, Event Grid token audience) are maintained here as
+explicit cloud-name -> value mappings.
+
+When adding new cloud-dependent functionality, resolve values through ``CloudConfig``
+rather than hardcoding public-cloud URLs.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from azure.cli.core.commands import AzCliCommand
+
+# Known cloud names as reported by ``cmd.cli_ctx.cloud.name``.
+CLOUD_AZURE_PUBLIC = "AzureCloud"
+CLOUD_AZURE_US_GOVERNMENT = "AzureUSGovernment"
+CLOUD_AZURE_CHINA = "AzureChinaCloud"
+
+# Service Bus FQDN suffix per cloud. Not provided by the Azure CLI cloud framework.
+SERVICEBUS_SUFFIX_MAP = {
+    CLOUD_AZURE_PUBLIC: "servicebus.windows.net",
+    CLOUD_AZURE_US_GOVERNMENT: "servicebus.usgovcloudapi.net",
+    CLOUD_AZURE_CHINA: "servicebus.chinacloudapi.cn",
+}
+
+# Event Grid token audience per cloud. Not provided by the Azure CLI cloud framework.
+EVENTGRID_AUDIENCE_MAP = {
+    CLOUD_AZURE_PUBLIC: "https://eventgrid.azure.net",
+    CLOUD_AZURE_US_GOVERNMENT: "https://eventgrid.azure.us",
+    CLOUD_AZURE_CHINA: "https://eventgrid.azure.cn",
+}
+
+# Clouds where Microsoft Fabric OneLake is available.
+FABRIC_ONELAKE_SUPPORTED_CLOUDS = frozenset({CLOUD_AZURE_PUBLIC})
+
+# Clouds where Event Grid Namespaces with MQTT (used by management actions) is available.
+EVENTGRID_MQTT_SUPPORTED_CLOUDS = frozenset({CLOUD_AZURE_PUBLIC, CLOUD_AZURE_US_GOVERNMENT})
+
+
+class CloudConfig:
+    """Resolves cloud-specific values for the user's active Azure CLI cloud context."""
+
+    def __init__(self, cmd: "AzCliCommand"):
+        self._cloud = cmd.cli_ctx.cloud
+
+    @property
+    def name(self) -> str:
+        return self._cloud.name
+
+    # --- Values provided by the Azure CLI cloud framework ---
+
+    @property
+    def arm_endpoint(self) -> str:
+        """Azure Resource Manager endpoint (e.g. https://management.azure.com/)."""
+        return self._cloud.endpoints.resource_manager
+
+    @property
+    def arm_scope(self) -> str:
+        """ARM token scope (e.g. https://management.azure.com/.default)."""
+        return f"{self._cloud.endpoints.active_directory_resource_id.rstrip('/')}/.default"
+
+    @property
+    def graph_endpoint(self) -> str:
+        """Microsoft Graph endpoint with trailing slash (e.g. https://graph.microsoft.com/)."""
+        endpoint = self._cloud.endpoints.microsoft_graph_resource_id
+        return endpoint if endpoint.endswith("/") else f"{endpoint}/"
+
+    @property
+    def graph_token_resource(self) -> str:
+        """Microsoft Graph token resource (no trailing slash)."""
+        return self._cloud.endpoints.microsoft_graph_resource_id.rstrip("/")
+
+    @property
+    def storage_suffix(self) -> str:
+        """Storage endpoint suffix (e.g. core.windows.net)."""
+        return self._cloud.suffixes.storage_endpoint
+
+    @property
+    def keyvault_dns_suffix(self) -> str:
+        """Key Vault DNS suffix (e.g. .vault.azure.net)."""
+        return self._cloud.suffixes.keyvault_dns
+
+    @property
+    def keyvault_scope(self) -> str:
+        """Key Vault data-plane token scope (e.g. https://vault.azure.net/.default)."""
+        return f"https://{self._cloud.suffixes.keyvault_dns.lstrip('.')}/.default"
+
+    @property
+    def acr_suffix(self) -> str:
+        """Azure Container Registry login server suffix (e.g. .azurecr.io)."""
+        return self._cloud.suffixes.acr_login_server_endpoint
+
+    # --- Values maintained here (not provided by the framework) ---
+
+    @property
+    def servicebus_suffix(self) -> str:
+        """Service Bus FQDN suffix (e.g. servicebus.windows.net)."""
+        return SERVICEBUS_SUFFIX_MAP.get(self.name, SERVICEBUS_SUFFIX_MAP[CLOUD_AZURE_PUBLIC])
+
+    @property
+    def eventgrid_audience(self) -> str:
+        """Event Grid token audience (e.g. https://eventgrid.azure.net)."""
+        return EVENTGRID_AUDIENCE_MAP.get(self.name, EVENTGRID_AUDIENCE_MAP[CLOUD_AZURE_PUBLIC])
+
+    # --- Feature availability ---
+
+    @property
+    def supports_fabric_onelake(self) -> bool:
+        return self.name in FABRIC_ONELAKE_SUPPORTED_CLOUDS
+
+    @property
+    def supports_eventgrid_mqtt(self) -> bool:
+        return self.name in EVENTGRID_MQTT_SUPPORTED_CLOUDS

--- a/azext_edge/edge/util/oci_client.py
+++ b/azext_edge/edge/util/oci_client.py
@@ -308,7 +308,7 @@ class OciRegistryClient:
         headers: Dict[str, str] = {}
 
         token = None
-        if self._is_acr_registry(registry):
+        if self._is_acr_registry(registry, cmd=cmd):
             token = self._get_acr_access_token(cmd=cmd, registry=registry, repository=repository)
         if not token:
             token = self._get_anonymous_token(registry, repository)
@@ -359,7 +359,9 @@ class OciRegistryClient:
             return None
 
         try:
-            arm_token = AZURE_CLI_CREDENTIAL.get_token("https://management.azure.com/.default").token
+            from .cloud_config import CloudConfig
+
+            arm_token = AZURE_CLI_CREDENTIAL.get_token(CloudConfig(cmd).arm_scope).token
         except Exception as ex:  # pragma: no cover - credential failures
             logger.warning(f"Failed to obtain ARM token for ACR: {ex}")
             return None
@@ -421,8 +423,15 @@ class OciRegistryClient:
         return token_resp.json().get("access_token")
 
     @staticmethod
-    def _is_acr_registry(registry: str) -> bool:
+    def _is_acr_registry(registry: str, cmd=None) -> bool:
         """Check if the registry is an Azure Container Registry."""
+        if cmd is not None:
+            from .cloud_config import CloudConfig
+
+            try:
+                return registry.endswith(CloudConfig(cmd).acr_suffix)
+            except Exception:  # pragma: no cover - cloud ACR suffix not set
+                pass
         return registry.endswith(".azurecr.io")
 
     @staticmethod

--- a/azext_edge/edge/util/oci_client.py
+++ b/azext_edge/edge/util/oci_client.py
@@ -361,7 +361,7 @@ class OciRegistryClient:
         try:
             from .cloud_config import CloudConfig
 
-            arm_token = AZURE_CLI_CREDENTIAL.get_token(CloudConfig(cmd).arm_scope).token
+            arm_token = AZURE_CLI_CREDENTIAL.get_token(CloudConfig(cmd).arm_endpoint_scope).token
         except Exception as ex:  # pragma: no cover - credential failures
             logger.warning(f"Failed to obtain ARM token for ACR: {ex}")
             return None

--- a/azext_edge/edge/util/queryable.py
+++ b/azext_edge/edge/util/queryable.py
@@ -11,10 +11,6 @@ from .az_client import get_resource_client
 from .resource_graph import ResourceGraph
 from knack.log import get_logger
 
-GRAPH_ENDPOINT = "https://graph.microsoft.com/"
-GRAPH_V1_ENDPOINT = f"{GRAPH_ENDPOINT}v1.0"
-GRAPH_V1_SP_ENDPOINT = f"{GRAPH_V1_ENDPOINT}/servicePrincipals"
-
 
 logger = get_logger(__name__)
 
@@ -66,11 +62,16 @@ class Queryable:
     def get_resource_group(self, name: str) -> dict:
         return self.resource_client.resource_groups.get(resource_group_name=name)
 
-    def get_sp_id(self, app_id: str, token_resource: str = "https://graph.microsoft.com", **kwargs) -> Optional[str]:
+    def get_sp_id(self, app_id: str, token_resource: Optional[str] = None, **kwargs) -> Optional[str]:
         """
         Attempts to fetch the service principal Id by app Id from the Microsoft Graph API.
         """
         from azure.cli.core.util import send_raw_request
+        from .cloud_config import CloudConfig
+
+        cloud_config = CloudConfig(self.cmd)
+        graph_sp_endpoint = f"{cloud_config.graph_endpoint}v1.0/servicePrincipals"
+        token_resource = token_resource or cloud_config.graph_token_resource
 
         # See if we can fetch the RP OID.
         logger.debug(f"Using aud: {token_resource}")
@@ -78,7 +79,7 @@ class Queryable:
             sp_response = send_raw_request(
                 cli_ctx=self.cmd.cli_ctx,
                 method="GET",
-                url=f"{GRAPH_V1_SP_ENDPOINT}(appId='{app_id}')",
+                url=f"{graph_sp_endpoint}(appId='{app_id}')",
                 resource=token_resource,
                 **kwargs,
             ).json()

--- a/azext_edge/tests/conftest.py
+++ b/azext_edge/tests/conftest.py
@@ -106,7 +106,7 @@ def mocked_cmd(mocker, mocked_get_subscription_id, mocked_azcli_cred_get_token, 
     cloud.endpoints = Stub()
     cloud.endpoints.resource_manager = "https://management.azure.com/"
     cloud.endpoints.active_directory = "https://login.microsoftonline.com/"
-    cloud.endpoints.active_directory_resource_id = "https://management.azure.com/"
+    cloud.endpoints.active_directory_resource_id = "https://management.core.windows.net/"
     cloud.endpoints.microsoft_graph_resource_id = "https://graph.microsoft.com/"
     cloud.suffixes = Stub()
     cloud.suffixes.storage_endpoint = "core.windows.net"

--- a/azext_edge/tests/conftest.py
+++ b/azext_edge/tests/conftest.py
@@ -102,10 +102,16 @@ def mocked_cmd(mocker, mocked_get_subscription_id, mocked_azcli_cred_get_token, 
         pass
 
     cloud = Stub()
+    cloud.name = "AzureCloud"
     cloud.endpoints = Stub()
     cloud.endpoints.resource_manager = "https://management.azure.com/"
     cloud.endpoints.active_directory = "https://login.microsoftonline.com/"
     cloud.endpoints.active_directory_resource_id = "https://management.azure.com/"
+    cloud.endpoints.microsoft_graph_resource_id = "https://graph.microsoft.com/"
+    cloud.suffixes = Stub()
+    cloud.suffixes.storage_endpoint = "core.windows.net"
+    cloud.suffixes.keyvault_dns = ".vault.azure.net"
+    cloud.suffixes.acr_login_server_endpoint = ".azurecr.io"
 
     az_cli_mock = mocker.patch("azure.cli.core.AzCli", autospec=True, **{"data": {"command": "az"}, "cloud": cloud})
     config = {"cli_ctx": az_cli_mock}

--- a/azext_edge/tests/edge/orchestration/resources/dataflow_endpoint/test_dataflow_endpoints_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/dataflow_endpoint/test_dataflow_endpoints_unit.py
@@ -175,3 +175,82 @@ def test_dataflow_endpoint_apply(mocked_cmd, mocked_responses: responses, mocked
     assert create_result == expected_payload
     request_payload = json.loads(put_response.calls[0].request.body)
     assert request_payload["extendedLocation"] == mock_instance_record["extendedLocation"]
+
+
+def _make_endpoint_provider(cloud_name: str):
+    # Bypass the heavy __init__ (which builds mgmt clients); we only need self.cmd
+    # to exercise _get_endpoint_host's cloud-aware construction.
+    from azext_edge.edge.providers.orchestration.resources.dataflows import DataFlowEndpoints
+    from azext_edge.tests.helpers import build_mock_cmd_for_cloud
+
+    provider = DataFlowEndpoints.__new__(DataFlowEndpoints)
+    provider.cmd = build_mock_cmd_for_cloud(cloud_name)
+    return provider
+
+
+@pytest.mark.parametrize(
+    "cloud_name, expected_suffix",
+    [
+        ("AzureCloud", "core.windows.net"),
+        ("AzureUSGovernment", "core.usgovcloudapi.net"),
+        ("AzureChinaCloud", "core.chinacloudapi.cn"),
+    ],
+)
+def test_adls_host_uses_cloud_storage_suffix(cloud_name, expected_suffix):
+    from azext_edge.edge.providers.orchestration.common import DataflowEndpointType
+
+    provider = _make_endpoint_provider(cloud_name)
+    account = generate_random_string()
+
+    host = provider._get_endpoint_host(
+        endpoint_type=DataflowEndpointType.DATALAKESTORAGE.value,
+        storage_account_name=account,
+    )
+
+    assert host == f"https://{account}.blob.{expected_suffix}"
+
+
+@pytest.mark.parametrize(
+    "cloud_name, expected_suffix",
+    [
+        ("AzureCloud", "servicebus.windows.net"),
+        ("AzureUSGovernment", "servicebus.usgovcloudapi.net"),
+        ("AzureChinaCloud", "servicebus.chinacloudapi.cn"),
+    ],
+)
+def test_eventhub_host_uses_cloud_servicebus_suffix(cloud_name, expected_suffix):
+    from azext_edge.edge.providers.orchestration.common import DataflowEndpointType
+
+    provider = _make_endpoint_provider(cloud_name)
+    namespace = generate_random_string()
+
+    host = provider._get_endpoint_host(
+        endpoint_type=DataflowEndpointType.EVENTHUB.value,
+        eventhub_namespace=namespace,
+    )
+
+    assert host == f"{namespace}.{expected_suffix}:9093"
+
+
+def test_fabric_onelake_allowed_in_public():
+    from azext_edge.edge.providers.orchestration.common import DataflowEndpointType
+
+    provider = _make_endpoint_provider("AzureCloud")
+
+    host = provider._get_endpoint_host(endpoint_type=DataflowEndpointType.FABRICONELAKE.value)
+
+    assert host == "https://onelake.dfs.fabric.microsoft.com"
+
+
+@pytest.mark.parametrize("cloud_name", ["AzureUSGovernment", "AzureChinaCloud"])
+def test_fabric_onelake_blocked_in_non_public(cloud_name):
+    from azure.cli.core.azclierror import InvalidArgumentValueError
+    from azext_edge.edge.providers.orchestration.common import DataflowEndpointType
+
+    provider = _make_endpoint_provider(cloud_name)
+
+    with pytest.raises(InvalidArgumentValueError) as exc:
+        provider._get_endpoint_host(endpoint_type=DataflowEndpointType.FABRICONELAKE.value)
+
+    assert "Fabric OneLake" in str(exc.value)
+    assert "Azure Public Cloud" in str(exc.value)

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -5726,3 +5726,43 @@ class TestRemoveManagementEndpoint:
                 confirm_yes=True,
                 wait_sec=0,
             )
+
+
+class TestMgmtActionsCloudGate:
+    """Event Grid MQTT-based management actions are gated by cloud (blocked in China)."""
+
+    @staticmethod
+    def _make_mgmt_actions(cloud_name: str) -> MgmtActions:
+        # Bypass the heavy __init__; enable() applies the cloud gate before using any client.
+        from azext_edge.tests.helpers import build_mock_cmd_for_cloud
+
+        provider = MgmtActions.__new__(MgmtActions)
+        provider.cmd = build_mock_cmd_for_cloud(cloud_name)
+        return provider
+
+    def test_mgmt_actions_enable_blocked_in_china(self):
+        provider = self._make_mgmt_actions("AzureChinaCloud")
+
+        with pytest.raises(ValidationError) as exc:
+            provider.enable(
+                name=generate_random_string(),
+                resource_group_name=generate_random_string(),
+                eg_resource_id=generate_random_string(),
+            )
+
+        assert "not available in this cloud environment" in str(exc.value)
+
+    @pytest.mark.parametrize("cloud_name", ["AzureCloud", "AzureUSGovernment"])
+    def test_mgmt_actions_enable_not_blocked_in_supported_clouds(self, cloud_name):
+        provider = self._make_mgmt_actions(cloud_name)
+
+        # In supported clouds the cloud gate must NOT raise; the call proceeds past the gate
+        # and fails later for an unrelated reason (no mgmt client wired in this lightweight setup).
+        with pytest.raises(Exception) as exc:
+            provider.enable(
+                name=generate_random_string(),
+                resource_group_name=generate_random_string(),
+                eg_resource_id=generate_random_string(),
+            )
+
+        assert "not available in this cloud environment" not in str(exc.value)

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -441,3 +441,59 @@ def wait_for_expected_count(
         f"Expected {expected_count} items but got {len(result)} after {max_retries} retries"
     )
     return result
+
+
+# Representative endpoint/suffix values per cloud, matching what the Azure CLI
+# cloud framework exposes at runtime. Used to build mock cmd objects for
+# government-cloud (Fairfax) and China-cloud readiness tests.
+CLOUD_CONFIG_FIXTURES = {
+    "AzureCloud": {
+        "resource_manager": "https://management.azure.com/",
+        "active_directory_resource_id": "https://management.core.windows.net/",
+        "microsoft_graph_resource_id": "https://graph.microsoft.com/",
+        "storage_endpoint": "core.windows.net",
+        "keyvault_dns": ".vault.azure.net",
+        "acr_login_server_endpoint": ".azurecr.io",
+    },
+    "AzureUSGovernment": {
+        "resource_manager": "https://management.usgovcloudapi.net/",
+        "active_directory_resource_id": "https://management.core.usgovcloudapi.net/",
+        "microsoft_graph_resource_id": "https://graph.microsoft.us/",
+        "storage_endpoint": "core.usgovcloudapi.net",
+        "keyvault_dns": ".vault.usgovcloudapi.net",
+        "acr_login_server_endpoint": ".azurecr.us",
+    },
+    "AzureChinaCloud": {
+        "resource_manager": "https://management.chinacloudapi.cn",
+        "active_directory_resource_id": "https://management.core.chinacloudapi.cn/",
+        "microsoft_graph_resource_id": "https://microsoftgraph.chinacloudapi.cn",
+        "storage_endpoint": "core.chinacloudapi.cn",
+        "keyvault_dns": ".vault.azure.cn",
+        "acr_login_server_endpoint": ".azurecr.cn",
+    },
+}
+
+
+def build_mock_cmd_for_cloud(cloud_name: str) -> "Mock":
+    """Build a mock cmd whose cli_ctx.cloud reflects the given cloud's endpoints/suffixes."""
+    from unittest.mock import Mock
+
+    fixture = CLOUD_CONFIG_FIXTURES[cloud_name]
+
+    class _Stub:
+        pass
+
+    cloud = _Stub()
+    cloud.name = cloud_name
+    cloud.endpoints = _Stub()
+    cloud.endpoints.resource_manager = fixture["resource_manager"]
+    cloud.endpoints.active_directory_resource_id = fixture["active_directory_resource_id"]
+    cloud.endpoints.microsoft_graph_resource_id = fixture["microsoft_graph_resource_id"]
+    cloud.suffixes = _Stub()
+    cloud.suffixes.storage_endpoint = fixture["storage_endpoint"]
+    cloud.suffixes.keyvault_dns = fixture["keyvault_dns"]
+    cloud.suffixes.acr_login_server_endpoint = fixture["acr_login_server_endpoint"]
+
+    cmd = Mock()
+    cmd.cli_ctx.cloud = cloud
+    return cmd

--- a/azext_edge/tests/helpers.py
+++ b/azext_edge/tests/helpers.py
@@ -474,7 +474,7 @@ CLOUD_CONFIG_FIXTURES = {
 }
 
 
-def build_mock_cmd_for_cloud(cloud_name: str) -> "Mock":
+def build_mock_cmd_for_cloud(cloud_name: str):
     """Build a mock cmd whose cli_ctx.cloud reflects the given cloud's endpoints/suffixes."""
     from unittest.mock import Mock
 

--- a/azext_edge/tests/utility/test_queryable_unit.py
+++ b/azext_edge/tests/utility/test_queryable_unit.py
@@ -303,3 +303,95 @@ class TestQueryableBackwardCompat:
 
         assert q.subscriptions == ["default-sub-id"]
         assert q.default_subscription_id == "default-sub-id"
+
+
+class TestCloudConfig:
+    """Cloud-aware endpoint/suffix/scope resolution for sovereign-cloud readiness."""
+
+    @pytest.mark.parametrize(
+        "cloud_name, expected",
+        [
+            (
+                "AzureCloud",
+                {
+                    "arm_endpoint": "https://management.azure.com/",
+                    "arm_scope": "https://management.core.windows.net/.default",
+                    "graph_endpoint": "https://graph.microsoft.com/",
+                    "graph_token_resource": "https://graph.microsoft.com",
+                    "storage_suffix": "core.windows.net",
+                    "keyvault_scope": "https://vault.azure.net/.default",
+                    "acr_suffix": ".azurecr.io",
+                    "servicebus_suffix": "servicebus.windows.net",
+                    "eventgrid_audience": "https://eventgrid.azure.net",
+                    "supports_fabric_onelake": True,
+                    "supports_eventgrid_mqtt": True,
+                },
+            ),
+            (
+                "AzureUSGovernment",
+                {
+                    "arm_endpoint": "https://management.usgovcloudapi.net/",
+                    "arm_scope": "https://management.core.usgovcloudapi.net/.default",
+                    "graph_endpoint": "https://graph.microsoft.us/",
+                    "graph_token_resource": "https://graph.microsoft.us",
+                    "storage_suffix": "core.usgovcloudapi.net",
+                    "keyvault_scope": "https://vault.usgovcloudapi.net/.default",
+                    "acr_suffix": ".azurecr.us",
+                    "servicebus_suffix": "servicebus.usgovcloudapi.net",
+                    "eventgrid_audience": "https://eventgrid.azure.us",
+                    "supports_fabric_onelake": False,
+                    "supports_eventgrid_mqtt": True,
+                },
+            ),
+            (
+                "AzureChinaCloud",
+                {
+                    "arm_endpoint": "https://management.chinacloudapi.cn",
+                    "arm_scope": "https://management.core.chinacloudapi.cn/.default",
+                    "graph_endpoint": "https://microsoftgraph.chinacloudapi.cn/",
+                    "graph_token_resource": "https://microsoftgraph.chinacloudapi.cn",
+                    "storage_suffix": "core.chinacloudapi.cn",
+                    "keyvault_scope": "https://vault.azure.cn/.default",
+                    "acr_suffix": ".azurecr.cn",
+                    "servicebus_suffix": "servicebus.chinacloudapi.cn",
+                    "eventgrid_audience": "https://eventgrid.azure.cn",
+                    "supports_fabric_onelake": False,
+                    "supports_eventgrid_mqtt": False,
+                },
+            ),
+        ],
+    )
+    def test_cloud_config_resolution(self, cloud_name, expected):
+        from azext_edge.edge.util.cloud_config import CloudConfig
+        from azext_edge.tests.helpers import build_mock_cmd_for_cloud
+
+        config = CloudConfig(build_mock_cmd_for_cloud(cloud_name))
+
+        assert config.name == cloud_name
+        assert config.arm_endpoint == expected["arm_endpoint"]
+        assert config.arm_scope == expected["arm_scope"]
+        assert config.graph_endpoint == expected["graph_endpoint"]
+        assert config.graph_token_resource == expected["graph_token_resource"]
+        assert config.storage_suffix == expected["storage_suffix"]
+        assert config.keyvault_scope == expected["keyvault_scope"]
+        assert config.acr_suffix == expected["acr_suffix"]
+        assert config.servicebus_suffix == expected["servicebus_suffix"]
+        assert config.eventgrid_audience == expected["eventgrid_audience"]
+        assert config.supports_fabric_onelake == expected["supports_fabric_onelake"]
+        assert config.supports_eventgrid_mqtt == expected["supports_eventgrid_mqtt"]
+
+    def test_cloud_config_unknown_cloud_falls_back_to_public_maps(self):
+        from azext_edge.edge.util.cloud_config import CloudConfig
+        from azext_edge.tests.helpers import build_mock_cmd_for_cloud
+
+        cmd = build_mock_cmd_for_cloud("AzureCloud")
+        cmd.cli_ctx.cloud.name = "SomeCustomCloud"
+
+        config = CloudConfig(cmd)
+
+        # Maps not provided by the framework fall back to public values.
+        assert config.servicebus_suffix == "servicebus.windows.net"
+        assert config.eventgrid_audience == "https://eventgrid.azure.net"
+        # Unknown clouds are treated as not supporting gated features.
+        assert config.supports_fabric_onelake is False
+        assert config.supports_eventgrid_mqtt is False

--- a/azext_edge/tests/utility/test_queryable_unit.py
+++ b/azext_edge/tests/utility/test_queryable_unit.py
@@ -316,6 +316,7 @@ class TestCloudConfig:
                 {
                     "arm_endpoint": "https://management.azure.com/",
                     "arm_scope": "https://management.core.windows.net/.default",
+                    "arm_endpoint_scope": "https://management.azure.com/.default",
                     "graph_endpoint": "https://graph.microsoft.com/",
                     "graph_token_resource": "https://graph.microsoft.com",
                     "storage_suffix": "core.windows.net",
@@ -332,6 +333,7 @@ class TestCloudConfig:
                 {
                     "arm_endpoint": "https://management.usgovcloudapi.net/",
                     "arm_scope": "https://management.core.usgovcloudapi.net/.default",
+                    "arm_endpoint_scope": "https://management.usgovcloudapi.net/.default",
                     "graph_endpoint": "https://graph.microsoft.us/",
                     "graph_token_resource": "https://graph.microsoft.us",
                     "storage_suffix": "core.usgovcloudapi.net",
@@ -348,6 +350,7 @@ class TestCloudConfig:
                 {
                     "arm_endpoint": "https://management.chinacloudapi.cn",
                     "arm_scope": "https://management.core.chinacloudapi.cn/.default",
+                    "arm_endpoint_scope": "https://management.chinacloudapi.cn/.default",
                     "graph_endpoint": "https://microsoftgraph.chinacloudapi.cn/",
                     "graph_token_resource": "https://microsoftgraph.chinacloudapi.cn",
                     "storage_suffix": "core.chinacloudapi.cn",
@@ -370,6 +373,7 @@ class TestCloudConfig:
         assert config.name == cloud_name
         assert config.arm_endpoint == expected["arm_endpoint"]
         assert config.arm_scope == expected["arm_scope"]
+        assert config.arm_endpoint_scope == expected["arm_endpoint_scope"]
         assert config.graph_endpoint == expected["graph_endpoint"]
         assert config.graph_token_resource == expected["graph_token_resource"]
         assert config.storage_suffix == expected["storage_suffix"]

--- a/azext_edge/tests/utility/test_queryable_unit.py
+++ b/azext_edge/tests/utility/test_queryable_unit.py
@@ -315,7 +315,6 @@ class TestCloudConfig:
                 "AzureCloud",
                 {
                     "arm_endpoint": "https://management.azure.com/",
-                    "arm_scope": "https://management.core.windows.net/.default",
                     "arm_endpoint_scope": "https://management.azure.com/.default",
                     "graph_endpoint": "https://graph.microsoft.com/",
                     "graph_token_resource": "https://graph.microsoft.com",
@@ -332,7 +331,6 @@ class TestCloudConfig:
                 "AzureUSGovernment",
                 {
                     "arm_endpoint": "https://management.usgovcloudapi.net/",
-                    "arm_scope": "https://management.core.usgovcloudapi.net/.default",
                     "arm_endpoint_scope": "https://management.usgovcloudapi.net/.default",
                     "graph_endpoint": "https://graph.microsoft.us/",
                     "graph_token_resource": "https://graph.microsoft.us",
@@ -349,7 +347,6 @@ class TestCloudConfig:
                 "AzureChinaCloud",
                 {
                     "arm_endpoint": "https://management.chinacloudapi.cn",
-                    "arm_scope": "https://management.core.chinacloudapi.cn/.default",
                     "arm_endpoint_scope": "https://management.chinacloudapi.cn/.default",
                     "graph_endpoint": "https://microsoftgraph.chinacloudapi.cn/",
                     "graph_token_resource": "https://microsoftgraph.chinacloudapi.cn",
@@ -372,7 +369,6 @@ class TestCloudConfig:
 
         assert config.name == cloud_name
         assert config.arm_endpoint == expected["arm_endpoint"]
-        assert config.arm_scope == expected["arm_scope"]
         assert config.arm_endpoint_scope == expected["arm_endpoint_scope"]
         assert config.graph_endpoint == expected["graph_endpoint"]
         assert config.graph_token_resource == expected["graph_token_resource"]


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
