### PR TITLE
feat: add generalized namespace asset stream commands

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -388,6 +388,19 @@ def load_iotops_commands(self, _):
         cmd_group.command("list", "list_namespace_asset_event_group_events", is_preview=True)
         cmd_group.command("remove", "remove_namespace_asset_event_group_event", is_preview=True)
 
+    # generalized stream group (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset stream",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_stream", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_stream", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_stream", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_streams", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_stream", is_preview=True)
+        cmd_group.show_command("show", "show_namespace_asset_stream", is_preview=True)
+        cmd_group.command("update", "update_namespace_asset_stream", is_preview=True)
+
     # dataset
     for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -3277,3 +3277,58 @@ def add_namespace_asset_event_group_event(
 
 export_namespace_asset_event_group_event = _make_event_export_func("export_event_group_events")
 import_namespace_asset_event_group_event = _make_event_import_func("import_event_group_events")
+
+
+# GENERALIZED STREAM COMMANDS
+
+
+def add_namespace_asset_stream(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    stream_name: str,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    stream_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).add_stream_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        stream_name=stream_name,
+        type_ref=type_ref,
+        replace=replace,
+        stream_config=stream_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+def update_namespace_asset_stream(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    stream_name: str,
+    type_ref: Optional[str] = None,
+    stream_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update_stream_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        stream_name=stream_name,
+        type_ref=type_ref,
+        stream_config=stream_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_stream = _make_export_func("export_streams")
+import_namespace_asset_stream = _make_import_func("import_streams")

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -2490,6 +2490,84 @@ def load_iotops_arguments(self, _):
             arg_type=get_three_state_flag(),
         )
 
+    with self.argument_context("iot ops ns asset stream") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "stream_name",
+            options_list=["--name", "-n"],
+            help="Stream name.",
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "stream_config",
+            options_list=["--stream-config", "--stc"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific stream configuration and/or destinations. Accepted keys are "
+            "'streamConfiguration' (connector-specific config object) and 'destinations' (list of "
+            "destination objects). Use --show-template to discover the supported keys and schema "
+            "for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter stream configuration template for the asset's connector type "
+            "and exit without modifying the stream. The connector type is read from the existing "
+            "asset. config: fields shown with their default values (null if no default); output is "
+            "directly usable as --stream-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset stream add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the stream if another stream with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset stream export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type([FileType.json.value, FileType.yaml.value], default=FileType.json.value),
+            help="Export file format (JSON or YAML).",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Output directory for export.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the local file if present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset stream import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON or YAML).",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing streams that share a name with an imported stream.",
+            arg_type=get_three_state_flag(),
+        )
+
     with self.argument_context("iot ops clone") as context:
         context.argument(
             "summary_mode",

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -2915,6 +2915,162 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset stream"
+    ] = """
+        type: group
+        short-summary: Manage streams for namespaced assets in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --stream-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset stream add"
+    ] = """
+        type: command
+        short-summary: Add a stream to a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration and destinations can be supplied via --stream-config.
+            Use --show-template to discover the supported config schema. For non-OPC UA connectors,
+            a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic stream to any asset type
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+
+        - name: Show the stream config template for the asset's connector type
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --show-template config
+
+        - name: Add a stream with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+            --stream-config '{"streamConfiguration": {"taskType": "snapshot-to-mqtt", "snapshotsPerSecond": 5}}'
+
+        - name: Add a stream with configuration from a file
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --stream-config ./stream_config.json
+
+        - name: Add a stream with an MQTT destination
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+            --stream-config '{"destinations": [{"target": "Mqtt", "configuration": {"topic": "factory/streams", "retain": "Keep", "qos": "Qos1", "ttl": 3600}}]}'
+
+        - name: Replace an existing stream
+          text: >
+            az iot ops ns asset stream add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --replace
+    """
+
+    helps[
+        "iot ops ns asset stream update"
+    ] = """
+        type: command
+        short-summary: Update a stream for a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Use --stream-config to supply connector-specific configuration.
+            Use --show-template config to see current stream values pre-filled in the full schema
+            structure (ready to edit and pass back via --stream-config).
+            Use --show-template schema to see the full connector schema with types and constraints.
+
+        examples:
+        - name: Show current stream config pre-filled with existing values (for editing before update)
+          text: >
+            az iot ops ns asset stream update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --show-template config
+
+        - name: Show the stream config schema with types and constraints
+          text: >
+            az iot ops ns asset stream update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --show-template schema
+
+        - name: Update stream configuration from inline JSON
+          text: >
+            az iot ops ns asset stream update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+            --stream-config '{"streamConfiguration": {"snapshotsPerSecond": 10}}'
+
+        - name: Update stream type reference
+          text: >
+            az iot ops ns asset stream update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream --type-ref "myTypeRef"
+    """
+
+    helps[
+        "iot ops ns asset stream list"
+    ] = """
+        type: command
+        short-summary: List streams for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: List all streams for an asset
+          text: >
+            az iot ops ns asset stream list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset stream remove"
+    ] = """
+        type: command
+        short-summary: Remove a stream from a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Remove a stream from an asset
+          text: >
+            az iot ops ns asset stream remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+    """
+
+    helps[
+        "iot ops ns asset stream show"
+    ] = """
+        type: command
+        short-summary: Show details of a stream for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Show stream details
+          text: >
+            az iot ops ns asset stream show --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name videoStream
+    """
+
+    helps[
+        "iot ops ns asset stream export"
+    ] = """
+        type: command
+        short-summary: Export streams to file.
+
+        examples:
+        - name: Export streams to JSON
+          text: >
+            az iot ops ns asset stream export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset stream import"
+    ] = """
+        type: command
+        short-summary: Import streams from file.
+
+        examples:
+        - name: Import streams from a JSON file
+          text: >
+            az iot ops ns asset stream import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --input-file ./streams.json
+    """
+
+    helps[
         "iot ops ns asset opcua dataset"
     ] = """
         type: group

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -3603,7 +3603,8 @@ class NamespaceAssets(Queryable):
         dest_raw = parsed.get("destinations")
         if dest_raw is not None:
             dest_data = self._validate_stream_destinations(dest_raw, stream_section)
-            if dest_data:
+            # Preserve an explicitly empty list so callers can clear destinations.
+            if dest_data or dest_raw == []:
                 result["destinations"] = dest_data
 
         return result

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -2651,9 +2651,15 @@ class NamespaceAssets(Queryable):
 
         return result
 
-    def _validate_event_destinations(self, dest_raw, eg_section: dict) -> List[dict]:
-        """Validate and filter a destinations list against the connector's supported event
-        destinations. Shared by event-group and event config loaders."""
+    def _filter_and_validate_destinations(
+        self, dest_raw, supported: List[str], resource_label: str
+    ) -> List[dict]:
+        """Filter a destinations list (dropping entries with empty configuration) and validate the
+        remaining targets against the connector's supported destination set.
+
+        Shared by the event, event-group, and stream config loaders. ``supported`` is the already
+        resolved ``supportedDestinations`` list; ``resource_label`` is used in error messages.
+        """
         from .helpers import strip_nulls as _strip_nulls
 
         dest_data = _strip_nulls(dest_raw)
@@ -2674,23 +2680,26 @@ class NamespaceAssets(Queryable):
                 )
                 continue
             filtered.append(item)
-        dest_data = filtered
-        if dest_data:
-            events_section = eg_section.get("events", {}) if eg_section else {}
-            dest_section = events_section.get("destinations", {}) if isinstance(events_section, dict) else {}
-            supported = (
-                dest_section.get("supportedDestinations", [])
-                if isinstance(dest_section, dict) else []
-            )
-            if supported:
-                for dest_item in dest_data:
-                    target = dest_item.get("target")
-                    if target and target not in supported:
-                        raise InvalidArgumentValueError(
-                            f"Destination target '{target}' is not supported for events. "
-                            f"Supported: {supported}."
-                        )
-        return dest_data
+        if filtered and supported:
+            for dest_item in filtered:
+                target = dest_item.get("target")
+                if target and target not in supported:
+                    raise InvalidArgumentValueError(
+                        f"Destination target '{target}' is not supported for {resource_label}. "
+                        f"Supported: {supported}."
+                    )
+        return filtered
+
+    def _validate_event_destinations(self, dest_raw, eg_section: dict) -> List[dict]:
+        """Validate and filter a destinations list against the connector's supported event
+        destinations. Shared by event-group and event config loaders."""
+        events_section = eg_section.get("events", {}) if eg_section else {}
+        dest_section = events_section.get("destinations", {}) if isinstance(events_section, dict) else {}
+        supported = (
+            dest_section.get("supportedDestinations", [])
+            if isinstance(dest_section, dict) else []
+        )
+        return self._filter_and_validate_destinations(dest_raw, supported, "events")
 
     def _handle_event_show_template(
         self,
@@ -3445,6 +3454,367 @@ class NamespaceAssets(Queryable):
             )
             # note that we return a list of events
             return _get_sub_property(asset, group_name, property_key="eventGroups")["events"]
+
+    def _handle_stream_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        stream_config: Optional[str],
+    ) -> dict:
+        """Return a stream config/schema template for --show-template and exit early.
+
+        Discovers the streamConfigurationSchema and supported destinations from connector
+        metadata and returns a slimmed template. OPC UA uses bundled metadata; all other types
+        require a connector template in the instance.
+        """
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        if stream_config:
+            raise InvalidArgumentValueError(
+                "--show-template and --stream-config cannot be used together. "
+                "--show-template displays the template and exits without modifying the stream."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        stream_section = endpoint.get("streams", {})
+        schema = stream_section.get("streamConfigurationSchema")
+
+        stream_config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            stream_config_template["streamConfiguration"] = slimmed
+
+        destinations = self._build_stream_destinations_template(stream_section, template_mode)
+        if destinations is not None:
+            stream_config_template["destinations"] = destinations
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, "streamConfig": stream_config_template}
+
+    def _build_stream_destinations_template(self, stream_section: dict, template_mode: str) -> Optional[list]:
+        """Build a destinations template from the connector's supported stream destinations.
+
+        Stream destinations live at ``streams.destinations``. Returns None when no destinations
+        are supported.
+        """
+        dest_section = stream_section.get("destinations", {}) if isinstance(stream_section, dict) else {}
+        supported = dest_section.get("supportedDestinations", []) if isinstance(dest_section, dict) else []
+        if not supported:
+            return None
+        return _build_destination_template(
+            supported_destinations=supported,
+            default_destination=dest_section.get("defaultDestination"),
+            mode=template_mode,
+        )
+
+    def _validate_stream_destinations(self, dest_raw, stream_section: dict) -> List[dict]:
+        """Validate and filter a destinations list against the connector's supported stream
+        destinations."""
+        dest_section = stream_section.get("destinations", {}) if isinstance(stream_section, dict) else {}
+        supported = (
+            dest_section.get("supportedDestinations", [])
+            if isinstance(dest_section, dict) else []
+        )
+        return self._filter_and_validate_destinations(dest_raw, supported, "streams")
+
+    def _load_and_validate_stream_config(
+        self,
+        stream_config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+    ) -> dict:
+        """Load stream config from file/inline JSON, validate against connector schema, and
+        return ARM-ready values.
+
+        Input JSON is expected to be the 'streamConfig' dict (output of --show-template), e.g.:
+          {
+            "streamConfiguration": {...},
+            "destinations": [...]
+          }
+        Or the full --show-template output with 'connectorType' and 'streamConfig' keys,
+        which is auto-unwrapped.
+
+        Returns a dict with:
+          - "streamConfiguration": serialized JSON string (if present)
+          - "destinations": list of destination dicts (if present)
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        raw = process_additional_configuration(
+            additional_configuration=stream_config,
+            config_type="stream",
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and "streamConfig" in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
+            parsed = parsed["streamConfig"]
+
+        if not isinstance(parsed, dict) or not {"streamConfiguration", "destinations"}.intersection(parsed):
+            raise InvalidArgumentValueError(
+                "--stream-config must be a JSON object with 'streamConfiguration' "
+                "and/or 'destinations' keys."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        stream_section = endpoint.get("streams", {}) if endpoint else {}
+
+        result = {}
+
+        config_data_raw = parsed.get("streamConfiguration")
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = stream_section.get("streamConfigurationSchema") if stream_section else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping streamConfiguration validation: %s", skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name="streamConfiguration")
+            result["streamConfiguration"] = json.dumps(config_data)
+
+        dest_raw = parsed.get("destinations")
+        if dest_raw is not None:
+            dest_data = self._validate_stream_destinations(dest_raw, stream_section)
+            if dest_data:
+                result["destinations"] = dest_data
+
+        return result
+
+    def add_stream_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        stream_name: str,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        stream_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized add-stream that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --stream-config for
+        JSON or file-based connector-specific stream configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type, device = self._get_connector_type_and_device(asset)
+
+        if show_template:
+            return self._handle_stream_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                stream_config=stream_config,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+            asset=asset,
+            device=device,
+        )
+
+        original_streams = asset["properties"].get("streams", [])
+        new_streams = [stream for stream in original_streams if stream["name"] != stream_name]
+        if len(new_streams) < len(original_streams) and not replace:
+            raise InvalidArgumentValueError(
+                f"Stream '{stream_name}' already exists in asset '{asset_name}'. "
+                "Use --replace to overwrite the existing stream."
+            )
+
+        new_stream: dict = {
+            "name": stream_name,
+            "streamConfiguration": None,
+            "destinations": [],
+            "typeRef": type_ref,
+        }
+
+        if stream_config:
+            config_result = self._load_and_validate_stream_config(
+                stream_config=stream_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "streamConfiguration" in config_result:
+                new_stream["streamConfiguration"] = config_result["streamConfiguration"]
+            if "destinations" in config_result:
+                new_stream["destinations"] = config_result["destinations"]
+
+        new_streams.append(new_stream)
+        update_payload = {"properties": {"streams": new_streams}}
+
+        with console.status(f"Adding stream {stream_name} to asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, stream_name, property_key="streams")
+
+    def update_stream_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        stream_name: str,
+        type_ref: Optional[str] = None,
+        stream_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized update-stream that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --stream-config for
+        JSON or file-based connector-specific stream configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type, device = self._get_connector_type_and_device(asset)
+
+        if show_template:
+            from .common import EndpointTemplateMode
+            template_mode = show_template.lower()
+            if template_mode == EndpointTemplateMode.CONFIG.value:
+                if stream_config:
+                    raise InvalidArgumentValueError(
+                        "--show-template and --stream-config cannot be used together. "
+                        "--show-template displays the template and exits without modifying the stream."
+                    )
+                streams_existing = asset["properties"].get("streams", [])
+                existing = next((s for s in streams_existing if s["name"] == stream_name), None)
+                if existing is None:
+                    raise InvalidArgumentValueError(
+                        f"Stream '{stream_name}' not found in asset '{asset_name}'."
+                    )
+                template_result = self._handle_stream_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    stream_config=None,
+                )
+                stream_config_tmpl = template_result.get("streamConfig", {})
+                raw_config = existing.get("streamConfiguration")
+                if raw_config:
+                    existing_config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+                    tmpl_sc = stream_config_tmpl.get("streamConfiguration")
+                    stream_config_tmpl["streamConfiguration"] = (
+                        _deep_merge_template(tmpl_sc, existing_config)
+                        if isinstance(tmpl_sc, dict)
+                        else existing_config
+                    )
+                existing_dests = existing.get("destinations", [])
+                if existing_dests:
+                    tmpl_dests = stream_config_tmpl.get("destinations", [])
+                    stream_config_tmpl["destinations"] = _merge_destinations_template(
+                        tmpl_dests, existing_dests
+                    )
+                return {"connectorType": connector_type, "streamConfig": stream_config_tmpl}
+            else:
+                return self._handle_stream_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    stream_config=stream_config,
+                )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+            asset=asset,
+            device=device,
+        )
+
+        streams = asset["properties"].get("streams", [])
+        stream_list = [s for s in streams if s["name"] == stream_name]
+        if not stream_list:
+            raise InvalidArgumentValueError(
+                f"Stream '{stream_name}' not found in asset '{asset_name}'."
+            )
+        stream = stream_list[0]
+
+        if stream_config is not None:
+            config_result = self._load_and_validate_stream_config(
+                stream_config=stream_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+            )
+            if "streamConfiguration" in config_result:
+                stream["streamConfiguration"] = config_result["streamConfiguration"]
+            if "destinations" in config_result:
+                stream["destinations"] = config_result["destinations"]
+
+        if type_ref is not None:
+            stream["typeRef"] = type_ref
+
+        update_payload = {"properties": {"streams": streams}}
+        with console.status(f"Updating stream {stream_name} in asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, stream_name, property_key="streams")
 
     # STREAMS - allowed for media and custom assets
     def add_stream(

--- a/azext_edge/tests/edge/adr/test_namespace_asset_stream_export_import_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_stream_export_import_int.py
@@ -88,3 +88,75 @@ def test_namespace_asset_stream_export_import(
                 log.check(f"stream {name} imported", name in imported_dict)
             final = log.run_command(f"{cmd_prefix} list {cmd_args}")
             log.check("final count == 2", len(final) == 2, actual=len(final))
+
+
+@pytest.mark.parametrize("asset_type, endpoint_type, endpoint_address", [
+    ("custom", "custom", "http://192.168.1.100:8000/custom/service"),
+    ("media", "media", "rtsp://mediaserver.local:554/stream"),
+])
+def test_namespace_asset_stream_export_import_generalized(
+    require_namespace_init_session, tracked_resources: List[str], tracked_files: List[str], tmp_path,
+    shared_device: str, endpoint_cache: dict,
+    asset_type: str, endpoint_type: str, endpoint_address: str
+):
+    """Test stream export and import via the generalized (connector-agnostic) command group."""
+    instance_name = require_namespace_init_session["instanceName"]
+    resource_group = require_namespace_init_session["resourceGroup"]
+    output_dir = str(tmp_path)
+    asset_name = f"{asset_type}-{generate_random_string(8, force_lower=True)}"
+    stream_name_1 = f"s1-{generate_random_string(6, force_lower=True)}"
+    stream_name_2 = f"s2-{generate_random_string(6, force_lower=True)}"
+    stream_names = [stream_name_1, stream_name_2]
+
+    with TestLog(
+        f"test_namespace_asset_stream_export_import_generalized[{asset_type}]", total_steps=6,
+    ) as log:
+
+        with log.step(1, "Ensure Device + Endpoint"):
+            device_name, endpoint_name = ensure_device_and_endpoint(
+                log, instance_name, resource_group, asset_type, endpoint_type,
+                endpoint_address, shared_device, endpoint_cache,
+            )
+
+        with log.step(2, f"Create {asset_type} Asset"):
+            log.run_command(
+                f"az iot ops ns asset {asset_type} create --name {asset_name} --instance {instance_name} "
+                f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}",
+                tracked_resources=tracked_resources,
+            )
+
+        # Generalized command group — no connector type in the command path.
+        cmd_prefix = "az iot ops ns asset stream"
+        cmd_args = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
+
+        with log.step(3, "Add Streams"):
+            for name in stream_names:
+                log.run_command(f"{cmd_prefix} add {cmd_args} --name {name}")
+            result = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("2 streams added", len(result) == 2, actual=len(result))
+
+        with log.step(4, "Export Streams (JSON)"):
+            export_result = log.run_command(f"{cmd_prefix} export {cmd_args} -f json --output-dir {output_dir}")
+            exported_file = validate_export_result(
+                log, export_result, "stream_count", 2, "json", tracked_files,
+            )
+            with open(exported_file, 'r', encoding='utf-8') as f:
+                items = json.load(f)
+            item_dict = {s["name"]: s for s in items}
+            for name in stream_names:
+                log.check(f"stream {name} exported", name in item_dict)
+                log.check(f"stream {name} no destinations",
+                          "destinations" not in item_dict[name] or not item_dict[name]["destinations"])
+
+        with log.step(5, "Remove Stream & Verify"):
+            log.run_command(f"{cmd_prefix} remove {cmd_args} --name {stream_name_1}")
+            result = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("1 stream remains", len(result) == 1, actual=len(result))
+
+        with log.step(6, "Import & Verify"):
+            imported = log.run_command(f"{cmd_prefix} import {cmd_args} --input-file {exported_file}")
+            imported_dict = {s["name"]: s for s in imported}
+            for name in stream_names:
+                log.check(f"stream {name} imported", name in imported_dict)
+            final = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("final count == 2", len(final) == 2, actual=len(final))

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_int.py
@@ -10,7 +10,8 @@ import pytest
 from ...generators import generate_random_string
 from ...helpers import run
 from .namespace_helpers import (
-    create_config_file, assert_stream_properties, check_destinations
+    create_config_file, assert_stream_properties, check_destinations,
+    _save_json_to_file, _try_show_template
 )
 
 
@@ -312,3 +313,110 @@ def assert_media_stream_properties(result, **expected):
 
     if "destinations" in expected:
         check_destinations(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) stream commands
+# ---------------------------------------------------------------------------
+
+
+def test_generalized_stream_lifecycle_custom(asset_factory, tracked_files: List[str]):
+    """Generalized stream lifecycle on a custom asset.
+
+    A connector template must exist in the instance for --show-template / --stream-config
+    to resolve connector metadata. When no template is installed, --show-template returns an
+    empty dict and the test exercises the metadata-free path (no config payload).
+    """
+    info = asset_factory("custom")
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    stream_name = f"gen-stream-{generate_random_string(6, force_lower=True)}"
+    stream_name_2 = f"gen-stream2-{generate_random_string(6, force_lower=True)}"
+
+    # 1. SHOW-TEMPLATE - stream (may be empty when no connector template installed)
+    stream_template = _try_show_template(
+        f"az iot ops ns asset stream add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {stream_name} --show-template config"
+    )
+
+    stream_config_arg = ""
+    if stream_template:
+        assert "connectorType" in stream_template
+        assert "streamConfig" in stream_template
+        stream_config = stream_template.copy()
+        stream_config["streamConfig"].pop("destinations", None)
+        stream_config_file = _save_json_to_file(stream_config, tracked_files)
+        stream_config_arg = f"--stream-config {stream_config_file}"
+
+    # 2. ADD stream
+    added_stream = run(
+        f"az iot ops ns asset stream add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {stream_name} {stream_config_arg}"
+    )
+    assert_stream_properties(added_stream, name=stream_name)
+
+    # 3. SHOW stream
+    shown_stream = run(
+        f"az iot ops ns asset stream show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {stream_name}"
+    )
+    assert_stream_properties(shown_stream, name=stream_name)
+
+    # 4. LIST streams
+    stream_list = run(
+        f"az iot ops ns asset stream list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert any(s["name"] == stream_name for s in stream_list)
+
+    # 5. ADD a second stream (minimal)
+    added_stream_2 = run(
+        f"az iot ops ns asset stream add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {stream_name_2}"
+    )
+    assert_stream_properties(added_stream_2, name=stream_name_2)
+    stream_names = [s["name"] for s in run(
+        f"az iot ops ns asset stream list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )]
+    assert stream_name in stream_names and stream_name_2 in stream_names
+
+    # 6. UPDATE stream (type reference)
+    updated_stream = run(
+        f"az iot ops ns asset stream update --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {stream_name} --type-ref myTypeRef"
+    )
+    assert_stream_properties(updated_stream, name=stream_name)
+    assert updated_stream.get("typeRef") == "myTypeRef"
+
+    # 7. REPLACE stream
+    replaced_stream = run(
+        f"az iot ops ns asset stream add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {stream_name} --replace"
+    )
+    assert_stream_properties(replaced_stream, name=stream_name)
+
+    # 8. EXPORT streams
+    export_result = run(
+        f"az iot ops ns asset stream export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --output-dir /tmp --replace"
+    )
+    assert export_result["stream_count"] >= 1
+    tracked_files.append(export_result["file_path"])
+
+    # 9. REMOVE streams
+    for stream in [stream_name, stream_name_2]:
+        run(
+            f"az iot ops ns asset stream remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {stream}"
+        )
+    remaining = [s["name"] for s in (run(
+        f"az iot ops ns asset stream list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    ) or [])]
+    assert stream_name not in remaining and stream_name_2 not in remaining

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
@@ -2019,3 +2019,81 @@ def test_add_namespace_asset_stream_generalized_invalid_config_shape_raises(
             stream_config=json.dumps({"foo": "bar"}),
             wait_sec=0,
         )
+
+
+def test_update_namespace_asset_stream_generalized_clears_destinations(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """An explicit empty destinations array clears the stream's existing destinations."""
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 1}),
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "old/topic"}}],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(connector_type),
+    )
+
+    captured = {}
+
+    def _capture_patch(request):
+        captured["body"] = json.loads(request.body)
+        return (200, {}, json.dumps(asset))
+
+    mocked_responses.add_callback(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        callback=_capture_patch,
+        content_type="application/json",
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_stream = deepcopy(existing_stream)
+    updated_stream["destinations"] = []
+    updated_asset["properties"]["streams"] = [updated_stream]
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        stream_config=json.dumps({"destinations": []}),
+        wait_sec=0,
+    )
+
+    # The PATCH payload should carry an empty destinations list (cleared, not left in place).
+    patched_stream = next(
+        s for s in captured["body"]["properties"]["streams"] if s["name"] == stream_name
+    )
+    assert patched_stream["destinations"] == []
+    assert result["destinations"] == []

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
@@ -20,6 +20,10 @@ from azext_edge.edge.commands_namespaces import (
     update_namespace_custom_asset_stream,
     update_namespace_media_asset_stream,
 )
+from azext_edge.edge.commands_namespaces import (
+    add_namespace_asset_stream,
+    update_namespace_asset_stream,
+)
 
 from .test_namespace_assets_unit import (
     add_device_get_call, get_namespace_asset_mgmt_uri, get_namespace_asset_record
@@ -1206,3 +1210,812 @@ def test_import_namespace_asset_streams(
     # Verify result is a list of streams
     assert isinstance(result, list)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) stream unit tests
+# ---------------------------------------------------------------------------
+
+
+def _build_asset_with_connector_streams(
+    asset_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    streams: Optional[list] = None,
+) -> dict:
+    """Build a mock asset record pre-wired for the generalized stream path."""
+    asset = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    asset["properties"]["streams"] = streams or []
+    return asset
+
+
+def _add_device_get_for_generalized_streams(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    connector_type: str,
+) -> None:
+    """Register GET device mock needed by _get_connector_type_and_device and _check_device_props."""
+    device_name = asset["properties"]["deviceRef"]["deviceName"]
+    endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
+    add_device_get_call(
+        mocked_responses,
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        endpoint_name=endpoint_name,
+        endpoint_type=connector_type,
+    )
+
+
+def _stream_metadata(connector_type: str, stream_schema=None, supported=("Mqtt",)) -> dict:
+    """Build a connector metadata payload for the generalized stream path."""
+    return {
+        "inboundEndpoints": [{
+            "endpointType": f"Microsoft.{connector_type}",
+            "streams": {
+                "streamConfigurationSchema": stream_schema,
+                "destinations": {"supportedDestinations": list(supported)},
+            },
+        }]
+    }
+
+
+def _register_asset_and_device_get(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    connector_type: str,
+) -> None:
+    """Register the single asset GET + device GET used by the generalized front-door
+    (self.show + _get_connector_type_and_device)."""
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_streams(
+        mocked_responses, asset, namespace_name, resource_group_name, connector_type
+    )
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_stream (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_stream_config", [False, True])
+@pytest.mark.parametrize("replace, pre_existing", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_add_namespace_asset_stream_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_stream_config: bool,
+    replace: bool,
+    pre_existing: bool,
+):
+    asset_name = "gen-asset"
+    stream_name = f"stream-{generate_random_string()}"
+    connector_type = "Custom.Test"
+
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    stream_config_json = json.dumps({
+        "streamConfiguration": {"snapshotsPerSecond": 5},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "t/test"}}],
+    })
+
+    existing_streams = [generate_stream(stream_name=stream_name)] if pre_existing else []
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=existing_streams,
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    if has_stream_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value=_stream_metadata(connector_type),
+        )
+
+    updated_asset = deepcopy(asset)
+    updated_asset["properties"]["streams"] = [
+        {"name": stream_name, "streamConfiguration": None, "destinations": [], "typeRef": None}
+    ]
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        replace=replace,
+        stream_config=stream_config_json if has_stream_config else None,
+        wait_sec=0,
+    )
+
+    assert result["name"] == stream_name
+
+
+def test_add_namespace_asset_stream_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    stream_name = "existing-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[generate_stream(stream_name=stream_name)],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            replace=False,
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_stream_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on add should return a blank template wrapped with connectorType."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(
+            connector_type,
+            stream_schema={
+                "type": "object",
+                "properties": {"snapshotsPerSecond": {"type": "integer", "default": 1}},
+            },
+        ),
+    )
+
+    result = add_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name="new-stream",
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    stream_cfg = result["streamConfig"]
+    assert "streamConfiguration" in stream_cfg
+    dests = stream_cfg["destinations"]
+    assert any(d["target"] == "Mqtt" for d in dests)
+
+
+def test_add_namespace_asset_stream_generalized_show_template_schema(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=schema returns the connector schema structure (type/default/constraints)."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(
+            connector_type,
+            stream_schema={
+                "type": "object",
+                "properties": {
+                    "snapshotsPerSecond": {"type": "integer", "default": 1, "minimum": 0},
+                },
+            },
+        ),
+    )
+
+    result = add_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name="new-stream",
+        show_template="schema",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    stream_cfg = result["streamConfig"]["streamConfiguration"]
+    sps = (
+        stream_cfg["properties"]["snapshotsPerSecond"]
+        if "properties" in stream_cfg else stream_cfg["snapshotsPerSecond"]
+    )
+    assert sps["type"] == "integer"
+    assert sps["default"] == 1
+
+
+def test_add_namespace_asset_stream_generalized_show_template_with_config_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """--show-template and --stream-config are mutually exclusive."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="cannot be used together"):
+        add_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name="new-stream",
+            show_template="config",
+            stream_config=json.dumps({"streamConfiguration": {"snapshotsPerSecond": 5}}),
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_stream_generalized_unsupported_destination_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """A destination target not in the connector's supported set is rejected."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(connector_type, supported=("Mqtt",)),
+    )
+
+    bad_config = json.dumps({
+        "destinations": [{"target": "BrokerStateStore", "configuration": {"key": "cache"}}],
+    })
+
+    with pytest.raises(InvalidArgumentValueError, match="not supported for streams"):
+        add_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name="new-stream",
+            stream_config=bad_config,
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_stream_generalized_connector_type_mismatch_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """A --show-template output generated for a different connector type is rejected."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mismatched_config = json.dumps({
+        "connectorType": "Microsoft.OpcUa",
+        "streamConfig": {"streamConfiguration": {"snapshotsPerSecond": 5}},
+    })
+
+    with pytest.raises(InvalidArgumentValueError, match="does not match asset connectorType"):
+        add_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name="new-stream",
+            stream_config=mismatched_config,
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_namespace_asset_stream (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_namespace_asset_stream_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 1}),
+        "destinations": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+
+    stream_config_json = json.dumps({
+        "streamConfiguration": {"snapshotsPerSecond": 10},
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}],
+    })
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(connector_type),
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_stream = deepcopy(existing_stream)
+    updated_stream["streamConfiguration"] = json.dumps({"snapshotsPerSecond": 10})
+    updated_stream["destinations"] = [{"target": "Mqtt", "configuration": {"topic": "updated/topic"}}]
+    updated_asset["properties"]["streams"] = [updated_stream]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        stream_config=stream_config_json,
+        wait_sec=0,
+    )
+
+    assert result["name"] == stream_name
+    assert json.loads(result["streamConfiguration"])["snapshotsPerSecond"] == 10
+
+
+def test_update_namespace_asset_stream_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on update should pre-fill existing ARM values into the template."""
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 3, "bufferSize": 5}),
+        "destinations": [{"target": "Mqtt", "configuration": {"topic": "live/topic", "qos": "Qos1"}}],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(
+            connector_type,
+            stream_schema={
+                "type": "object",
+                "properties": {
+                    "snapshotsPerSecond": {"type": "integer", "default": 1},
+                    "bufferSize": {"type": "integer", "default": 10},
+                },
+            },
+        ),
+    )
+
+    result = update_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    stream_cfg = result["streamConfig"]["streamConfiguration"]
+    assert stream_cfg["snapshotsPerSecond"] == 3
+    assert stream_cfg["bufferSize"] == 5
+    dests = result["streamConfig"]["destinations"]
+    mqtt_dest = next((d for d in dests if d["target"] == "Mqtt"), None)
+    assert mqtt_dest is not None
+    assert mqtt_dest["configuration"]["topic"] == "live/topic"
+
+
+def test_update_namespace_asset_stream_generalized_raises_if_not_found(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="not found"):
+        update_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name="missing-stream",
+            show_template="config",
+            wait_sec=0,
+        )
+
+
+def test_update_namespace_asset_stream_generalized_type_ref(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """Updating only --type-ref updates the stream typeRef without touching config."""
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 1}),
+        "destinations": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_stream = deepcopy(existing_stream)
+    updated_stream["typeRef"] = "myTypeRef"
+    updated_asset["properties"]["streams"] = [updated_stream]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        type_ref="myTypeRef",
+        wait_sec=0,
+    )
+
+    assert result["name"] == stream_name
+    assert result["typeRef"] == "myTypeRef"
+
+
+def test_update_namespace_asset_stream_generalized_show_template_schema(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=schema on update returns the connector schema (not pre-filled with values)."""
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 3}),
+        "destinations": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_stream_metadata(
+            connector_type,
+            stream_schema={
+                "type": "object",
+                "properties": {"snapshotsPerSecond": {"type": "integer", "default": 1, "minimum": 0}},
+            },
+        ),
+    )
+
+    result = update_namespace_asset_stream(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        stream_name=stream_name,
+        show_template="schema",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    stream_cfg = result["streamConfig"]["streamConfiguration"]
+    sps = (
+        stream_cfg["properties"]["snapshotsPerSecond"]
+        if "properties" in stream_cfg else stream_cfg["snapshotsPerSecond"]
+    )
+    assert sps["type"] == "integer"
+    assert sps["default"] == 1
+
+
+def test_update_namespace_asset_stream_generalized_show_template_with_config_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """--show-template config and --stream-config are mutually exclusive on update."""
+    asset_name = "gen-asset"
+    stream_name = "sensor-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_stream = {
+        "name": stream_name,
+        "streamConfiguration": json.dumps({"snapshotsPerSecond": 3}),
+        "destinations": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[existing_stream],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="cannot be used together"):
+        update_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            show_template="config",
+            stream_config=json.dumps({"streamConfiguration": {"snapshotsPerSecond": 5}}),
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_stream_generalized_invalid_config_shape_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """--stream-config without 'streamConfiguration' or 'destinations' keys is rejected."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=[],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="must be a JSON object with"):
+        add_namespace_asset_stream(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name="new-stream",
+            stream_config=json.dumps({"foo": "bar"}),
+            wait_sec=0,
+        )


### PR DESCRIPTION
- Adds a connector-agnostic `az iot ops ns asset stream` command group (add, update, show, list, remove, export, import) that auto-detects the connector type from the asset's device endpoint.
- Supports `--stream-config` (inline JSON or file) and `--show-template` config|schema for connector-specific configuration discovery and validation.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
