### PR TITLE
feat: generalize ns asset event-group and event commands

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -364,6 +364,30 @@ def load_iotops_commands(self, _):
         cmd_group.command("list", "list_namespace_asset_dataset_points", is_preview=True)
         cmd_group.command("remove", "remove_namespace_asset_dataset_point", is_preview=True)
 
+    # generalized event-group group (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset event-group",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_event_group", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_event_group", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_event_group", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_event_groups", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_event_group", is_preview=True)
+        cmd_group.show_command("show", "show_namespace_asset_event_group", is_preview=True)
+        cmd_group.command("update", "update_namespace_asset_event_group", is_preview=True)
+
+    # generalized event group event (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset event",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_event_group_event", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_event_group_event", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_event_group_event", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_event_group_events", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_event_group_event", is_preview=True)
+
     # dataset
     for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -1923,12 +1923,12 @@ def _make_datapoint_import_func(method_name: str):
 def _make_event_export_func(method_name: str):
     """Factory that generates a typed event export command function."""
     def export_func(
-        cmd, asset_name: str, event_group_name: str, instance_name: str,
+        cmd, asset_name: str, group_name: str, instance_name: str,
         instance_resource_group: str, extension: str = "json",
         output_dir: str = ".", replace: bool = False,
     ) -> dict:
         return getattr(NamespaceAssets(cmd), method_name)(
-            asset_name=asset_name, event_group_name=event_group_name,
+            asset_name=asset_name, event_group_name=group_name,
             instance_name=instance_name, instance_resource_group=instance_resource_group,
             extension=extension, output_dir=output_dir, replace=replace,
         )
@@ -1938,12 +1938,12 @@ def _make_event_export_func(method_name: str):
 def _make_event_import_func(method_name: str):
     """Factory that generates a typed event import command function."""
     def import_func(
-        cmd, asset_name: str, event_group_name: str, instance_name: str,
+        cmd, asset_name: str, group_name: str, instance_name: str,
         instance_resource_group: str, file_path: str,
         replace: bool = False, **kwargs
     ) -> List[dict]:
         return getattr(NamespaceAssets(cmd), method_name)(
-            asset_name=asset_name, event_group_name=event_group_name,
+            asset_name=asset_name, event_group_name=group_name,
             instance_name=instance_name, instance_resource_group=instance_resource_group,
             file_path=file_path, replace=replace, **kwargs
         )

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -3182,3 +3182,98 @@ def add_namespace_asset_dataset_point(
 
 export_namespace_asset_dataset_point = _make_datapoint_export_func("export_dataset_datapoints")
 import_namespace_asset_dataset_point = _make_datapoint_import_func("import_dataset_datapoints")
+
+
+# GENERALIZED EVENT-GROUP COMMANDS
+
+
+def add_namespace_asset_event_group(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    data_source: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    event_group_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).add_event_group_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        replace=replace,
+        event_group_config=event_group_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+def update_namespace_asset_event_group(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    data_source: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    event_group_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update_event_group_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        event_group_config=event_group_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_event_group = _make_export_func("export_event_groups")
+import_namespace_asset_event_group = _make_import_func("import_event_groups")
+
+
+# GENERALIZED EVENT COMMANDS
+
+
+def add_namespace_asset_event_group_event(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    event_name: str,
+    data_source: Optional[str] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    event_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> List[dict]:
+    return NamespaceAssets(cmd).add_event_group_event_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        event_name=event_name,
+        data_source=data_source,
+        type_ref=type_ref,
+        replace=replace,
+        event_config=event_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_event_group_event = _make_event_export_func("export_event_group_events")
+import_namespace_asset_event_group_event = _make_event_import_func("import_event_group_events")

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -2319,6 +2319,182 @@ def load_iotops_arguments(self, _):
             arg_type=get_three_state_flag(),
         )
 
+    with self.argument_context("iot ops ns asset event-group") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--name", "-n"],
+            help="Event-group name.",
+        )
+        context.argument(
+            "data_source",
+            options_list=["--data-source", "--ds"],
+            help="Data source for the event-group.",
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "event_group_config",
+            options_list=["--event-group-config", "--egc"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific event-group configuration and/or default destinations. Accepted keys "
+            "are 'eventGroupConfiguration' (connector-specific config object) and 'destinations' (list "
+            "of destination objects). Use --show-template to discover the supported keys and schema "
+            "for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter event-group configuration template for the asset's connector type and "
+            "exit without modifying the event-group. The connector type is read from the existing asset. "
+            "config: fields shown with their default values (null if no default); output is "
+            "directly usable as --event-group-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset event-group add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the event-group if another event-group with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset event-group export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type([FileType.json.value, FileType.yaml.value], default=FileType.json.value),
+            help="Export file format (JSON or YAML).",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Output directory for export.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the local file if present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset event-group import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON or YAML).",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing event-groups that share a name with an imported event-group.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset event") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--event-group", "--eg"],
+            help="Event-group name.",
+        )
+        context.argument(
+            "event_group_name",
+            options_list=["--event-group", "--eg"],
+            help="Event-group name.",
+        )
+        context.argument(
+            "event_name",
+            options_list=["--name", "-n"],
+            help="Event name.",
+        )
+        context.argument(
+            "data_source",
+            options_list=["--data-source", "--ds"],
+            help="Data source for the event.",
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "event_config",
+            options_list=["--event-config", "--ec"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific event configuration and/or destinations. Accepted keys are "
+            "'eventConfiguration' (connector-specific config object) and 'destinations' (list of "
+            "destination objects). Use --show-template to discover the supported keys and schema "
+            "for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter event configuration template for the asset's connector type "
+            "and exit without modifying the event. The connector type is read from the existing "
+            "asset. config: fields shown with their default values (null if no default); output is "
+            "directly usable as --event-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset event add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the event if another event with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset event export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type(FileType, default=FileType.json.value),
+            help="Export file format.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Output directory for export.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the local file if present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset event import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON, YAML, or CSV).",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing events that share a name with an imported event.",
+            arg_type=get_three_state_flag(),
+        )
+
     with self.argument_context("iot ops clone") as context:
         context.argument(
             "summary_mode",

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -2414,11 +2414,6 @@ def load_iotops_arguments(self, _):
             help="Event-group name.",
         )
         context.argument(
-            "event_group_name",
-            options_list=["--event-group", "--eg"],
-            help="Event-group name.",
-        )
-        context.argument(
             "event_name",
             options_list=["--name", "-n"],
             help="Event name.",

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -2648,6 +2648,273 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset event-group"
+    ] = """
+        type: group
+        short-summary: Manage event-groups for namespaced assets in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --event-group-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset event-group add"
+    ] = """
+        type: command
+        short-summary: Add an event-group to a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration can be supplied via --event-group-config.
+            Use --show-template to discover the supported config schema. For non-OPC UA connectors,
+            a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic event-group to any asset type
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+
+        - name: Show the event-group config template for the asset's connector type
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --show-template config
+
+        - name: Add an event-group with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+            --event-group-config '{"eventGroupConfiguration": {"queueSize": 5}}'
+
+        - name: Add an event-group with configuration from a file
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --event-group-config ./event_group_config.json
+
+        - name: Add an event-group with a default MQTT destination
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+            --event-group-config '{"destinations": [{"target": "Mqtt", "configuration": {"topic": "factory/alarms", "retain": "Keep", "qos": "Qos1", "ttl": 3600}}]}'
+
+        - name: Replace an existing event-group
+          text: >
+            az iot ops ns asset event-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --replace
+    """
+
+    helps[
+        "iot ops ns asset event-group update"
+    ] = """
+        type: command
+        short-summary: Update an event-group for a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Use --event-group-config to supply connector-specific configuration.
+            Use --show-template config to see current event-group values pre-filled in the full schema
+            structure (ready to edit and pass back via --event-group-config).
+            Use --show-template schema to see the full connector schema with types and constraints.
+
+        examples:
+        - name: Show current event-group config pre-filled with existing values (for editing before update)
+          text: >
+            az iot ops ns asset event-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --show-template config
+
+        - name: Show the event-group config schema with types and constraints
+          text: >
+            az iot ops ns asset event-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --show-template schema
+
+        - name: Update event-group configuration from inline JSON
+          text: >
+            az iot ops ns asset event-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+            --event-group-config '{"eventGroupConfiguration": {"queueSize": 10}}'
+
+        - name: Update event-group data source
+          text: >
+            az iot ops ns asset event-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup --data-source "alarm.updated"
+    """
+
+    helps[
+        "iot ops ns asset event-group list"
+    ] = """
+        type: command
+        short-summary: List event-groups for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: List all event-groups for an asset
+          text: >
+            az iot ops ns asset event-group list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset event-group remove"
+    ] = """
+        type: command
+        short-summary: Remove an event-group from a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Remove an event-group from an asset
+          text: >
+            az iot ops ns asset event-group remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+    """
+
+    helps[
+        "iot ops ns asset event-group show"
+    ] = """
+        type: command
+        short-summary: Show details of an event-group for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Show event-group details
+          text: >
+            az iot ops ns asset event-group show --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name alarmGroup
+    """
+
+    helps[
+        "iot ops ns asset event-group export"
+    ] = """
+        type: command
+        short-summary: Export event-groups to file.
+
+        examples:
+        - name: Export event-groups to JSON
+          text: >
+            az iot ops ns asset event-group export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset event-group import"
+    ] = """
+        type: command
+        short-summary: Import event-groups from file.
+
+        examples:
+        - name: Import event-groups from a JSON file
+          text: >
+            az iot ops ns asset event-group import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --input-file ./event_groups.json
+    """
+
+    helps[
+        "iot ops ns asset event"
+    ] = """
+        type: group
+        short-summary: Manage events for asset event-groups in IoT Operations namespaces.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --event-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset event add"
+    ] = """
+        type: command
+        short-summary: Add an event to an asset event-group in an IoT Operations namespace.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration (queue size, sampling interval, etc.) and destinations
+            can be supplied via --event-config. Use --show-template to discover the supported
+            config schema. For non-OPC UA connectors, a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic event to any asset type
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity"
+
+        - name: Show the event config template for the asset's connector type
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity"
+            --show-template config
+
+        - name: Add an event with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity"
+            --event-config '{"eventConfiguration": {"samplingInterval": 1000, "queueSize": 5}}'
+
+        - name: Add an event with configuration from a file
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity"
+            --event-config ./event_config.json
+
+        - name: Add an event with an MQTT destination
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity"
+            --event-config '{"destinations": [{"target": "Mqtt", "configuration": {"topic": "factory/alarms", "retain": "Keep", "qos": "Qos1", "ttl": 3600}}]}'
+
+        - name: Replace an existing event
+          text: >
+            az iot ops ns asset event add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity --data-source "alarm.severity.updated"
+            --replace
+    """
+
+    helps[
+        "iot ops ns asset event list"
+    ] = """
+        type: command
+        short-summary: List events for an asset event-group in an IoT Operations namespace.
+
+        examples:
+        - name: List all events for an event-group
+          text: >
+            az iot ops ns asset event list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup
+    """
+
+    helps[
+        "iot ops ns asset event remove"
+    ] = """
+        type: command
+        short-summary: Remove an event from an asset event-group in an IoT Operations namespace.
+
+        examples:
+        - name: Remove an event from an event-group
+          text: >
+            az iot ops ns asset event remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --name severity
+    """
+
+    helps[
+        "iot ops ns asset event export"
+    ] = """
+        type: command
+        short-summary: Export events to file.
+
+        examples:
+        - name: Export events to JSON
+          text: >
+            az iot ops ns asset event export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup
+    """
+
+    helps[
+        "iot ops ns asset event import"
+    ] = """
+        type: command
+        short-summary: Import events from file.
+
+        examples:
+        - name: Import events from a JSON file
+          text: >
+            az iot ops ns asset event import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --event-group alarmGroup --input-file ./events.json
+    """
+
+    helps[
         "iot ops ns asset opcua dataset"
     ] = """
         type: group

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -2479,6 +2479,606 @@ class NamespaceAssets(Queryable):
             )
             return _get_sub_property(asset, event_group_name, property_key="eventGroups")["events"]
 
+    def _handle_event_group_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        event_group_config: Optional[str],
+    ) -> dict:
+        """Return an event-group config/schema template for --show-template and exit early.
+
+        Discovers the eventGroupConfigurationSchema and supported destinations from connector
+        metadata and returns a slimmed template. OPC UA uses bundled metadata; all other types
+        require a connector template in the instance.
+        """
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        if event_group_config:
+            raise InvalidArgumentValueError(
+                "--show-template and --event-group-config cannot be used together. "
+                "--show-template displays the template and exits without modifying the event-group."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        eg_section = endpoint.get("eventGroups", {})
+        schema = eg_section.get("eventGroupConfigurationSchema")
+
+        event_group_config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            event_group_config_template["eventGroupConfiguration"] = slimmed
+
+        # Destinations metadata lives at the event level; the event-group's defaultDestinations
+        # share the same supported destination set.
+        destinations = self._build_event_destinations_template(eg_section, template_mode)
+        if destinations is not None:
+            event_group_config_template["destinations"] = destinations
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, "eventGroupConfig": event_group_config_template}
+
+    def _build_event_destinations_template(self, eg_section: dict, template_mode: str) -> Optional[list]:
+        """Build a destinations template from the connector's supported event destinations.
+
+        Event-group defaultDestinations and event destinations share the same supported set, which
+        lives at ``eventGroups.events.destinations``. Returns None when no destinations are supported.
+        """
+        events_section = eg_section.get("events", {}) if isinstance(eg_section, dict) else {}
+        dest_section = events_section.get("destinations", {}) if isinstance(events_section, dict) else {}
+        supported = dest_section.get("supportedDestinations", []) if isinstance(dest_section, dict) else []
+        if not supported:
+            return None
+        return _build_destination_template(
+            supported_destinations=supported,
+            default_destination=dest_section.get("defaultDestination"),
+            mode=template_mode,
+        )
+
+    def _load_and_validate_event_group_config(
+        self,
+        event_group_config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load event-group config from file/inline JSON, validate against connector schema, and
+        return ARM-ready values.
+
+        Input JSON is expected to be the 'eventGroupConfig' dict (output of --show-template), e.g.:
+          {
+            "eventGroupConfiguration": {...},
+            "destinations": [...]
+          }
+        Or the full --show-template output with 'connectorType' and 'eventGroupConfig' keys,
+        which is auto-unwrapped.
+
+        Returns a dict with:
+          - "eventGroupConfiguration": serialized JSON string (if present)
+          - "destinations": list of destination dicts (if present)
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        raw = process_additional_configuration(
+            additional_configuration=event_group_config,
+            config_type="event-group",
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and "eventGroupConfig" in parsed and "connectorType" in parsed:
+            parsed = parsed["eventGroupConfig"]
+
+        if not isinstance(parsed, dict):
+            raise InvalidArgumentValueError(
+                "--event-group-config must be a JSON object with 'eventGroupConfiguration' "
+                "and/or 'destinations' keys."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
+
+        result = {}
+
+        config_data_raw = parsed.get("eventGroupConfiguration")
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = eg_section.get("eventGroupConfigurationSchema") if eg_section else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping eventGroupConfiguration validation: %s", skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name="eventGroupConfiguration")
+            result["eventGroupConfiguration"] = json.dumps(config_data)
+
+        dest_raw = parsed.get("destinations")
+        if dest_raw is not None:
+            dest_data = self._validate_event_destinations(dest_raw, eg_section)
+            if dest_data:
+                result["destinations"] = dest_data
+
+        return result
+
+    def _validate_event_destinations(self, dest_raw, eg_section: dict) -> List[dict]:
+        """Validate and filter a destinations list against the connector's supported event
+        destinations. Shared by event-group and event config loaders."""
+        from .helpers import strip_nulls as _strip_nulls
+
+        dest_data = _strip_nulls(dest_raw)
+        if not isinstance(dest_data, list):
+            raise InvalidArgumentValueError(
+                "'destinations' must be a JSON array of destination objects."
+            )
+        filtered: List[dict] = []
+        for item in dest_data:
+            if not isinstance(item, dict):
+                raise InvalidArgumentValueError(
+                    "'destinations' entries must be JSON objects."
+                )
+            if not item.get("configuration"):
+                logger.warning(
+                    "Ignoring destination '%s' because its configuration is empty.",
+                    item.get("target"),
+                )
+                continue
+            filtered.append(item)
+        dest_data = filtered
+        if dest_data:
+            events_section = eg_section.get("events", {}) if eg_section else {}
+            dest_section = events_section.get("destinations", {}) if isinstance(events_section, dict) else {}
+            supported = (
+                dest_section.get("supportedDestinations", [])
+                if isinstance(dest_section, dict) else []
+            )
+            if supported:
+                for dest_item in dest_data:
+                    target = dest_item.get("target")
+                    if target and target not in supported:
+                        raise InvalidArgumentValueError(
+                            f"Destination target '{target}' is not supported for events. "
+                            f"Supported: {supported}."
+                        )
+        return dest_data
+
+    def _handle_event_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        event_config: Optional[str],
+    ) -> dict:
+        """Return an event config/schema template for --show-template and exit early."""
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        if event_config:
+            raise InvalidArgumentValueError(
+                "--show-template and --event-config cannot be used together. "
+                "--show-template displays the template and exits without modifying the event."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        eg_section = endpoint.get("eventGroups", {})
+        events_section = eg_section.get("events", {})
+        schema = events_section.get("eventConfigurationSchema")
+
+        event_config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            event_config_template["eventConfiguration"] = slimmed
+
+        destinations = self._build_event_destinations_template(eg_section, template_mode)
+        if destinations is not None:
+            event_config_template["destinations"] = destinations
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, "eventConfig": event_config_template}
+
+    def _load_and_validate_event_config(
+        self,
+        event_config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load event config from file/inline JSON, validate against connector schema.
+
+        Input JSON is expected to be the 'eventConfig' dict (output of --show-template), e.g.:
+          {
+            "eventConfiguration": {...},
+            "destinations": [...]
+          }
+        Or the full --show-template output with 'connectorType' and 'eventConfig' keys,
+        which is auto-unwrapped.
+
+        Returns a dict with:
+          - "eventConfiguration": serialized JSON string (if present)
+          - "destinations": list of destination dicts (if present)
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        raw = process_additional_configuration(
+            additional_configuration=event_config,
+            config_type="event",
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and "eventConfig" in parsed and "connectorType" in parsed:
+            parsed = parsed["eventConfig"]
+
+        if not isinstance(parsed, dict):
+            raise InvalidArgumentValueError(
+                "--event-config must be a JSON object with 'eventConfiguration' "
+                "and/or 'destinations' keys."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
+        events_section = eg_section.get("events", {}) if eg_section else {}
+
+        result = {}
+
+        config_data_raw = parsed.get("eventConfiguration")
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = events_section.get("eventConfigurationSchema") if events_section else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping eventConfiguration validation: %s", skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name="eventConfiguration")
+            result["eventConfiguration"] = json.dumps(config_data)
+
+        dest_raw = parsed.get("destinations")
+        if dest_raw is not None:
+            dest_data = self._validate_event_destinations(dest_raw, eg_section)
+            if dest_data:
+                result["destinations"] = dest_data
+
+        return result
+
+    def add_event_group_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        data_source: Optional[str] = None,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        event_group_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized add-event-group that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --event-group-config for
+        JSON or file-based connector-specific event-group configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            return self._handle_event_group_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                event_group_config=event_group_config,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        original_egs = asset["properties"].get("eventGroups", [])
+        new_egs = [event for event in original_egs if event["name"] != group_name]
+        if len(new_egs) < len(original_egs) and not replace:
+            raise InvalidArgumentValueError(
+                f"Event group '{group_name}' already exists in asset '{asset_name}'. "
+                "Use --replace to overwrite the existing event group."
+            )
+
+        new_eg: dict = {
+            "name": group_name,
+            "eventGroupConfiguration": None,
+            "defaultDestinations": [],
+            "events": [],
+            "typeRef": type_ref,
+        }
+        if data_source:
+            new_eg["dataSource"] = data_source
+
+        if event_group_config:
+            config_result = self._load_and_validate_event_group_config(
+                event_group_config=event_group_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "eventGroupConfiguration" in config_result:
+                new_eg["eventGroupConfiguration"] = config_result["eventGroupConfiguration"]
+            if "destinations" in config_result:
+                new_eg["defaultDestinations"] = config_result["destinations"]
+
+        new_egs.append(new_eg)
+        update_payload = {"properties": {"eventGroups": new_egs}}
+
+        with console.status(f"Adding event group {group_name} to asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="eventGroups")
+
+    def update_event_group_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        data_source: Optional[str] = None,
+        type_ref: Optional[str] = None,
+        event_group_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized update-event-group that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --event-group-config for
+        JSON or file-based connector-specific event-group configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            from .common import EndpointTemplateMode
+            template_mode = show_template.lower()
+            if template_mode == EndpointTemplateMode.CONFIG.value:
+                if event_group_config:
+                    raise InvalidArgumentValueError(
+                        "--show-template and --event-group-config cannot be used together. "
+                        "--show-template displays the template and exits without modifying the event-group."
+                    )
+                egs_existing = asset["properties"].get("eventGroups", [])
+                existing = next((d for d in egs_existing if d["name"] == group_name), None)
+                if existing is None:
+                    raise InvalidArgumentValueError(
+                        f"Event group '{group_name}' not found in asset '{asset_name}'."
+                    )
+                template_result = self._handle_event_group_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    event_group_config=None,
+                )
+                eg_config_tmpl = template_result.get("eventGroupConfig", {})
+                raw_config = existing.get("eventGroupConfiguration")
+                if raw_config:
+                    existing_config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+                    tmpl_ec = eg_config_tmpl.get("eventGroupConfiguration")
+                    eg_config_tmpl["eventGroupConfiguration"] = (
+                        _deep_merge_template(tmpl_ec, existing_config)
+                        if isinstance(tmpl_ec, dict)
+                        else existing_config
+                    )
+                existing_dests = existing.get("defaultDestinations", [])
+                if existing_dests:
+                    tmpl_dests = eg_config_tmpl.get("destinations", [])
+                    eg_config_tmpl["destinations"] = _merge_destinations_template(
+                        tmpl_dests, existing_dests
+                    )
+                return {"connectorType": connector_type, "eventGroupConfig": eg_config_tmpl}
+            else:
+                return self._handle_event_group_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    event_group_config=event_group_config,
+                )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        event_groups = asset["properties"].get("eventGroups", [])
+        group_list = [eg for eg in event_groups if eg["name"] == group_name]
+        if not group_list:
+            raise InvalidArgumentValueError(
+                f"Event group '{group_name}' not found in asset '{asset_name}'."
+            )
+        group = group_list[0]
+
+        if event_group_config is not None:
+            config_result = self._load_and_validate_event_group_config(
+                event_group_config=event_group_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "eventGroupConfiguration" in config_result:
+                group["eventGroupConfiguration"] = config_result["eventGroupConfiguration"]
+            if "destinations" in config_result:
+                group["defaultDestinations"] = config_result["destinations"]
+
+        if data_source is not None:
+            group["dataSource"] = data_source
+        if type_ref is not None:
+            group["typeRef"] = type_ref
+
+        update_payload = {"properties": {"eventGroups": event_groups}}
+        with console.status(f"Updating event group {group_name} in asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="eventGroups")
+
+    def add_event_group_event_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        event_name: str,
+        data_source: Optional[str] = None,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        event_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> List[dict]:
+        """Generalized add-event that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --event-config for
+        JSON or file-based connector-specific event configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type = self._get_connector_type_from_asset(asset)
+
+        if show_template:
+            return self._handle_event_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                event_config=event_config,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+        )
+
+        event_group = _get_sub_property(asset, group_name, property_key="eventGroups")
+        og_events = event_group.get("events", [])
+        remaining_events = [ev for ev in og_events if ev["name"] != event_name]
+        if len(remaining_events) < len(og_events) and not replace:
+            raise InvalidArgumentValueError(
+                f"event '{event_name}' already exists in event group '{group_name}' of asset '{asset_name}'. "
+                "Use --replace to overwrite the existing event."
+            )
+
+        event: dict = {"name": event_name}
+        if data_source:
+            event["dataSource"] = data_source
+        if type_ref:
+            event["typeRef"] = type_ref
+
+        if event_config:
+            config_result = self._load_and_validate_event_config(
+                event_config=event_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "eventConfiguration" in config_result:
+                event["eventConfiguration"] = config_result["eventConfiguration"]
+            if "destinations" in config_result:
+                event["destinations"] = config_result["destinations"]
+
+        remaining_events.append(event)
+        event_group["events"] = remaining_events
+
+        update_payload = {"properties": {"eventGroups": asset["properties"]["eventGroups"]}}
+        with console.status(f"Adding event {event_name} to event group {group_name} in asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="eventGroups")["events"]
+
     # EVENT GROUPS - allowed for opcua, onvif, and custom assets
     def add_event_group(
         self,

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -902,10 +902,15 @@ class NamespaceAssets(Queryable):
         )
         parsed = json.loads(raw)
 
-        if isinstance(parsed, dict) and "datasetConfig" in parsed and "connectorType" in parsed:
+        if isinstance(parsed, dict) and "datasetConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
             parsed = parsed["datasetConfig"]
 
-        if not isinstance(parsed, dict):
+        if not isinstance(parsed, dict) or not {"datasetConfiguration", "destinations"}.intersection(parsed):
             raise InvalidArgumentValueError(
                 "--dataset-config must be a JSON object with 'datasetConfiguration' "
                 "and/or 'destinations' keys."
@@ -1044,10 +1049,15 @@ class NamespaceAssets(Queryable):
         )
         parsed = json.loads(raw)
 
-        if isinstance(parsed, dict) and "datapointConfig" in parsed and "connectorType" in parsed:
+        if isinstance(parsed, dict) and "datapointConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
             parsed = parsed["datapointConfig"]
 
-        if not isinstance(parsed, dict):
+        if not isinstance(parsed, dict) or "datapointConfiguration" not in parsed:
             raise InvalidArgumentValueError(
                 "--datapoint-config must be a JSON object with a 'datapointConfiguration' key."
             )
@@ -1428,10 +1438,16 @@ class NamespaceAssets(Queryable):
         parsed = json.loads(raw)
 
         # Auto-unwrap --show-template output
-        if isinstance(parsed, dict) and "assetConfig" in parsed and "connectorType" in parsed:
+        if isinstance(parsed, dict) and "assetConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
             parsed = parsed["assetConfig"]
 
-        if not isinstance(parsed, dict):
+        _asset_config_keys = {s[2] for s in _ASSET_SCHEMA_SECTIONS} | {s[4] for s in _ASSET_SCHEMA_SECTIONS if s[4]}
+        if not isinstance(parsed, dict) or not _asset_config_keys.intersection(parsed):
             raise InvalidArgumentValueError(
                 "--asset-config must be a JSON object with defaultDatasetsConfiguration, "
                 "defaultEventsConfiguration, and/or defaultStreamsConfiguration keys."
@@ -2590,10 +2606,15 @@ class NamespaceAssets(Queryable):
         )
         parsed = json.loads(raw)
 
-        if isinstance(parsed, dict) and "eventGroupConfig" in parsed and "connectorType" in parsed:
+        if isinstance(parsed, dict) and "eventGroupConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
             parsed = parsed["eventGroupConfig"]
 
-        if not isinstance(parsed, dict):
+        if not isinstance(parsed, dict) or not {"eventGroupConfiguration", "destinations"}.intersection(parsed):
             raise InvalidArgumentValueError(
                 "--event-group-config must be a JSON object with 'eventGroupConfiguration' "
                 "and/or 'destinations' keys."
@@ -2748,10 +2769,15 @@ class NamespaceAssets(Queryable):
         )
         parsed = json.loads(raw)
 
-        if isinstance(parsed, dict) and "eventConfig" in parsed and "connectorType" in parsed:
+        if isinstance(parsed, dict) and "eventConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
             parsed = parsed["eventConfig"]
 
-        if not isinstance(parsed, dict):
+        if not isinstance(parsed, dict) or not {"eventConfiguration", "destinations"}.intersection(parsed):
             raise InvalidArgumentValueError(
                 "--event-config must be a JSON object with 'eventConfiguration' "
                 "and/or 'destinations' keys."

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -725,8 +725,12 @@ class NamespaceAssets(Queryable):
                 resource_group=namespace["resource_group"],
             )
 
-    def _get_connector_type_from_asset(self, asset: dict) -> str:
-        """Extract the connector type from an existing asset via its device endpoint type."""
+    def _get_connector_type_and_device(self, asset: dict) -> Tuple[str, dict]:
+        """Extract the connector type from an asset and return the fetched device.
+
+        Returns the device alongside the connector type so callers can reuse the device
+        (e.g. pass it into ``_check_device_props``) instead of re-fetching it.
+        """
         device_ref = asset.get("properties", {}).get("deviceRef", {})
         device_name = device_ref.get("deviceName", "")
         endpoint_name = device_ref.get("endpointName", "")
@@ -750,7 +754,7 @@ class NamespaceAssets(Queryable):
                 f"Device '{device_name}' endpoint '{endpoint_name}' is missing 'endpointType'. "
                 "Verify the device endpoint was created correctly."
             )
-        return connector_type
+        return connector_type, device
 
     def _get_connector_metadata(
         self,
@@ -1098,7 +1102,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             return self._handle_dataset_show_template(
@@ -1115,6 +1119,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         datasets = asset["properties"].get("datasets", [])
@@ -1193,7 +1199,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             from .common import EndpointTemplateMode
@@ -1255,6 +1261,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         datasets = asset["properties"].get("datasets", [])
@@ -1328,7 +1336,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             return self._handle_datapoint_show_template(
@@ -1344,6 +1352,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         dataset = _get_sub_property(asset, dataset_name, property_key="datasets")
@@ -2803,7 +2813,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             return self._handle_event_group_show_template(
@@ -2819,6 +2829,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         original_egs = asset["properties"].get("eventGroups", [])
@@ -2892,7 +2904,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             from .common import EndpointTemplateMode
@@ -2947,6 +2959,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         event_groups = asset["properties"].get("eventGroups", [])
@@ -3015,7 +3029,7 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             resource_group=instance_resource_group,
         )
-        connector_type = self._get_connector_type_from_asset(asset)
+        connector_type, device = self._get_connector_type_and_device(asset)
 
         if show_template:
             return self._handle_event_show_template(
@@ -3031,6 +3045,8 @@ class NamespaceAssets(Queryable):
             instance_name=instance_name,
             asset_type=connector_type,
             asset_name=asset_name,
+            asset=asset,
+            device=device,
         )
 
         event_group = _get_sub_property(asset, group_name, property_key="eventGroups")
@@ -4309,7 +4325,9 @@ class NamespaceAssets(Queryable):
         asset_type: Union[List[str], str],  # change to list
         asset_name: Optional[str] = None,
         device_name: Optional[str] = None,
-        device_endpoint_name: Optional[str] = None
+        device_endpoint_name: Optional[str] = None,
+        asset: Optional[dict] = None,
+        device: Optional[dict] = None,
     ) -> Tuple[dict, Dict[str, str]]:
         """
         Checks the device properties to ensure the endpoint type matches the asset operation's type.
@@ -4319,17 +4337,18 @@ class NamespaceAssets(Queryable):
         This also includes the cluster connectivity check.
 
         If asset_name is provided (in the case of the asset is already created), it will retrieve the
-        asset to populate the device_name and device_endpoint_name.
+        asset to populate the device_name and device_endpoint_name. A previously fetched ``asset``
+        and/or ``device`` may be passed in to avoid redundant round trips.
         """
-        asset = None
         namespace = None
         if asset_name:
             # get the asset to populate the device name and endpoint name
-            asset = self.show(
-                resource_group=instance_resource_group,
-                instance_name=instance_name,
-                asset_name=asset_name
-            )
+            if asset is None:
+                asset = self.show(
+                    resource_group=instance_resource_group,
+                    instance_name=instance_name,
+                    asset_name=asset_name
+                )
             device_name = asset["properties"]["deviceRef"]["deviceName"]
             device_endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
             namespace = parse_resource_id(asset["id"])
@@ -4340,11 +4359,12 @@ class NamespaceAssets(Queryable):
                 instance_resource_group=instance_resource_group
             )
 
-        device = self.device_ops.get(
-            resource_group_name=namespace["resource_group"],
-            namespace_name=namespace["name"],
-            device_name=device_name
-        )
+        if device is None:
+            device = self.device_ops.get(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                device_name=device_name
+            )
 
         # use the device to check cluster connectivity
         check_cluster_connectivity(self.cmd, device)

--- a/azext_edge/edge/providers/adr/namespace_devices.py
+++ b/azext_edge/edge/providers/adr/namespace_devices.py
@@ -531,7 +531,12 @@ class NamespaceDevices(Queryable):
         # That output is a dict with 'connectorType' and 'endpointConfig' keys;
         # --endpoint-config expects only the inner endpointConfig value.
         _parsed = json.loads(additional_configuration)
-        if isinstance(_parsed, dict) and "endpointConfig" in _parsed and "connectorType" in _parsed:
+        if isinstance(_parsed, dict) and "endpointConfig" in _parsed:
+            provided = _parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match endpoint connectorType '{connector_type}'."
+                )
             additional_configuration = json.dumps(_parsed["endpointConfig"])
 
         if skip_connector_check:

--- a/azext_edge/edge/providers/adr/params.py
+++ b/azext_edge/edge/providers/adr/params.py
@@ -1596,7 +1596,7 @@ def load_adr_arguments(self, _):
             context.argument(
                 "group_name",
                 options_list=["--event-group", "--eg"],
-                help="Event name.",
+                help="Event-group name.",
             )
             context.argument(
                 "event_name",
@@ -2094,7 +2094,6 @@ def load_adr_arguments(self, _):
     _register_export_import_args(["custom", "opcua", "onvif", "sse"], "event-group")
     _register_export_import_args(
         ["custom", "opcua", "onvif", "sse"], "event", supports_csv=True,
-        extra_args={"event_group_name": {"options_list": ["--event-group", "--eg"], "help": "Event-group name."}},
     )
 
     with self.argument_context("iot ops ns asset opcua event add") as context:

--- a/azext_edge/tests/edge/adr/namespace_helpers.py
+++ b/azext_edge/tests/edge/adr/namespace_helpers.py
@@ -6,11 +6,35 @@
 
 from functools import partial
 import json
-from typing import Optional, Callable, Tuple
+from typing import List, Optional, Callable, Tuple
+
+from azure.cli.core.azclierror import CLIInternalError
+
 from ...generators import generate_random_string
-from ...helpers import create_file
+from ...helpers import create_file, run
 
 """Helpers for ADR v2 tests."""
+
+
+def _save_json_to_file(content: dict, tracked_files: List[str]) -> str:
+    """Serialize content to a temp JSON file and return its path."""
+    return create_file(
+        file_name=f"template_{generate_random_string(6)}.json",
+        module_file=__file__,
+        tracked_files=tracked_files,
+        content=json.dumps(content),
+    )
+
+
+def _try_show_template(cmd: str) -> dict:
+    """Run a --show-template command and return the parsed result.
+
+    Returns an empty dict if the command fails (e.g. no connector template installed).
+    """
+    try:
+        return run(cmd) or {}
+    except CLIInternalError:
+        return {}
 
 
 def assert_dataset_properties(result, **expected):

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -4,15 +4,18 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-import json
 import pytest
 from typing import List
 
-from azure.cli.core.azclierror import CLIInternalError
-
 from ...generators import generate_random_string
-from ...helpers import create_file, run, wait_for_expected_count
-from .namespace_helpers import create_config_file, assert_point_properties, assert_dataset_properties
+from ...helpers import run, wait_for_expected_count
+from .namespace_helpers import (
+    create_config_file,
+    assert_point_properties,
+    assert_dataset_properties,
+    _save_json_to_file,
+    _try_show_template,
+)
 
 
 pytestmark = [pytest.mark.rpsaas, pytest.mark.long_running]
@@ -846,31 +849,6 @@ def test_namespace_mqtt_asset_dataset_lifecycle_operations(asset_factory):
 
     remaining_dataset_names = [dataset["name"] for dataset in datasets_list_after_remove]
     assert dataset_name_1 not in remaining_dataset_names
-
-
-# ---------------------------------------------------------------------------
-# Helpers for generalized (connector-agnostic) tests
-# ---------------------------------------------------------------------------
-
-def _save_json_to_file(content: dict, tracked_files: List[str]) -> str:
-    """Serialize content to a temp JSON file and return its path."""
-    return create_file(
-        file_name=f"template_{generate_random_string(6)}.json",
-        module_file=__file__,
-        tracked_files=tracked_files,
-        content=json.dumps(content),
-    )
-
-
-def _try_show_template(cmd: str) -> dict:
-    """Run a --show-template command and return the parsed result.
-
-    Returns an empty dict if the command fails (e.g. no connector template installed).
-    """
-    try:
-        return run(cmd) or {}
-    except CLIInternalError:
-        return {}
 
 
 # ---------------------------------------------------------------------------

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -2093,7 +2093,7 @@ def test_export_namespace_asset_event_group_events(
     result = func(
         cmd=mocked_cmd,
         asset_name=asset_name,
-        event_group_name=event_group_name,
+        group_name=event_group_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
         extension=extension,
@@ -2240,7 +2240,7 @@ def test_import_namespace_asset_event_group_events(
     result = func(
         cmd=mocked_cmd,
         asset_name=asset_name,
-        event_group_name=event_group_name,
+        group_name=event_group_name,
         instance_name=instance_name,
         instance_resource_group=instance_resource_group,
         file_path=str(import_file),
@@ -2348,7 +2348,7 @@ def _add_device_get_for_generalized(
     resource_group_name: str,
     connector_type: str,
 ) -> None:
-    """Register GET device mock needed by _get_connector_type_from_asset and _check_device_props."""
+    """Register GET device mock needed by _get_connector_type_and_device and _check_device_props."""
     device_name = asset["properties"]["deviceRef"]["deviceName"]
     endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
     add_device_get_call(
@@ -2402,15 +2402,7 @@ def test_add_namespace_asset_dataset_generalized(
         datasets=existing_datasets,
     )
 
-    # _get_connector_type_from_asset: GET asset + GET device
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-
-    # _check_device_props(asset_name=...): GET asset + GET device
+    # self.show + _get_connector_type_and_device: GET asset + GET device
     mocked_responses.add(
         responses.GET,
         get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
@@ -2543,14 +2535,7 @@ def test_update_namespace_asset_dataset_generalized(
         "destinations": [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}],
     })
 
-    # _get_connector_type_from_asset
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
+    # self.show + _get_connector_type_and_device
     mocked_responses.add(
         responses.GET,
         get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
@@ -2760,14 +2745,7 @@ def test_add_namespace_asset_dataset_point_generalized(
         "datapointConfiguration": {"samplingInterval": 250, "deadBand": 0.5, "enabled": True}
     })
 
-    # _get_connector_type_from_asset
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
+    # self.show + _get_connector_type_and_device
     mocked_responses.add(
         responses.GET,
         get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_int.py
@@ -10,7 +10,13 @@ import pytest
 
 from ...generators import generate_random_string
 from ...helpers import run, wait_for_expected_count
-from .namespace_helpers import create_config_file, assert_point_properties, assert_event_properties
+from .namespace_helpers import (
+    create_config_file,
+    assert_point_properties,
+    assert_event_properties,
+    _save_json_to_file,
+    _try_show_template,
+)
 
 
 pytestmark = [pytest.mark.rpsaas, pytest.mark.long_running]
@@ -593,3 +599,295 @@ def test_namespace_sse_asset_event_lifecycle_operations(asset_factory):
 
     remaining_event_group_names = [ev["name"] for ev in remaining_event_groups]
     assert event_group_name not in remaining_event_group_names
+
+
+# ---------------------------------------------------------------------------
+# Generalized event-group / event commands — OPC UA (bundled metadata)
+# ---------------------------------------------------------------------------
+
+
+def test_generalized_event_lifecycle_opcua(asset_factory, tracked_files: List[str]):
+    """Full lifecycle of generalized event-group + event commands on an OPC UA asset.
+
+    Flow:
+      1. --show-template config  ->  discover schema
+      2. Fill connector-specific values in the returned template
+      3. Use filled template as --event-group-config / --event-config
+      4. CRUD: add / show / list / update / remove
+      5. Export round-trip
+    """
+    info = asset_factory("opcua")
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    eg_name = f"gen-eg-{generate_random_string(6, force_lower=True)}"
+    eg_name_2 = f"gen-eg2-{generate_random_string(6, force_lower=True)}"
+    event_name = f"gen-ev-{generate_random_string(6, force_lower=True)}"
+    data_source = "ns=2;s=Boiler"
+    ev_data_source = "ns=2;s=Boiler.Event"
+
+    # 1. SHOW-TEMPLATE - event-group
+    eg_template = run(
+        f"az iot ops ns asset event-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name} --show-template config"
+    )
+    assert isinstance(eg_template, dict)
+    assert "connectorType" in eg_template
+    assert "eventGroupConfig" in eg_template
+
+    eg_config = eg_template.copy()
+    eg_config["eventGroupConfig"]["eventGroupConfiguration"] = {
+        "publishingInterval": 1000,
+        "queueSize": 5,
+    }
+    eg_config["eventGroupConfig"].pop("destinations", None)
+    eg_config_file = _save_json_to_file(eg_config, tracked_files)
+
+    # 2. ADD event-group with config
+    added_eg = run(
+        f"az iot ops ns asset event-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name} --data-source '{data_source}' "
+        f"--event-group-config {eg_config_file}"
+    )
+    assert_event_properties(
+        added_eg, name=eg_name, data_source=data_source,
+        opcua_configuration={"publishingInterval": 1000},
+    )
+
+    # 3. SHOW event-group
+    shown_eg = run(
+        f"az iot ops ns asset event-group show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {eg_name}"
+    )
+    assert_event_properties(shown_eg, name=eg_name, data_source=data_source)
+
+    # 4. LIST event-groups
+    eg_list = run(
+        f"az iot ops ns asset event-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert any(g["name"] == eg_name for g in eg_list)
+
+    # 5. ADD a second event-group (minimal)
+    added_eg_2 = run(
+        f"az iot ops ns asset event-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name_2} --data-source '{data_source}'"
+    )
+    assert_event_properties(added_eg_2, name=eg_name_2)
+    eg_names = [g["name"] for g in run(
+        f"az iot ops ns asset event-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )]
+    assert eg_name in eg_names and eg_name_2 in eg_names
+
+    # 6. UPDATE event-group
+    updated_source = "ns=2;s=Boiler.Updated"
+    eg_config["eventGroupConfig"]["eventGroupConfiguration"]["publishingInterval"] = 2000
+    updated_eg_file = _save_json_to_file(eg_config, tracked_files)
+    updated_eg = run(
+        f"az iot ops ns asset event-group update --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name} --data-source '{updated_source}' "
+        f"--event-group-config {updated_eg_file}"
+    )
+    assert_event_properties(
+        updated_eg, name=eg_name, data_source=updated_source,
+        opcua_configuration={"publishingInterval": 2000},
+    )
+
+    # 7. SHOW-TEMPLATE - event
+    event_template = run(
+        f"az iot ops ns asset event add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name} "
+        f"--data-source '{ev_data_source}' --show-template config"
+    )
+    assert isinstance(event_template, dict)
+    assert "connectorType" in event_template
+    assert "eventConfig" in event_template
+
+    event_config = event_template.copy()
+    event_config["eventConfig"]["eventConfiguration"] = {
+        "queueSize": 3,
+    }
+    event_config["eventConfig"].pop("destinations", None)
+    event_config_file = _save_json_to_file(event_config, tracked_files)
+
+    # 8. ADD event with config
+    added_events = run(
+        f"az iot ops ns asset event add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name} "
+        f"--data-source '{ev_data_source}' --event-config {event_config_file}"
+    )
+    assert_point_properties(added_events, name=event_name, data_source=ev_data_source)
+
+    # 9. LIST events
+    ev_list = run(
+        f"az iot ops ns asset event list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --event-group {eg_name}"
+    )
+    assert any(ev["name"] == event_name for ev in ev_list)
+
+    # 10. REPLACE event
+    replaced_ev_source = "ns=2;s=Boiler.Replaced"
+    replaced_events = run(
+        f"az iot ops ns asset event add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name} "
+        f"--data-source '{replaced_ev_source}' --replace"
+    )
+    assert_point_properties(replaced_events, name=event_name, data_source=replaced_ev_source)
+
+    # 11. EXPORT event-groups
+    export_result = run(
+        f"az iot ops ns asset event-group export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --output-dir /tmp --replace"
+    )
+    assert export_result["event_group_count"] >= 1
+    tracked_files.append(export_result["file_path"])
+
+    # 12. EXPORT events
+    ev_export_result = run(
+        f"az iot ops ns asset event export --asset {asset_name} "
+        f"--event-group {eg_name} --instance {instance_name} -g {resource_group} "
+        f"--output-dir /tmp --replace"
+    )
+    assert ev_export_result["event_count"] >= 1
+    tracked_files.append(ev_export_result["file_path"])
+
+    # 13. REMOVE event
+    run(
+        f"az iot ops ns asset event remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name}"
+    )
+    ev_list_after = run(
+        f"az iot ops ns asset event list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --event-group {eg_name}"
+    )
+    assert not any(ev["name"] == event_name for ev in (ev_list_after or []))
+
+    # 14. REMOVE event-groups
+    for eg in [eg_name, eg_name_2]:
+        run(
+            f"az iot ops ns asset event-group remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {eg}"
+        )
+    remaining = [g["name"] for g in (run(
+        f"az iot ops ns asset event-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    ) or [])]
+    assert eg_name not in remaining and eg_name_2 not in remaining
+
+
+# ---------------------------------------------------------------------------
+# Generalized event-group / event commands — custom (connector template required)
+# ---------------------------------------------------------------------------
+
+
+def test_generalized_event_lifecycle_custom(asset_factory, tracked_files: List[str]):
+    """Generalized event-group + event lifecycle on a custom asset.
+
+    A connector template must exist in the instance for --show-template / --event-group-config
+    to resolve connector metadata. When no template is installed, --show-template returns an
+    empty dict and the test exercises the metadata-free path (no config payload).
+    """
+    info = asset_factory("custom")
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    eg_name = f"gen-eg-{generate_random_string(6, force_lower=True)}"
+    event_name = f"gen-ev-{generate_random_string(6, force_lower=True)}"
+    data_source = "custom/boiler"
+    ev_data_source = "custom/boiler/event"
+
+    # 1. SHOW-TEMPLATE - event-group (may be empty when no connector template installed)
+    eg_template = _try_show_template(
+        f"az iot ops ns asset event-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name} --show-template config"
+    )
+
+    eg_config_arg = ""
+    if eg_template:
+        assert "connectorType" in eg_template
+        assert "eventGroupConfig" in eg_template
+        eg_config = eg_template.copy()
+        eg_config["eventGroupConfig"].pop("destinations", None)
+        eg_config_file = _save_json_to_file(eg_config, tracked_files)
+        eg_config_arg = f"--event-group-config {eg_config_file}"
+
+    # 2. ADD event-group
+    added_eg = run(
+        f"az iot ops ns asset event-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {eg_name} --data-source '{data_source}' {eg_config_arg}"
+    )
+    assert_event_properties(added_eg, name=eg_name, data_source=data_source)
+
+    # 3. LIST event-groups
+    eg_list = run(
+        f"az iot ops ns asset event-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert any(g["name"] == eg_name for g in eg_list)
+
+    # 4. SHOW-TEMPLATE - event (may be empty)
+    event_template = _try_show_template(
+        f"az iot ops ns asset event add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name} "
+        f"--data-source '{ev_data_source}' --show-template config"
+    )
+
+    event_config_arg = ""
+    if event_template:
+        assert "connectorType" in event_template
+        assert "eventConfig" in event_template
+        event_config = event_template.copy()
+        event_config["eventConfig"].pop("destinations", None)
+        event_config_file = _save_json_to_file(event_config, tracked_files)
+        event_config_arg = f"--event-config {event_config_file}"
+
+    # 5. ADD event
+    added_events = run(
+        f"az iot ops ns asset event add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name} "
+        f"--data-source '{ev_data_source}' {event_config_arg}"
+    )
+    assert_point_properties(added_events, name=event_name, data_source=ev_data_source)
+
+    # 6. LIST events
+    ev_list = run(
+        f"az iot ops ns asset event list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --event-group {eg_name}"
+    )
+    assert any(ev["name"] == event_name for ev in ev_list)
+
+    # 7. REMOVE event
+    run(
+        f"az iot ops ns asset event remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--event-group {eg_name} --name {event_name}"
+    )
+    ev_list_after = run(
+        f"az iot ops ns asset event list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --event-group {eg_name}"
+    )
+    assert not any(ev["name"] == event_name for ev in (ev_list_after or []))
+
+    # 8. REMOVE event-group
+    run(
+        f"az iot ops ns asset event-group remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {eg_name}"
+    )
+    remaining = [g["name"] for g in (run(
+        f"az iot ops ns asset event-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    ) or [])]
+    assert eg_name not in remaining

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
@@ -30,6 +30,11 @@ from azext_edge.edge.commands_namespaces import (
     list_namespace_asset_event_group_events,
     remove_namespace_asset_event_group_event
 )
+from azext_edge.edge.commands_namespaces import (
+    add_namespace_asset_event_group,
+    update_namespace_asset_event_group,
+    add_namespace_asset_event_group_event,
+)
 
 from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
@@ -1370,3 +1375,620 @@ def test_remove_namespace_asset_event_group_event(
         instance_name=instance_name,
         instance_resource_group=instance_resource_group
     )
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) event-group / event unit tests
+# ---------------------------------------------------------------------------
+
+
+def _build_asset_with_connector_events(
+    asset_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    event_groups: Optional[list] = None,
+) -> dict:
+    """Build a mock asset record pre-wired for the generalized event path."""
+    asset = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    asset["properties"]["eventGroups"] = event_groups or []
+    return asset
+
+
+def _add_device_get_for_generalized_events(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    connector_type: str,
+) -> None:
+    """Register GET device mock needed by _get_connector_type_from_asset and _check_device_props."""
+    device_name = asset["properties"]["deviceRef"]["deviceName"]
+    endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
+    add_device_get_call(
+        mocked_responses,
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        endpoint_name=endpoint_name,
+        endpoint_type=connector_type,
+    )
+
+
+def _event_metadata(connector_type: str, eg_schema=None, ev_schema=None, supported=("Mqtt",)) -> dict:
+    """Build a connector metadata payload for the generalized event path."""
+    return {
+        "inboundEndpoints": [{
+            "endpointType": f"Microsoft.{connector_type}",
+            "eventGroups": {
+                "eventGroupConfigurationSchema": eg_schema,
+                "events": {
+                    "eventConfigurationSchema": ev_schema,
+                    "destinations": {"supportedDestinations": list(supported)},
+                },
+            },
+        }]
+    }
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_event_group (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_event_group_config", [False, True])
+@pytest.mark.parametrize("replace, pre_existing", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_add_namespace_asset_event_group_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_event_group_config: bool,
+    replace: bool,
+    pre_existing: bool,
+):
+    asset_name = "gen-asset"
+    group_name = f"eg-{generate_random_string()}"
+    connector_type = "Custom.Test"
+
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    event_group_config_json = json.dumps({
+        "eventGroupConfiguration": {"publishingInterval": 1000},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "t/test"}}],
+    })
+
+    existing_egs = [generate_event_group(group_name=group_name)] if pre_existing else []
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=existing_egs,
+    )
+
+    # _get_connector_type_from_asset: GET asset + GET device
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    # _check_device_props: GET asset + GET device
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    if has_event_group_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value=_event_metadata(connector_type),
+        )
+
+    updated_asset = deepcopy(asset)
+    updated_asset["properties"]["eventGroups"] = [
+        {"name": group_name, "dataSource": "src/test", "events": []}
+    ]
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_event_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        data_source="src/test",
+        replace=replace,
+        event_group_config=event_group_config_json if has_event_group_config else None,
+        wait_sec=0,
+    )
+
+    assert result["name"] == group_name
+
+
+def test_add_namespace_asset_event_group_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "existing-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[generate_event_group(group_name=group_name)],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_event_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            replace=False,
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_event_group_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on add should return a blank template wrapped with connectorType."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(
+            connector_type,
+            eg_schema={
+                "type": "object",
+                "properties": {"publishingInterval": {"type": "integer", "default": 1000}},
+            },
+        ),
+    )
+
+    result = add_namespace_asset_event_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name="new-eg",
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    eg_cfg = result["eventGroupConfig"]
+    assert "eventGroupConfiguration" in eg_cfg
+    # Destinations metadata pulled from the event level
+    dests = eg_cfg["destinations"]
+    assert any(d["target"] == "Mqtt" for d in dests)
+
+
+# ---------------------------------------------------------------------------
+# update_namespace_asset_event_group (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_namespace_asset_event_group_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_eg = {
+        "name": group_name,
+        "dataSource": "orig/src",
+        "eventGroupConfiguration": json.dumps({"publishingInterval": 1000}),
+        "defaultDestinations": [],
+        "events": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[existing_eg],
+    )
+
+    event_group_config_json = json.dumps({
+        "eventGroupConfiguration": {"publishingInterval": 5000},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}],
+    })
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(connector_type),
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_eg = deepcopy(existing_eg)
+    updated_eg["eventGroupConfiguration"] = json.dumps({"publishingInterval": 5000})
+    updated_eg["defaultDestinations"] = [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}]
+    updated_asset["properties"]["eventGroups"] = [updated_eg]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_event_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        event_group_config=event_group_config_json,
+        wait_sec=0,
+    )
+
+    assert result["name"] == group_name
+    assert json.loads(result["eventGroupConfiguration"])["publishingInterval"] == 5000
+
+
+def test_update_namespace_asset_event_group_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on update should pre-fill existing ARM values into the template."""
+    asset_name = "gen-asset"
+    group_name = "sensor-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_eg = {
+        "name": group_name,
+        "dataSource": "orig/src",
+        "eventGroupConfiguration": json.dumps({"publishingInterval": 3000, "bufferSize": 5}),
+        "defaultDestinations": [{"target": "Mqtt", "configuration": {"topic": "live/topic", "qos": "Qos1"}}],
+        "events": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[existing_eg],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(
+            connector_type,
+            eg_schema={
+                "type": "object",
+                "properties": {
+                    "publishingInterval": {"type": "integer", "default": 1000},
+                    "bufferSize": {"type": "integer", "default": 10},
+                },
+            },
+        ),
+    )
+
+    result = update_namespace_asset_event_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    eg_cfg = result["eventGroupConfig"]["eventGroupConfiguration"]
+    # Existing ARM values should be pre-filled
+    assert eg_cfg["publishingInterval"] == 3000
+    assert eg_cfg["bufferSize"] == 5
+    # Existing destination topic should be pre-filled
+    dests = result["eventGroupConfig"]["destinations"]
+    mqtt_dest = next((d for d in dests if d["target"] == "Mqtt"), None)
+    assert mqtt_dest is not None
+    assert mqtt_dest["configuration"]["topic"] == "live/topic"
+
+
+def test_update_namespace_asset_event_group_generalized_raises_if_not_found(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="not found"):
+        update_namespace_asset_event_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="missing-eg",
+            show_template="config",
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_event_group_event (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_event_config", [False, True])
+def test_add_namespace_asset_event_group_event_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_event_config: bool,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-eg"
+    event_name = "temp-ev"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_eg = {
+        "name": group_name,
+        "dataSource": "s/src",
+        "events": [],
+    }
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[existing_eg],
+    )
+
+    event_config_json = json.dumps({
+        "eventConfiguration": {"samplingInterval": 250, "queueSize": 10},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "ev/temp"}}],
+    })
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    if has_event_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value=_event_metadata(connector_type),
+        )
+
+    updated_asset = deepcopy(asset)
+    added_ev = {"name": event_name, "dataSource": "sensors/temp"}
+    if has_event_config:
+        added_ev["eventConfiguration"] = json.dumps({"samplingInterval": 250, "queueSize": 10})
+        added_ev["destinations"] = [{"target": "Mqtt", "configuration": {"topic": "ev/temp"}}]
+    updated_asset["properties"]["eventGroups"][0]["events"] = [added_ev]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_event_group_event(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        event_name=event_name,
+        data_source="sensors/temp",
+        replace=False,
+        event_config=event_config_json if has_event_config else None,
+        wait_sec=0,
+    )
+
+    assert isinstance(result, list)
+    ev = next((e for e in result if e["name"] == event_name), None)
+    assert ev is not None
+    assert ev["dataSource"] == "sensors/temp"
+    if has_event_config:
+        cfg = json.loads(ev["eventConfiguration"])
+        assert cfg["samplingInterval"] == 250
+        assert cfg["queueSize"] == 10
+
+
+def test_add_namespace_asset_event_group_event_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-eg"
+    event_name = "existing-ev"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_eg = {
+        "name": group_name,
+        "dataSource": "s/src",
+        "events": [{"name": event_name, "dataSource": "sensors/old"}],
+    }
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[existing_eg],
+    )
+
+    # _get_connector_type_from_asset
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+    # _check_device_props
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_event_group_event(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            event_name=event_name,
+            data_source="sensors/new",
+            replace=False,
+            wait_sec=0,
+        )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
@@ -2208,3 +2208,45 @@ def test_add_event_generalized_show_template_config(
     assert "eventConfiguration" in ev_cfg
     # Destinations metadata is surfaced at the event level too
     assert any(d["target"] == "Mqtt" for d in ev_cfg["destinations"])
+
+
+def test_add_event_group_generalized_connector_type_mismatch_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """A --show-template output generated for a different connector type is rejected."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # Config wrapper declares a different connectorType than the asset's
+    mismatched_config = json.dumps({
+        "connectorType": "Microsoft.OpcUa",
+        "eventGroupConfig": {"eventGroupConfiguration": {"publishingInterval": 1000}},
+    })
+
+    with pytest.raises(InvalidArgumentValueError, match="does not match asset connectorType"):
+        add_namespace_asset_event_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="new-eg",
+            event_group_config=mismatched_config,
+            wait_sec=0,
+        )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
@@ -1405,7 +1405,7 @@ def _add_device_get_for_generalized_events(
     resource_group_name: str,
     connector_type: str,
 ) -> None:
-    """Register GET device mock needed by _get_connector_type_from_asset and _check_device_props."""
+    """Register GET device mock needed by _get_connector_type_and_device and _check_device_props."""
     device_name = asset["properties"]["deviceRef"]["deviceName"]
     endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
     add_device_get_call(
@@ -1484,14 +1484,6 @@ def test_add_namespace_asset_event_group_generalized(
     )
     _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
 
-    # _check_device_props: GET asset + GET device
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-
     if has_event_group_config:
         mocker.patch(
             "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
@@ -1550,13 +1542,6 @@ def test_add_namespace_asset_event_group_generalized_raises_on_duplicate(
     )
 
     # _get_connector_type_from_asset
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
     mocked_responses.add(
         responses.GET,
         get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
@@ -1674,13 +1659,6 @@ def test_update_namespace_asset_event_group_generalized(
     })
 
     # _get_connector_type_from_asset
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
     mocked_responses.add(
         responses.GET,
         get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
@@ -1883,13 +1861,6 @@ def test_add_namespace_asset_event_group_event_generalized(
         json=asset, status=200,
     )
     _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
 
     if has_event_config:
         mocker.patch(
@@ -1972,13 +1943,6 @@ def test_add_namespace_asset_event_group_event_generalized_raises_on_duplicate(
         json=asset, status=200,
     )
     _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
-    # _check_device_props
-    mocked_responses.add(
-        responses.GET,
-        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
-        json=asset, status=200,
-    )
-    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
 
     with pytest.raises(InvalidArgumentValueError, match="already exists"):
         add_namespace_asset_event_group_event(
@@ -1992,3 +1956,255 @@ def test_add_namespace_asset_event_group_event_generalized_raises_on_duplicate(
             replace=False,
             wait_sec=0,
         )
+
+
+# ---------------------------------------------------------------------------
+# generalized guard / validation unit tests
+# ---------------------------------------------------------------------------
+
+
+def _register_asset_and_device_get(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    connector_type: str,
+) -> None:
+    """Register the single asset GET + device GET used by the generalized front-door
+    (self.show + _get_connector_type_and_device)."""
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_events(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+
+def test_add_event_group_generalized_show_template_with_config_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """--show-template and --event-group-config are mutually exclusive."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="cannot be used together"):
+        add_namespace_asset_event_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="new-eg",
+            show_template="config",
+            event_group_config=json.dumps({"eventGroupConfiguration": {"publishingInterval": 1000}}),
+            wait_sec=0,
+        )
+
+
+def test_add_event_generalized_show_template_with_config_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """--show-template and --event-config are mutually exclusive on the add-event path."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[{"name": "sensor-eg", "dataSource": "s/src", "events": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="cannot be used together"):
+        add_namespace_asset_event_group_event(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="sensor-eg",
+            event_name="temp-ev",
+            show_template="config",
+            event_config=json.dumps({"eventConfiguration": {"queueSize": 5}}),
+            wait_sec=0,
+        )
+
+
+def test_add_event_group_generalized_unsupported_destination_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """A destination target not in the connector's supported set is rejected."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # Connector only supports Mqtt destinations
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(connector_type, supported=("Mqtt",)),
+    )
+
+    bad_config = json.dumps({
+        "destinations": [{"target": "BrokerStateStore", "configuration": {"key": "cache"}}],
+    })
+
+    with pytest.raises(InvalidArgumentValueError, match="not supported for events"):
+        add_namespace_asset_event_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="new-eg",
+            event_group_config=bad_config,
+            wait_sec=0,
+        )
+
+
+def test_add_event_group_generalized_show_template_schema(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=schema returns the connector schema structure (type/default/constraints)."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(
+            connector_type,
+            eg_schema={
+                "type": "object",
+                "properties": {
+                    "publishingInterval": {"type": "integer", "default": 1000, "minimum": 0},
+                },
+            },
+        ),
+    )
+
+    result = add_namespace_asset_event_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name="new-eg",
+        show_template="schema",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    eg_cfg = result["eventGroupConfig"]["eventGroupConfiguration"]
+    # In schema mode the field is described (type/default/constraints), not just a default value.
+    pub = eg_cfg["properties"]["publishingInterval"] if "properties" in eg_cfg else eg_cfg["publishingInterval"]
+    assert pub["type"] == "integer"
+    assert pub["default"] == 1000
+
+
+def test_add_event_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on the add-event path returns an eventConfig template."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[{"name": "sensor-eg", "dataSource": "s/src", "events": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_event_metadata(
+            connector_type,
+            ev_schema={
+                "type": "object",
+                "properties": {"queueSize": {"type": "integer", "default": 10}},
+            },
+        ),
+    )
+
+    result = add_namespace_asset_event_group_event(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name="sensor-eg",
+        event_name="temp-ev",
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    ev_cfg = result["eventConfig"]
+    assert "eventConfiguration" in ev_cfg
+    # Destinations metadata is surfaced at the event level too
+    assert any(d["target"] == "Mqtt" for d in ev_cfg["destinations"])

--- a/azext_edge/tests/edge/adr/test_namespace_assets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_assets_int.py
@@ -17,7 +17,8 @@ from .namespace_helpers import (
     assert_stream_properties,
     create_config_file,
     assert_point_properties,
-    assert_dataset_properties
+    assert_dataset_properties,
+    _save_json_to_file,
 )
 
 pytestmark = pytest.mark.rpsaas
@@ -717,12 +718,10 @@ def test_generalized_asset_error_cases(require_namespace_init_module):
 
 
 def test_generalized_asset_lifecycle(
-    require_namespace_init_module, shared_device, tracked_resources: List[str]
+    require_namespace_init_module, shared_device, tracked_resources: List[str], tracked_files: List[str]
 ):
     """Integration lifecycle test for the generalized ns asset create / update commands."""
     import json
-    import os
-    import tempfile
 
     instance_name = require_namespace_init_module["instanceName"]
     resource_group = require_namespace_init_module["resourceGroup"]
@@ -774,28 +773,23 @@ def test_generalized_asset_lifecycle(
     assert "assetConfig" in template_result
     assert "defaultDatasetsConfiguration" in template_result["assetConfig"]
 
-    config_fd, config_path = tempfile.mkstemp(suffix=".json")
-    try:
-        with os.fdopen(config_fd, "w") as f:
-            json.dump(template_result["assetConfig"], f)
-        asset_name_2 = f"gen-asset2-{generate_random_string(8, force_lower=True)}"
-        created_2 = run(
-            f"az iot ops ns asset create "
-            f"--connector-type opcua "
-            f"--name {asset_name_2} "
-            f"--device {device_name} "
-            f"--endpoint {endpoint_name} "
-            f"--instance {instance_name} -g {resource_group} "
-            f"--asset-config {config_path}"
-        )
-        tracked_resources.append(created_2["id"])
-        assert created_2["name"] == asset_name_2
-        asset_props = created_2["properties"]
-        datasets_config = json.loads(asset_props.get("defaultDatasetsConfiguration", "{}"))
-        assert datasets_config.get("publishingInterval") == 1000
-        assert datasets_config.get("samplingInterval") == 1000
-    finally:
-        os.unlink(config_path)
+    config_path = _save_json_to_file(template_result["assetConfig"], tracked_files)
+    asset_name_2 = f"gen-asset2-{generate_random_string(8, force_lower=True)}"
+    created_2 = run(
+        f"az iot ops ns asset create "
+        f"--connector-type opcua "
+        f"--name {asset_name_2} "
+        f"--device {device_name} "
+        f"--endpoint {endpoint_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--asset-config {config_path}"
+    )
+    tracked_resources.append(created_2["id"])
+    assert created_2["name"] == asset_name_2
+    asset_props = created_2["properties"]
+    datasets_config = json.loads(asset_props.get("defaultDatasetsConfiguration", "{}"))
+    assert datasets_config.get("publishingInterval") == 1000
+    assert datasets_config.get("samplingInterval") == 1000
 
     # --- Update asset using the generalized update command ---
     updated = run(


### PR DESCRIPTION
Overview:

- Adds connector-agnostic `iot ops ns asset event-group` and `iot ops ns asset event` commands (add/update/show/list/remove/export/import) that auto-detect the connector type from the asset
- Introduces `--show-template` config|schema for schema discovery and --event-group-config/--event-config (inline JSON or file) for configuration, with shared destination va

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
