### PR TITLE
test(registry-endpoint): fix int tests for ACR audience validation

### DIFF
--- a/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
+++ b/azext_edge/tests/edge/orchestration/resources/registry_endpoint/test_registry_endpoints_int.py
@@ -38,6 +38,7 @@ def test_registry_endpoint_lifecycle_anonymous(registry_endpoint_test_setup, tra
     instance_name = registry_endpoint_test_setup["instanceName"]
     registry_endpoint_name = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
     host = "myregistry.azurecr.io"
+    registry_endpoint = {}
 
     try:
         # CREATE - SAMI authentication (default)
@@ -124,6 +125,7 @@ def test_registry_endpoint_artifact_pull_secret(registry_endpoint_test_setup, tr
     registry_endpoint_name = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
     host = "secretregistry.azurecr.io"
     secret_ref = "my-registry-secret"
+    registry_endpoint = {}
 
     try:
         # CREATE - ArtifactPullSecret authentication
@@ -183,7 +185,8 @@ def test_registry_endpoint_system_assigned_auth(registry_endpoint_test_setup, tr
     instance_name = registry_endpoint_test_setup["instanceName"]
     registry_endpoint_name = f"test-registry-{generate_random_string(force_lower=True, size=8)}"
     host = "systemregistry.azurecr.io"
-    audience = "system-audience"
+    audience = "https://containerregistry.azure.net"
+    registry_endpoint = {}
 
     try:
         # CREATE - SystemAssigned authentication with audience
@@ -245,7 +248,8 @@ def test_registry_endpoint_user_assigned_auth(registry_endpoint_test_setup, trac
     host = "userregistry.azurecr.io"
     client_id = "test-client-id"
     tenant_id = "test-tenant-id"
-    scope = "test-scope"
+    scope = "https://containerregistry.azure.net"
+    registry_endpoint = {}
 
     try:
         # CREATE - UserAssigned authentication with full parameters
@@ -428,6 +432,7 @@ def test_registry_endpoint_code_signing_cas(registry_endpoint_test_setup, tracke
     configmap2 = "configmap2"
     secret1 = "secret1"
     secret2 = "secret2"
+    registry_endpoint = {}
 
     try:
         # CREATE - with one configmap


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
