### PR TITLE
build: increment kubernetes client to 36.0.2

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -290,7 +290,6 @@ jobs:
           path: ./.coverage
           include-hidden-files: true
       - name: "Run smoke tests"
-        continue-on-error: true
         run: |
           az iot ops support create-bundle
           az iot ops support create-bundle --svc broker --broker-traces

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -241,10 +241,16 @@ def mocked_namespaced_custom_objects(mocked_client):
 
 @pytest.fixture
 def mocked_list_cron_jobs(mocked_client):
+    from kubernetes.client import Configuration
     from kubernetes.client.models import V1CronJobList, V1CronJob, V1ObjectMeta
+    no_validation = Configuration()
+    no_validation.client_side_validation = False
 
     def _handle_list_cron_jobs(*args, **kwargs):
-        cron_job = V1CronJob(metadata=V1ObjectMeta(namespace="mock_namespace", name="mock_cron_job"))
+        cron_job = V1CronJob(
+            metadata=V1ObjectMeta(namespace="mock_namespace", name="mock_cron_job"),
+            local_vars_configuration=no_validation,
+        )
         cron_job_list = V1CronJobList(items=[cron_job])
 
         return cron_job_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "rich>=13.6,<14.0",
-    "kubernetes>=35.0,<36.0",
+    "kubernetes>=36.0.2,<37.0",
     "azure-identity>=1.14.1,<1.18.0",
     "protobuf~=4.25.0",
     "opentelemetry-proto~=1.20.0",


### PR DESCRIPTION
## Summary
Bumps `kubernetes` 35.x -> **36.0.2** to fix the `NO_PROXY` env var being ignored (v34.1.0–35.x reset `Configuration.no_proxy` to `None`, so proxied users route cluster traffic through the proxy instead of bypassing it)

## Changes
 - **pyproject.toml** - `kubernetes >=35.0,<36.0` -> `>=36.0.2,<37.0`.
 -  **tests/edge/support/conftest.py** - v36 requires `CronJob.spec` at construction, which broke the metadata-only mock. Build it with `client_side_validation=False` (keeps the mock minimal and the serialized YAML identical, so the assertion is unchanged). 
 - **.github/workflows/int_test.yml** - remove the temporary `continue-on-error` on the smoke step (added in #784).

## Verification 
- Unit suite green on 36.0.2 (0 failed). 
- `NO_PROXY`/`HTTP(S)_PROXY` evaluated - before/after: `35.0.0 -> no_proxy=None` vs `36.0.2 -> no_proxy=<value>`.
<img width="1383" height="91" alt="Screenshot 2026-07-08 232623" src="https://github.com/user-attachments/assets/18a08dc7-96bb-4ec3-bba4-31595e490848" />
<img width="1387" height="134" alt="Screenshot 2026-07-08 232631" src="https://github.com/user-attachments/assets/268993dc-e16d-4777-93db-1e9dc7a0b10b" />
