### PR TITLE
feat: generalize ns asset mgmt-group and mgmt-action commands

### DIFF
--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -388,6 +388,30 @@ def load_iotops_commands(self, _):
         cmd_group.command("list", "list_namespace_asset_event_group_events", is_preview=True)
         cmd_group.command("remove", "remove_namespace_asset_event_group_event", is_preview=True)
 
+    # generalized management group (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset mgmt-group",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_management_group", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_management_group", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_management_group", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_management_groups", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_management_group", is_preview=True)
+        cmd_group.show_command("show", "show_namespace_asset_management_group", is_preview=True)
+        cmd_group.command("update", "update_namespace_asset_management_group", is_preview=True)
+
+    # generalized management group action (connector-agnostic)
+    with self.command_group(
+        "iot ops ns asset mgmt-action",
+        command_type=namespace_resource_ops,
+    ) as cmd_group:
+        cmd_group.command("add", "add_namespace_asset_management_group_action", is_preview=True)
+        cmd_group.command("export", "export_namespace_asset_management_group_action", is_preview=True)
+        cmd_group.command("import", "import_namespace_asset_management_group_action", is_preview=True)
+        cmd_group.command("list", "list_namespace_asset_management_group_actions", is_preview=True)
+        cmd_group.command("remove", "remove_namespace_asset_management_group_action", is_preview=True)
+
     # dataset
     for asset_type in ["custom", "opcua", "rest", "sse", "mqtt"]:
         with self.command_group(

--- a/azext_edge/edge/commands_namespaces.py
+++ b/azext_edge/edge/commands_namespaces.py
@@ -3277,3 +3277,112 @@ def add_namespace_asset_event_group_event(
 
 export_namespace_asset_event_group_event = _make_event_export_func("export_event_group_events")
 import_namespace_asset_event_group_event = _make_event_import_func("import_event_group_events")
+
+
+# GENERALIZED MANAGEMENT GROUP COMMANDS
+
+
+def add_namespace_asset_management_group(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    data_source: Optional[str] = None,
+    default_topic: Optional[str] = None,
+    default_timeout: Optional[int] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    mgmt_group_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).add_management_group_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        data_source=data_source,
+        default_topic=default_topic,
+        default_timeout=default_timeout,
+        type_ref=type_ref,
+        replace=replace,
+        mgmt_group_config=mgmt_group_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+def update_namespace_asset_management_group(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    data_source: Optional[str] = None,
+    default_topic: Optional[str] = None,
+    default_timeout: Optional[int] = None,
+    type_ref: Optional[str] = None,
+    mgmt_group_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> dict:
+    return NamespaceAssets(cmd).update_management_group_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        data_source=data_source,
+        default_topic=default_topic,
+        default_timeout=default_timeout,
+        type_ref=type_ref,
+        mgmt_group_config=mgmt_group_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_management_group = _make_export_func("export_management_groups")
+import_namespace_asset_management_group = _make_import_func("import_management_groups")
+
+
+# GENERALIZED MANAGEMENT GROUP ACTION COMMANDS
+
+
+def add_namespace_asset_management_group_action(
+    cmd,
+    asset_name: str,
+    instance_name: str,
+    instance_resource_group: str,
+    group_name: str,
+    action_name: str,
+    target_uri: Optional[str] = None,
+    topic: Optional[str] = None,
+    action_type: Optional[str] = None,
+    timeout: Optional[int] = None,
+    type_ref: Optional[str] = None,
+    replace: Optional[bool] = False,
+    action_config: Optional[str] = None,
+    show_template: Optional[str] = None,
+    **kwargs
+) -> List[dict]:
+    return NamespaceAssets(cmd).add_management_group_action_generalized(
+        asset_name=asset_name,
+        instance_name=instance_name,
+        instance_resource_group=instance_resource_group,
+        group_name=group_name,
+        action_name=action_name,
+        target_uri=target_uri,
+        topic=topic,
+        action_type=action_type,
+        timeout=timeout,
+        type_ref=type_ref,
+        replace=replace,
+        action_config=action_config,
+        show_template=show_template,
+        **kwargs
+    )
+
+
+export_namespace_asset_management_group_action = _make_mgmt_action_export_func("export_management_group_actions")
+import_namespace_asset_management_group_action = _make_mgmt_action_import_func("import_management_group_actions")

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -49,7 +49,7 @@ from .providers.orchestration.common import (
     TlsKeyAlgo,
     TlsKeyRotation,
 )
-from .providers.adr.common import EndpointTemplateMode, FileType
+from .providers.adr.common import ActionType, EndpointTemplateMode, FileType
 
 
 def load_iotops_arguments(self, _):
@@ -2487,6 +2487,206 @@ def load_iotops_arguments(self, _):
             "replace",
             options_list=["--replace"],
             help="Replace existing events that share a name with an imported event.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-group") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--name", "-n"],
+            help="Management group name.",
+        )
+        context.argument(
+            "data_source",
+            options_list=["--data-source", "--ds"],
+            help="Data source for the management group.",
+        )
+        context.argument(
+            "default_topic",
+            options_list=["--default-topic", "--dt"],
+            help="Default topic for management group actions.",
+        )
+        context.argument(
+            "default_timeout",
+            options_list=["--default-timeout", "--dto"],
+            help="Default timeout in seconds for management group actions. Minimum: 0",
+            type=int,
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "mgmt_group_config",
+            options_list=["--mgmt-group-config", "--mgc"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific management-group configuration. The accepted key is "
+            "'managementGroupConfiguration' (connector-specific config object). Use --show-template "
+            "to discover the supported keys and schema for the asset's connector type. Cannot be "
+            "combined with --show-template. For non-OPC UA connectors, a connector template must "
+            "exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter management-group configuration template for the asset's connector "
+            "type and exit without modifying the management group. The connector type is read from "
+            "the existing asset. config: fields shown with their default values (null if no default); "
+            "output is directly usable as --mgmt-group-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-group add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the management group if another management group with the same name is "
+            "already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-group export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type([FileType.json.value, FileType.yaml.value], default=FileType.json.value),
+            help="Export file format (JSON or YAML).",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Output directory for export.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the local file if present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-group import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON or YAML).",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing management groups that share a name with an imported management group.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-action") as context:
+        context.argument(
+            "asset_name",
+            options_list=["--asset", "-a"],
+            help="Asset name.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--group"],
+            help="Management group name.",
+        )
+        context.argument(
+            "action_name",
+            options_list=["--name", "-n"],
+            help="Action name.",
+        )
+        context.argument(
+            "target_uri",
+            options_list=["--target-uri", "--uri"],
+            help="Target URI for the management action.",
+        )
+        context.argument(
+            "topic",
+            options_list=["--topic", "-t"],
+            help="Topic override for this specific action.",
+        )
+        context.argument(
+            "action_type",
+            options_list=["--action-type", "--at"],
+            help="Type of management action.",
+            default=ActionType.call.value,
+            arg_type=get_enum_type(ActionType),
+        )
+        context.argument(
+            "timeout",
+            options_list=["--timeout", "--to"],
+            help="Timeout in seconds for this specific action. Minimum: 0",
+            type=int,
+        )
+        context.argument(
+            "type_ref",
+            options_list=["--type-ref", "--tr"],
+            help="Type definition ID or URI.",
+        )
+        context.argument(
+            "action_config",
+            options_list=["--action-config", "--ac"],
+            help="Inline JSON string or path to a JSON/YAML file (.json, .yaml, .yml) containing "
+            "connector-specific action configuration. The accepted key is 'actionConfiguration' "
+            "(connector-specific config object). Use --show-template to discover the supported keys "
+            "and schema for the asset's connector type. Cannot be combined with --show-template. "
+            "For non-OPC UA connectors, a connector template must exist in the instance.",
+        )
+        context.argument(
+            "show_template",
+            options_list=["--show-template"],
+            arg_type=get_enum_type(EndpointTemplateMode),
+            help="Show a starter action configuration template for the asset's connector type and "
+            "exit without modifying the action. The connector type is read from the existing asset. "
+            "config: fields shown with their default values (null if no default); output is directly "
+            "usable as --action-config input. "
+            "schema: every field includes type, default, and constraints (min, max, enum, pattern). "
+            "Draft-07 $ref pointers (#/definitions/...) are resolved inline in both modes.",
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-action add") as context:
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the action if another action with the same name is already present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-action export") as context:
+        context.argument(
+            "extension",
+            options_list=["--format", "-f"],
+            arg_type=get_enum_type(FileType, default=FileType.json.value),
+            help="Export file format.",
+        )
+        context.argument(
+            "output_dir",
+            options_list=["--output-dir", "--od"],
+            help="Output directory for export.",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace the local file if present.",
+            arg_type=get_three_state_flag(),
+        )
+
+    with self.argument_context("iot ops ns asset mgmt-action import") as context:
+        context.argument(
+            "file_path",
+            options_list=["--input-file", "--if"],
+            help="Path to import file (JSON, YAML, or CSV).",
+        )
+        context.argument(
+            "replace",
+            options_list=["--replace"],
+            help="Replace existing actions that share a name with an imported action.",
             arg_type=get_three_state_flag(),
         )
 

--- a/azext_edge/edge/providers/adr/_help.py
+++ b/azext_edge/edge/providers/adr/_help.py
@@ -2915,6 +2915,260 @@ def load_iotops_adr_help():
     """
 
     helps[
+        "iot ops ns asset mgmt-group"
+    ] = """
+        type: group
+        short-summary: Manage management groups for namespaced assets in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --mgmt-group-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group add"
+    ] = """
+        type: command
+        short-summary: Add a management group to a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration can be supplied via --mgmt-group-config.
+            Use --show-template to discover the supported config schema. For non-OPC UA connectors,
+            a connector template must exist in the instance.
+
+        examples:
+        - name: Add a basic management group to any asset type
+          text: >
+            az iot ops ns asset mgmt-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls
+
+        - name: Show the management group config template for the asset's connector type
+          text: >
+            az iot ops ns asset mgmt-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --show-template config
+
+        - name: Add a management group with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset mgmt-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls
+            --mgmt-group-config '{"managementGroupConfiguration": {"maxConcurrentRequests": 5}}'
+
+        - name: Add a management group with configuration from a file
+          text: >
+            az iot ops ns asset mgmt-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --mgmt-group-config ./mgmt_group_config.json
+
+        - name: Replace an existing management group
+          text: >
+            az iot ops ns asset mgmt-group add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --replace
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group update"
+    ] = """
+        type: command
+        short-summary: Update a management group for a namespaced asset in an IoT Operations instance.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Use --mgmt-group-config to supply connector-specific configuration.
+            Use --show-template config to see current management group values pre-filled in the full schema
+            structure (ready to edit and pass back via --mgmt-group-config).
+            Use --show-template schema to see the full connector schema with types and constraints.
+
+        examples:
+        - name: Show current management group config pre-filled with existing values (for editing before update)
+          text: >
+            az iot ops ns asset mgmt-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --show-template config
+
+        - name: Show the management group config schema with types and constraints
+          text: >
+            az iot ops ns asset mgmt-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --show-template schema
+
+        - name: Update management group configuration from inline JSON
+          text: >
+            az iot ops ns asset mgmt-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls
+            --mgmt-group-config '{"managementGroupConfiguration": {"maxConcurrentRequests": 10}}'
+
+        - name: Update management group data source
+          text: >
+            az iot ops ns asset mgmt-group update --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls --data-source "boiler.controls"
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group list"
+    ] = """
+        type: command
+        short-summary: List management groups for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: List all management groups for an asset
+          text: >
+            az iot ops ns asset mgmt-group list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group remove"
+    ] = """
+        type: command
+        short-summary: Remove a management group from a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Remove a management group from an asset
+          text: >
+            az iot ops ns asset mgmt-group remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group show"
+    ] = """
+        type: command
+        short-summary: Show details of a management group for a namespaced asset in an IoT Operations instance.
+
+        examples:
+        - name: Show management group details
+          text: >
+            az iot ops ns asset mgmt-group show --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --name boilerControls
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group export"
+    ] = """
+        type: command
+        short-summary: Export management groups to file.
+
+        examples:
+        - name: Export management groups to JSON
+          text: >
+            az iot ops ns asset mgmt-group export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup
+    """
+
+    helps[
+        "iot ops ns asset mgmt-group import"
+    ] = """
+        type: command
+        short-summary: Import management groups from file.
+
+        examples:
+        - name: Import management groups from a JSON file
+          text: >
+            az iot ops ns asset mgmt-group import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --input-file ./management_groups.json
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action"
+    ] = """
+        type: group
+        short-summary: Manage actions for asset management groups in IoT Operations namespaces.
+        long-summary: >
+            The connector type is detected automatically from the existing asset.
+            For connector-specific parameters use --action-config (inline JSON or file).
+            Use --show-template to discover the supported configuration schema for the asset's connector type.
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action add"
+    ] = """
+        type: command
+        short-summary: Add an action to an asset management group in an IoT Operations namespace.
+        long-summary: >
+            The connector type is detected from the asset's device endpoint.
+            Connector-specific configuration can be supplied via --action-config. Use --show-template
+            to discover the supported config schema. For non-OPC UA connectors, a connector template
+            must exist in the instance.
+
+        examples:
+        - name: Add a basic action to any asset type
+          text: >
+            az iot ops ns asset mgmt-action add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart --target-uri "opc.tcp://boiler/restart"
+
+        - name: Show the action config template for the asset's connector type
+          text: >
+            az iot ops ns asset mgmt-action add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart --show-template config
+
+        - name: Add an action with connector-specific configuration from inline JSON
+          text: >
+            az iot ops ns asset mgmt-action add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart --target-uri "opc.tcp://boiler/restart"
+            --action-config '{"actionConfiguration": {"retryCount": 3}}'
+
+        - name: Add an action with configuration from a file
+          text: >
+            az iot ops ns asset mgmt-action add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart --target-uri "opc.tcp://boiler/restart"
+            --action-config ./action_config.json
+
+        - name: Replace an existing action
+          text: >
+            az iot ops ns asset mgmt-action add --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart --target-uri "opc.tcp://boiler/restart"
+            --replace
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action list"
+    ] = """
+        type: command
+        short-summary: List actions for an asset management group in an IoT Operations namespace.
+
+        examples:
+        - name: List all actions for a management group
+          text: >
+            az iot ops ns asset mgmt-action list --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action remove"
+    ] = """
+        type: command
+        short-summary: Remove an action from an asset management group in an IoT Operations namespace.
+
+        examples:
+        - name: Remove an action from a management group
+          text: >
+            az iot ops ns asset mgmt-action remove --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --name restart
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action export"
+    ] = """
+        type: command
+        short-summary: Export management group actions to file.
+
+        examples:
+        - name: Export actions to JSON
+          text: >
+            az iot ops ns asset mgmt-action export --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls
+    """
+
+    helps[
+        "iot ops ns asset mgmt-action import"
+    ] = """
+        type: command
+        short-summary: Import management group actions from file.
+
+        examples:
+        - name: Import actions from a JSON file
+          text: >
+            az iot ops ns asset mgmt-action import --asset myasset --instance myInstance
+            -g myInstanceResourceGroup --group boilerControls --input-file ./actions.json
+    """
+
+    helps[
         "iot ops ns asset opcua dataset"
     ] = """
         type: group

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -3743,6 +3743,459 @@ class NamespaceAssets(Queryable):
             )
             return asset["properties"].get("streams", [])
 
+    # GENERALIZED MANAGEMENT GROUP / ACTION HELPERS AND METHODS
+    def _handle_management_show_template(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        template_mode: str,
+        config: Optional[str],
+        *,
+        is_action: bool,
+    ) -> dict:
+        """Return a management group/action config or schema template for --show-template and exit early.
+
+        Discovers the relevant *ConfigurationSchema from connector metadata and returns a slimmed
+        template. Management groups and actions have no destinations in the metadata schema. OPC UA
+        uses bundled metadata; all other types require a connector template in the instance.
+        """
+        from .helpers import _slim_schema, _consolidate_warnings
+        from .common import EndpointTemplateMode
+
+        config_arg = "--action-config" if is_action else "--mgmt-group-config"
+        label = "action" if is_action else "management group"
+        config_key = "actionConfiguration" if is_action else "managementGroupConfiguration"
+        result_key = "actionConfig" if is_action else "mgmtGroupConfig"
+
+        if config:
+            raise InvalidArgumentValueError(
+                f"--show-template and {config_arg} cannot be used together. "
+                f"--show-template displays the template and exits without modifying the {label}."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        mg_section = endpoint.get("managementGroups", {})
+        if is_action:
+            schema = mg_section.get("managementGroupActions", {}).get("actionConfigurationSchema")
+        else:
+            schema = mg_section.get("managementGroupConfigurationSchema")
+
+        config_template: dict = {}
+        all_warnings: List[str] = []
+
+        if schema:
+            warnings: List[str] = []
+            slimmed = _slim_schema(schema, mode=template_mode, _warnings=warnings)
+            all_warnings.extend(warnings)
+            if template_mode == EndpointTemplateMode.SCHEMA.value and isinstance(slimmed, dict):
+                slimmed.pop("$id", None)
+            config_template[config_key] = slimmed
+
+        for w in _consolidate_warnings(all_warnings):
+            logger.warning(w)
+
+        return {"connectorType": connector_type, result_key: config_template}
+
+    def _load_and_validate_management_config(
+        self,
+        config: str,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        *,
+        is_action: bool,
+    ) -> dict:
+        """Load management group/action config from file/inline JSON, validate against the connector
+        schema, and return ARM-ready values.
+
+        Input JSON is expected to be the 'mgmtGroupConfig'/'actionConfig' dict (output of
+        --show-template), e.g. ``{"managementGroupConfiguration": {...}}``, or the full
+        --show-template output with 'connectorType' and the config wrapper key, which is
+        auto-unwrapped.
+
+        Returns a dict with the serialized configuration JSON string (if present).
+        """
+        from .helpers import strip_nulls as _strip_nulls
+
+        config_arg = "--action-config" if is_action else "--mgmt-group-config"
+        config_type = "action" if is_action else "management group"
+        config_key = "actionConfiguration" if is_action else "managementGroupConfiguration"
+        result_key = "actionConfig" if is_action else "mgmtGroupConfig"
+
+        raw = process_additional_configuration(
+            additional_configuration=config,
+            config_type=config_type,
+        )
+        parsed = json.loads(raw)
+
+        if isinstance(parsed, dict) and result_key in parsed:
+            provided = parsed.get("connectorType")
+            if provided and connector_type and provided.lower() != connector_type.lower():
+                raise InvalidArgumentValueError(
+                    f"Config connectorType '{provided}' does not match asset connectorType '{connector_type}'."
+                )
+            parsed = parsed[result_key]
+
+        if not isinstance(parsed, dict) or config_key not in parsed:
+            raise InvalidArgumentValueError(
+                f"{config_arg} must be a JSON object with a '{config_key}' key."
+            )
+
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        mg_section = endpoint.get("managementGroups", {}) if endpoint else {}
+        if is_action:
+            schema_owner = mg_section.get("managementGroupActions", {}) if mg_section else {}
+            schema_key = "actionConfigurationSchema"
+        else:
+            schema_owner = mg_section
+            schema_key = "managementGroupConfigurationSchema"
+
+        result = {}
+
+        config_data_raw = parsed.get(config_key)
+        if config_data_raw is not None:
+            config_data = _strip_nulls(config_data_raw)
+            schema = schema_owner.get(schema_key) if schema_owner else None
+            if schema:
+                from ...util.schema_validation import check_json_schema, validate_data_against_schema
+                skip_reason = check_json_schema(schema)
+                if skip_reason:
+                    logger.warning("Skipping %s validation: %s", config_key, skip_reason)
+                else:
+                    validate_data_against_schema(schema, config_data, name=config_key)
+            result[config_key] = json.dumps(config_data)
+
+        return result
+
+    def add_management_group_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        data_source: Optional[str] = None,
+        default_topic: Optional[str] = None,
+        default_timeout: Optional[int] = None,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        mgmt_group_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized add-management-group that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --mgmt-group-config for
+        JSON or file-based connector-specific management-group configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type, device = self._get_connector_type_and_device(asset)
+
+        if show_template:
+            return self._handle_management_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                config=mgmt_group_config,
+                is_action=False,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+            asset=asset,
+            device=device,
+        )
+
+        og_mgmt_groups = asset["properties"].get("managementGroups", [])
+        remaining_mgmt_groups = [mgmt for mgmt in og_mgmt_groups if mgmt["name"] != group_name]
+        if len(remaining_mgmt_groups) < len(og_mgmt_groups) and not replace:
+            raise InvalidArgumentValueError(
+                f"Management group '{group_name}' already exists in asset '{asset_name}'. "
+                "Use --replace to overwrite the existing management group."
+            )
+
+        new_mgmt_group: dict = {
+            "name": group_name,
+            "defaultTopic": default_topic,
+            "defaultTimeoutInSeconds": default_timeout,
+            "managementGroupConfiguration": None,
+            "typeRef": type_ref,
+            "actions": [],
+        }
+        if data_source:
+            new_mgmt_group["dataSource"] = data_source
+
+        if mgmt_group_config:
+            config_result = self._load_and_validate_management_config(
+                config=mgmt_group_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                is_action=False,
+            )
+            if "managementGroupConfiguration" in config_result:
+                new_mgmt_group["managementGroupConfiguration"] = config_result["managementGroupConfiguration"]
+
+        remaining_mgmt_groups.append(new_mgmt_group)
+        update_payload = {"properties": {"managementGroups": remaining_mgmt_groups}}
+
+        with console.status(f"Adding management group {group_name} to asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="managementGroups")
+
+    def update_management_group_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        data_source: Optional[str] = None,
+        default_topic: Optional[str] = None,
+        default_timeout: Optional[int] = None,
+        type_ref: Optional[str] = None,
+        mgmt_group_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """Generalized update-management-group that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --mgmt-group-config for
+        JSON or file-based connector-specific management-group configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type, device = self._get_connector_type_and_device(asset)
+
+        if show_template:
+            from .common import EndpointTemplateMode
+            template_mode = show_template.lower()
+            if template_mode == EndpointTemplateMode.CONFIG.value:
+                if mgmt_group_config:
+                    raise InvalidArgumentValueError(
+                        "--show-template and --mgmt-group-config cannot be used together. "
+                        "--show-template displays the template and exits without modifying the management group."
+                    )
+                mgs_existing = asset["properties"].get("managementGroups", [])
+                existing = next((d for d in mgs_existing if d["name"] == group_name), None)
+                if existing is None:
+                    raise InvalidArgumentValueError(
+                        f"Management group '{group_name}' not found in asset '{asset_name}'."
+                    )
+                template_result = self._handle_management_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    config=None,
+                    is_action=False,
+                )
+                mg_config_tmpl = template_result.get("mgmtGroupConfig", {})
+                raw_config = existing.get("managementGroupConfiguration")
+                if raw_config:
+                    existing_config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+                    tmpl_c = mg_config_tmpl.get("managementGroupConfiguration")
+                    mg_config_tmpl["managementGroupConfiguration"] = (
+                        _deep_merge_template(tmpl_c, existing_config)
+                        if isinstance(tmpl_c, dict)
+                        else existing_config
+                    )
+                return {"connectorType": connector_type, "mgmtGroupConfig": mg_config_tmpl}
+            else:
+                return self._handle_management_show_template(
+                    connector_type=connector_type,
+                    instance_name=instance_name,
+                    instance_resource_group=instance_resource_group,
+                    template_mode=template_mode,
+                    config=mgmt_group_config,
+                    is_action=False,
+                )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+            asset=asset,
+            device=device,
+        )
+
+        mgmt_groups = asset["properties"].get("managementGroups", [])
+        group_list = [mgmt for mgmt in mgmt_groups if mgmt["name"] == group_name]
+        if not group_list:
+            raise InvalidArgumentValueError(
+                f"Management group '{group_name}' not found in asset '{asset_name}'."
+            )
+        group = group_list[0]
+
+        if mgmt_group_config is not None:
+            config_result = self._load_and_validate_management_config(
+                config=mgmt_group_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                is_action=False,
+            )
+            if "managementGroupConfiguration" in config_result:
+                group["managementGroupConfiguration"] = config_result["managementGroupConfiguration"]
+
+        if default_topic == "":
+            group.pop("defaultTopic", None)
+        elif default_topic:
+            group["defaultTopic"] = default_topic
+        if default_timeout is not None:
+            group["defaultTimeoutInSeconds"] = default_timeout
+        if data_source is not None:
+            group["dataSource"] = data_source
+        if type_ref is not None:
+            group["typeRef"] = type_ref
+
+        update_payload = {"properties": {"managementGroups": mgmt_groups}}
+        with console.status(f"Updating management group {group_name} in asset {asset_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="managementGroups")
+
+    def add_management_group_action_generalized(
+        self,
+        asset_name: str,
+        instance_name: str,
+        instance_resource_group: str,
+        group_name: str,
+        action_name: str,
+        target_uri: Optional[str] = None,
+        topic: Optional[str] = None,
+        action_type: Optional[str] = None,
+        timeout: Optional[int] = None,
+        type_ref: Optional[str] = None,
+        replace: bool = False,
+        action_config: Optional[str] = None,
+        show_template: Optional[str] = None,
+        **kwargs,
+    ) -> List[dict]:
+        """Generalized add-management-action that detects connector type from the asset.
+
+        Supports --show-template for config/schema discovery and --action-config for
+        JSON or file-based connector-specific action configuration. For non-OPC UA
+        connectors, a connector template must exist in the instance.
+        """
+        asset = self.show(
+            asset_name=asset_name,
+            instance_name=instance_name,
+            resource_group=instance_resource_group,
+        )
+        connector_type, device = self._get_connector_type_and_device(asset)
+
+        if show_template:
+            return self._handle_management_show_template(
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                template_mode=show_template.lower(),
+                config=action_config,
+                is_action=True,
+            )
+
+        _, namespace = self._check_device_props(
+            instance_resource_group=instance_resource_group,
+            instance_name=instance_name,
+            asset_type=connector_type,
+            asset_name=asset_name,
+            asset=asset,
+            device=device,
+        )
+
+        mgmt_group = _get_sub_property(asset, group_name, property_key="managementGroups")
+        actions = mgmt_group.get("actions", [])
+        unmatched_actions = [action for action in actions if action["name"] != action_name]
+        if len(unmatched_actions) < len(actions) and not replace:
+            raise InvalidArgumentValueError(
+                f"Action '{action_name}' already exists in management group '{group_name}' "
+                f"of asset '{asset_name}'. Use --replace to overwrite the existing action."
+            )
+
+        action: dict = {
+            "name": action_name,
+            "targetUri": target_uri,
+            "topic": topic,
+            "actionType": action_type,
+            "timeoutInSeconds": timeout,
+            "typeRef": type_ref,
+        }
+
+        if action_config:
+            config_result = self._load_and_validate_management_config(
+                config=action_config,
+                connector_type=connector_type,
+                instance_name=instance_name,
+                instance_resource_group=instance_resource_group,
+                is_action=True,
+            )
+            if "actionConfiguration" in config_result:
+                action["actionConfiguration"] = config_result["actionConfiguration"]
+
+        unmatched_actions.append(action)
+        mgmt_group["actions"] = unmatched_actions
+
+        update_payload = {"properties": {"managementGroups": asset["properties"]["managementGroups"]}}
+        with console.status(f"Adding action {action_name} to management group {group_name}..."):
+            poller = self.ops.begin_update(
+                resource_group_name=namespace["resource_group"],
+                namespace_name=namespace["name"],
+                asset_name=asset_name,
+                properties=update_payload,
+            )
+            wait_for_terminal_state(poller, **kwargs)
+            asset = self.show(
+                asset_name=asset_name,
+                namespace_name=namespace["name"],
+                resource_group=namespace["resource_group"],
+            )
+            return _get_sub_property(asset, group_name, property_key="managementGroups")["actions"]
+
     # Management Groups - allowed for opcua, onvif, and custom assets
     def add_management_group(
         self,

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -4449,9 +4449,9 @@ class NamespaceAssets(Queryable):
             group["defaultTopic"] = default_topic
         if default_timeout is not None:
             group["defaultTimeoutInSeconds"] = default_timeout
-        if data_source is not None:
+        if data_source:
             group["dataSource"] = data_source
-        if type_ref is not None:
+        if type_ref:
             group["typeRef"] = type_ref
 
         update_payload = {"properties": {"managementGroups": mgmt_groups}}

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_export_import_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_export_import_int.py
@@ -202,3 +202,186 @@ def test_namespace_asset_mgmt_action_export_import(
                 import_cmd_base=f"{cmd_prefix} import {cmd_args}",
                 field_name="targetUri", item_names=act_names,
             )
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) export / import round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("asset_type, endpoint_type, endpoint_address", [
+    ("custom", "custom", "http://192.168.1.100:8000/custom/service"),
+    ("opcua", "opcua", "opc.tcp://opcuaserver.local:4840"),
+])
+def test_namespace_asset_mgmt_group_export_import_generalized(
+    require_namespace_init_session, tracked_resources: List[str], tracked_files: List[str], tmp_path,
+    shared_device: str, endpoint_cache: dict,
+    asset_type: str, endpoint_type: str, endpoint_address: str
+):
+    """Test management-group export/import via the generalized (connector-agnostic) command group."""
+    instance_name = require_namespace_init_session["instanceName"]
+    resource_group = require_namespace_init_session["resourceGroup"]
+    output_dir = str(tmp_path)
+    asset_name = f"{asset_type}-{generate_random_string(8, force_lower=True)}"
+    mg_name_1 = f"mg1-{generate_random_string(6, force_lower=True)}"
+    mg_name_2 = f"mg2-{generate_random_string(6, force_lower=True)}"
+    mg_names = [mg_name_1, mg_name_2]
+    field_values = {n: f"mgmt/{n}" for n in mg_names}
+
+    with TestLog(
+        f"test_namespace_asset_mgmt_group_export_import_generalized[{asset_type}]", total_steps=7,
+    ) as log:
+
+        with log.step(1, "Ensure Device + Endpoint"):
+            device_name, endpoint_name = ensure_device_and_endpoint(
+                log, instance_name, resource_group, asset_type, endpoint_type,
+                endpoint_address, shared_device, endpoint_cache,
+            )
+
+        with log.step(2, f"Create {asset_type} Asset"):
+            log.run_command(
+                f"az iot ops ns asset {asset_type} create --name {asset_name} --instance {instance_name} "
+                f"-g {resource_group} --device {device_name} --endpoint {endpoint_name}",
+                tracked_resources=tracked_resources,
+            )
+
+        # Generalized command group — no connector type in the command path.
+        cmd_prefix = "az iot ops ns asset mgmt-group"
+        cmd_args = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
+
+        with log.step(3, "Add Management Groups"):
+            for name in mg_names:
+                log.run_command(
+                    f"{cmd_prefix} add {cmd_args} --name {name} --data-source mgmt/{name}"
+                )
+            result = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("2 mgmt-groups added", len(result) == 2, actual=len(result))
+
+        with log.step(4, "Export Management Groups (JSON)"):
+            export_result = log.run_command(f"{cmd_prefix} export {cmd_args} -f json --output-dir {output_dir}")
+            exported_file = validate_export_result(
+                log, export_result, "management_group_count", 2, "json", tracked_files,
+            )
+            with open(exported_file, 'r', encoding='utf-8') as f:
+                items = json.load(f)
+            verify_items_by_name(
+                log, items, mg_names, field_name="dataSource",
+                field_values=field_values, label="exported",
+            )
+
+        with log.step(5, "Remove Management Group & Verify"):
+            log.run_command(f"{cmd_prefix} remove {cmd_args} --name {mg_name_1}")
+            result = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("1 mgmt-group remains", len(result) == 1, actual=len(result))
+
+        with log.step(6, "Import Management Groups"):
+            imported = log.run_command(f"{cmd_prefix} import {cmd_args} --input-file {exported_file}")
+            verify_items_by_name(
+                log, imported, mg_names, field_name="dataSource",
+                field_values=field_values, label="imported",
+            )
+
+        with log.step(7, "Verify Final State"):
+            final = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("final count == 2", len(final) == 2, actual=len(final))
+
+
+@pytest.mark.parametrize("asset_type, endpoint_type, endpoint_address", [
+    ("custom", "custom", "http://192.168.1.100:8000/custom/service"),
+    ("opcua", "opcua", "opc.tcp://opcuaserver.local:4840"),
+])
+def test_namespace_asset_mgmt_action_export_import_generalized(
+    require_namespace_init_session, tracked_resources: List[str], tracked_files: List[str], tmp_path,
+    shared_device: str, endpoint_cache: dict, format_test_asset_cache: dict,
+    asset_type: str, endpoint_type: str, endpoint_address: str
+):
+    """Test management-action export/import via the generalized (connector-agnostic) command group."""
+    instance_name = require_namespace_init_session["instanceName"]
+    resource_group = require_namespace_init_session["resourceGroup"]
+    output_dir = str(tmp_path)
+    mgmt_group_name = f"mg-{generate_random_string(6, force_lower=True)}"
+    act_name_1 = f"a1-{generate_random_string(6, force_lower=True)}"
+    act_name_2 = f"a2-{generate_random_string(6, force_lower=True)}"
+    act_names = [act_name_1, act_name_2]
+    field_values = {n: f"mgmt/{n}" for n in act_names}
+
+    with TestLog(
+        f"test_namespace_asset_mgmt_action_export_import_generalized[{asset_type}]", total_steps=9,
+    ) as log:
+
+        with log.step(1, "Ensure Device + Endpoint"):
+            device_name, endpoint_name = ensure_device_and_endpoint(
+                log, instance_name, resource_group, asset_type, endpoint_type,
+                endpoint_address, shared_device, endpoint_cache,
+            )
+
+        with log.step(2, f"Ensure {asset_type} Asset + Create Mgmt Group"):
+            asset_name = ensure_asset_for_format_tests(
+                log, instance_name, resource_group, asset_type, device_name,
+                endpoint_name, tracked_resources, "mgmt", format_test_asset_cache,
+            )
+            # Create the parent management group via the generalized command group.
+            log.run_command(
+                f"az iot ops ns asset mgmt-group add --asset {asset_name} "
+                f"--instance {instance_name} -g {resource_group} --name {mgmt_group_name} "
+                f"--data-source mgmt/group1"
+            )
+
+        # Generalized command group — no connector type in the command path.
+        cmd_prefix = "az iot ops ns asset mgmt-action"
+        cmd_args = (
+            f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
+            f" --group {mgmt_group_name}"
+        )
+
+        with log.step(3, "Add Management Actions"):
+            add_tpl = f"{cmd_prefix} add {cmd_args} --name {{name}} --target-uri mgmt/{{name}}"
+            for name in act_names:
+                log.run_command(add_tpl.format(name=name))
+            wait_for_expected_count(
+                list_cmd=f"{cmd_prefix} list {cmd_args}",
+                expected_count=2, expected_names=act_names,
+                reissue_cmds={n: add_tpl.format(name=n) for n in act_names},
+                run_fn=log.run_command,
+            )
+
+        with log.step(4, "Export Management Actions (JSON)"):
+            export_result = log.run_command(
+                f"{cmd_prefix} export {cmd_args} -f json --output-dir {output_dir}"
+            )
+            exported_file = validate_export_result(
+                log, export_result, "action_count", 2, "json", tracked_files,
+            )
+            with open(exported_file, 'r', encoding='utf-8') as f:
+                verify_items_by_name(
+                    log, json.load(f), act_names, field_name="targetUri",
+                    field_values=field_values, label="exported",
+                )
+
+        with log.step(5, "Remove All Actions"):
+            rm_tpl = f"{cmd_prefix} remove {cmd_args} --name {{name}}"
+            for name in act_names:
+                log.run_command(rm_tpl.format(name=name))
+            wait_for_expected_count(
+                list_cmd=f"{cmd_prefix} list {cmd_args}",
+                expected_count=0, expected_names=act_names,
+                reissue_cmds={n: rm_tpl.format(name=n) for n in act_names},
+                reissue_on_missing=False, run_fn=log.run_command,
+            )
+
+        with log.step(6, "Import Management Actions"):
+            imported = log.run_command(f"{cmd_prefix} import {cmd_args} --input-file {exported_file}")
+            verify_items_by_name(
+                log, imported, act_names, field_name="targetUri",
+                field_values=field_values, label="imported",
+            )
+
+        with log.step(7, "Verify Final State"):
+            final = log.run_command(f"{cmd_prefix} list {cmd_args}")
+            log.check("final count == 2", len(final) == 2, actual=len(final))
+
+        do_replace_import_test(
+            log, 8, 9, exported_file, tracked_files,
+            import_cmd_base=f"{cmd_prefix} import {cmd_args}",
+            field_name="targetUri", item_names=act_names,
+        )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
@@ -11,7 +11,8 @@ import pytest
 from ...generators import generate_random_string
 from ...helpers import run, wait_for_expected_count
 from .namespace_helpers import (
-    create_config_file, assert_management_group_properties, assert_management_group_action_properties
+    create_config_file, assert_management_group_properties, assert_management_group_action_properties,
+    _save_json_to_file, _try_show_template
 )
 
 
@@ -483,3 +484,175 @@ def test_namespace_onvif_asset_management_group_lifecycle_operations(
 
     remaining_mgmt_group_names = [mg["name"] for mg in remaining_mgmt_groups]
     assert mgmt_group_name not in remaining_mgmt_group_names
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) management group / action commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("asset_type", ["opcua", "custom"])
+def test_generalized_management_lifecycle(asset_factory, tracked_files: List[str], asset_type: str):
+    """Full lifecycle of the generalized (connector-agnostic) mgmt-group + mgmt-action commands.
+
+    The connector type is detected automatically from the asset's device endpoint. A connector
+    template must exist for --show-template / --mgmt-group-config / --action-config to resolve
+    connector metadata. When no config schema is available (OPC UA bundles empty management
+    schemas, custom may have no template installed), --show-template returns an empty config and
+    the test exercises the metadata-free path (no config payload).
+    """
+    info = asset_factory(asset_type)
+    asset_name = info["name"]
+    instance_name = info["instanceName"]
+    resource_group = info["resourceGroup"]
+    mg_name = f"gen-mg-{generate_random_string(6, force_lower=True)}"
+    mg_name_2 = f"gen-mg2-{generate_random_string(6, force_lower=True)}"
+    action_name = f"gen-act-{generate_random_string(6, force_lower=True)}"
+    target_uri = (
+        "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;i=7019"
+        if asset_type == "opcua"
+        else "/mgmt/device_service?profile=startmethod"
+    )
+
+    # 1. SHOW-TEMPLATE mgmt-group (may be empty when no config schema is available)
+    mg_template = _try_show_template(
+        f"az iot ops ns asset mgmt-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} "
+        f"--name {mg_name} --show-template config"
+    )
+    mg_config_arg = ""
+    if mg_template and mg_template.get("mgmtGroupConfig", {}).get("managementGroupConfiguration"):
+        assert "connectorType" in mg_template
+        mg_config_file = _save_json_to_file(mg_template, tracked_files)
+        mg_config_arg = f"--mgmt-group-config {mg_config_file}"
+
+    # 2. ADD mgmt-group
+    default_topic = "factory/mgmt/responses"
+    default_timeout = 30
+    added_mg = run(
+        f"az iot ops ns asset mgmt-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {mg_name} "
+        f"--default-topic '{default_topic}' --default-timeout {default_timeout} {mg_config_arg}"
+    )
+    assert_management_group_properties(
+        added_mg, name=mg_name, default_topic=default_topic, default_timeout=default_timeout
+    )
+
+    # 3. SHOW mgmt-group
+    shown_mg = run(
+        f"az iot ops ns asset mgmt-group show --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {mg_name}"
+    )
+    assert_management_group_properties(shown_mg, name=mg_name, default_topic=default_topic)
+
+    # 4. LIST mgmt-groups
+    mg_list = run(
+        f"az iot ops ns asset mgmt-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )
+    assert any(mg["name"] == mg_name for mg in mg_list)
+
+    # 5. ADD a second mgmt-group (minimal)
+    added_mg_2 = run(
+        f"az iot ops ns asset mgmt-group add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {mg_name_2}"
+    )
+    assert_management_group_properties(added_mg_2, name=mg_name_2)
+    mg_names = [mg["name"] for mg in run(
+        f"az iot ops ns asset mgmt-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    )]
+    assert mg_name in mg_names and mg_name_2 in mg_names
+
+    # 6. UPDATE mgmt-group
+    updated_topic = "factory/mgmt/updated_responses"
+    updated_timeout = 45
+    updated_mg = run(
+        f"az iot ops ns asset mgmt-group update --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --name {mg_name} "
+        f"--default-topic '{updated_topic}' --default-timeout {updated_timeout}"
+    )
+    assert_management_group_properties(
+        updated_mg, name=mg_name, default_topic=updated_topic, default_timeout=updated_timeout
+    )
+
+    # 7. SHOW-TEMPLATE action (may be empty)
+    act_template = _try_show_template(
+        f"az iot ops ns asset mgmt-action add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name} "
+        f"--name {action_name} --target-uri '{target_uri}' --show-template config"
+    )
+    act_config_arg = ""
+    if act_template and act_template.get("actionConfig", {}).get("actionConfiguration"):
+        assert "connectorType" in act_template
+        act_config_file = _save_json_to_file(act_template, tracked_files)
+        act_config_arg = f"--action-config {act_config_file}"
+
+    # 8. ADD action
+    action_type = "Call"
+    action_timeout = 60
+    added_actions = run(
+        f"az iot ops ns asset mgmt-action add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name} "
+        f"--name {action_name} --target-uri '{target_uri}' --action-type {action_type} "
+        f"--timeout {action_timeout} {act_config_arg}"
+    )
+    assert_management_group_action_properties(
+        added_actions, name=action_name, target_uri=target_uri,
+        action_type=action_type, timeout=action_timeout,
+    )
+
+    # 9. LIST actions
+    act_list = run(
+        f"az iot ops ns asset mgmt-action list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name}"
+    )
+    assert any(a["name"] == action_name for a in act_list)
+
+    # 10. REPLACE action
+    replaced_actions = run(
+        f"az iot ops ns asset mgmt-action add --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name} "
+        f"--name {action_name} --target-uri '{target_uri}' --replace"
+    )
+    assert_management_group_action_properties(replaced_actions, name=action_name)
+
+    # 11. EXPORT mgmt-groups
+    mg_export = run(
+        f"az iot ops ns asset mgmt-group export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --output-dir /tmp --replace"
+    )
+    assert mg_export["management_group_count"] >= 1
+    tracked_files.append(mg_export["file_path"])
+
+    # 12. EXPORT actions
+    act_export = run(
+        f"az iot ops ns asset mgmt-action export --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name} "
+        f"--output-dir /tmp --replace"
+    )
+    assert act_export["action_count"] >= 1
+    tracked_files.append(act_export["file_path"])
+
+    # 13. REMOVE action
+    run(
+        f"az iot ops ns asset mgmt-action remove --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name} --name {action_name}"
+    )
+    act_list_after = run(
+        f"az iot ops ns asset mgmt-action list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group} --group {mg_name}"
+    )
+    assert not any(a["name"] == action_name for a in (act_list_after or []))
+
+    # 14. REMOVE mgmt-groups
+    for mg in [mg_name, mg_name_2]:
+        run(
+            f"az iot ops ns asset mgmt-group remove --asset {asset_name} "
+            f"--instance {instance_name} -g {resource_group} --name {mg}"
+        )
+    remaining = [mg["name"] for mg in (run(
+        f"az iot ops ns asset mgmt-group list --asset {asset_name} "
+        f"--instance {instance_name} -g {resource_group}"
+    ) or [])]
+    assert mg_name not in remaining and mg_name_2 not in remaining

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
@@ -26,6 +26,11 @@ from azext_edge.edge.commands_namespaces import (
     list_namespace_asset_management_group_actions,
     remove_namespace_asset_management_group_action
 )
+from azext_edge.edge.commands_namespaces import (
+    add_namespace_asset_management_group,
+    update_namespace_asset_management_group,
+    add_namespace_asset_management_group_action,
+)
 
 from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
@@ -1679,3 +1684,623 @@ def test_import_namespace_asset_management_group_actions(
     # Verify result is a list of actions
     assert isinstance(result, list)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Generalized (connector-agnostic) management-group / management-action unit tests
+# ---------------------------------------------------------------------------
+
+
+def _build_asset_with_mgmt_groups(
+    asset_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    management_groups: Optional[list] = None,
+) -> dict:
+    """Build a mock asset record pre-wired for the generalized management path."""
+    asset = get_namespace_asset_record(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+    asset["properties"]["managementGroups"] = management_groups or []
+    return asset
+
+
+def _add_device_get_for_generalized_mgmt(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    connector_type: str,
+) -> None:
+    """Register GET device mock needed by _get_connector_type_and_device and _check_device_props."""
+    device_name = asset["properties"]["deviceRef"]["deviceName"]
+    endpoint_name = asset["properties"]["deviceRef"]["endpointName"]
+    add_device_get_call(
+        mocked_responses,
+        device_name=device_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        endpoint_name=endpoint_name,
+        endpoint_type=connector_type,
+    )
+
+
+def _mgmt_metadata(connector_type: str, mg_schema=None, action_schema=None) -> dict:
+    """Build a connector metadata payload for the generalized management path.
+
+    Note: managementGroups have no destinations in the metadata schema.
+    """
+    return {
+        "inboundEndpoints": [{
+            "endpointType": f"Microsoft.{connector_type}",
+            "managementGroups": {
+                "managementGroupConfigurationSchema": mg_schema,
+                "managementGroupActions": {
+                    "actionConfigurationSchema": action_schema,
+                },
+            },
+        }]
+    }
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_management_group (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_mgmt_group_config", [False, True])
+@pytest.mark.parametrize("replace, pre_existing", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_add_namespace_asset_management_group_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_mgmt_group_config: bool,
+    replace: bool,
+    pre_existing: bool,
+):
+    asset_name = "gen-asset"
+    group_name = f"mg-{generate_random_string()}"
+    connector_type = "Custom.Test"
+
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    mgmt_group_config_json = json.dumps({
+        "managementGroupConfiguration": {"operationMode": "async"},
+    })
+
+    existing_groups = [generate_management_group(group_name=group_name)] if pre_existing else []
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=existing_groups,
+    )
+
+    # self.show + _get_connector_type_and_device: GET asset + GET device
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    if has_mgmt_group_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value=_mgmt_metadata(connector_type),
+        )
+
+    updated_asset = deepcopy(asset)
+    updated_asset["properties"]["managementGroups"] = [
+        {"name": group_name, "dataSource": "src/test", "actions": []}
+    ]
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_management_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        data_source="src/test",
+        replace=replace,
+        mgmt_group_config=mgmt_group_config_json if has_mgmt_group_config else None,
+        wait_sec=0,
+    )
+
+    assert result["name"] == group_name
+
+
+def test_add_namespace_asset_management_group_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "existing-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[generate_management_group(group_name=group_name)],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_management_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            replace=False,
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_management_group_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on add should return a blank template wrapped with connectorType.
+
+    Management groups have no destinations, so the template exposes only
+    managementGroupConfiguration.
+    """
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_mgmt_metadata(
+            connector_type,
+            mg_schema={
+                "type": "object",
+                "properties": {"operationMode": {"type": "string", "default": "sync"}},
+            },
+        ),
+    )
+
+    result = add_namespace_asset_management_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name="new-mg",
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    mg_cfg = result["mgmtGroupConfig"]
+    assert "managementGroupConfiguration" in mg_cfg
+    # Management groups have no destinations
+    assert "destinations" not in mg_cfg
+
+
+# ---------------------------------------------------------------------------
+# update_namespace_asset_management_group (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_namespace_asset_management_group_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_mg = {
+        "name": group_name,
+        "dataSource": "orig/src",
+        "managementGroupConfiguration": json.dumps({"operationMode": "sync"}),
+        "actions": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[existing_mg],
+    )
+
+    mgmt_group_config_json = json.dumps({
+        "managementGroupConfiguration": {"operationMode": "async"},
+    })
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_mgmt_metadata(connector_type),
+    )
+
+    updated_asset = deepcopy(asset)
+    updated_mg = deepcopy(existing_mg)
+    updated_mg["managementGroupConfiguration"] = json.dumps({"operationMode": "async"})
+    updated_asset["properties"]["managementGroups"] = [updated_mg]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = update_namespace_asset_management_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        mgmt_group_config=mgmt_group_config_json,
+        wait_sec=0,
+    )
+
+    assert result["name"] == group_name
+    assert json.loads(result["managementGroupConfiguration"])["operationMode"] == "async"
+
+
+def test_update_namespace_asset_management_group_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on update should pre-fill existing ARM values into the template."""
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_mg = {
+        "name": group_name,
+        "dataSource": "orig/src",
+        "managementGroupConfiguration": json.dumps({"operationMode": "async", "retries": 3}),
+        "actions": [],
+        "typeRef": None,
+    }
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[existing_mg],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_mgmt_metadata(
+            connector_type,
+            mg_schema={
+                "type": "object",
+                "properties": {
+                    "operationMode": {"type": "string", "default": "sync"},
+                    "retries": {"type": "integer", "default": 1},
+                },
+            },
+        ),
+    )
+
+    result = update_namespace_asset_management_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    mg_cfg = result["mgmtGroupConfig"]["managementGroupConfiguration"]
+    # Existing ARM values should be pre-filled
+    assert mg_cfg["operationMode"] == "async"
+    assert mg_cfg["retries"] == 3
+
+
+def test_update_namespace_asset_management_group_generalized_raises_if_not_found(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="not found"):
+        update_namespace_asset_management_group(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="missing-mg",
+            show_template="config",
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# add_namespace_asset_management_group_action (generalized) unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("has_action_config", [False, True])
+def test_add_namespace_asset_management_group_action_generalized(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    has_action_config: bool,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    action_name = "reboot-act"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_mg = {
+        "name": group_name,
+        "dataSource": "s/src",
+        "actions": [],
+    }
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[existing_mg],
+    )
+
+    action_config_json = json.dumps({
+        "actionConfiguration": {"method": "execute", "retries": 2},
+    })
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    if has_action_config:
+        mocker.patch(
+            "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+            return_value=_mgmt_metadata(connector_type),
+        )
+
+    updated_asset = deepcopy(asset)
+    added_action = {"name": action_name, "targetUri": "ns=2;s=Reboot"}
+    if has_action_config:
+        added_action["actionConfiguration"] = json.dumps({"method": "execute", "retries": 2})
+    updated_asset["properties"]["managementGroups"][0]["actions"] = [added_action]
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=updated_asset, status=200,
+    )
+
+    result = add_namespace_asset_management_group_action(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        action_name=action_name,
+        target_uri="ns=2;s=Reboot",
+        replace=False,
+        action_config=action_config_json if has_action_config else None,
+        wait_sec=0,
+    )
+
+    assert isinstance(result, list)
+    assert any(a["name"] == action_name for a in result)
+
+
+def test_add_namespace_asset_management_group_action_generalized_raises_on_duplicate(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    action_name = "existing-act"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_mg = {
+        "name": group_name,
+        "dataSource": "s/src",
+        "actions": [generate_management_group_action(action_name=action_name)],
+    }
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[existing_mg],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    with pytest.raises(InvalidArgumentValueError, match="already exists"):
+        add_namespace_asset_management_group_action(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            action_name=action_name,
+            target_uri="ns=2;s=Reboot",
+            replace=False,
+            wait_sec=0,
+        )
+
+
+def test_add_namespace_asset_management_group_action_generalized_show_template_config(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+):
+    """show_template=config on action add should return a template wrapped with connectorType."""
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[{"name": group_name, "actions": []}],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=_mgmt_metadata(
+            connector_type,
+            action_schema={
+                "type": "object",
+                "properties": {"method": {"type": "string", "default": "execute"}},
+            },
+        ),
+    )
+
+    result = add_namespace_asset_management_group_action(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        action_name="new-act",
+        show_template="config",
+        wait_sec=0,
+    )
+
+    assert result["connectorType"] == f"Microsoft.{connector_type}"
+    action_cfg = result["actionConfig"]
+    assert "actionConfiguration" in action_cfg
+    # Management actions have no destinations
+    assert "destinations" not in action_cfg

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
@@ -2009,6 +2009,74 @@ def test_update_namespace_asset_management_group_generalized(
     assert json.loads(result["managementGroupConfiguration"])["operationMode"] == "async"
 
 
+def test_update_namespace_asset_management_group_generalized_clears_fields(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+):
+    """defaultTopic is clearable via empty string; data_source / type_ref empty strings are
+    ignored (no-op), consistent with the existing connector-specific mgmt-group update."""
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    existing_mg = {
+        "name": group_name,
+        "dataSource": "orig/src",
+        "typeRef": "orig-ref",
+        "defaultTopic": "orig/topic",
+        "actions": [],
+    }
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[existing_mg],
+    )
+
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+    mocked_responses.add(
+        responses.PATCH,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        status=200,
+    )
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+
+    update_namespace_asset_management_group(
+        cmd=mocked_cmd,
+        asset_name=asset_name,
+        instance_name="inst",
+        instance_resource_group="rg",
+        group_name=group_name,
+        data_source="",
+        type_ref="",
+        default_topic="",
+        wait_sec=0,
+    )
+
+    patch_call = next(c for c in mocked_responses.calls if c.request.method == "PATCH")
+    patched_mg = json.loads(patch_call.request.body)["properties"]["managementGroups"][0]
+    # defaultTopic cleared via empty string
+    assert "defaultTopic" not in patched_mg
+    # data_source / type_ref empty strings are ignored -> original values preserved
+    assert patched_mg["dataSource"] == "orig/src"
+    assert patched_mg["typeRef"] == "orig-ref"
+
+
 def test_update_namespace_asset_management_group_generalized_show_template_config(
     mocked_cmd,
     mocked_responses: responses,


### PR DESCRIPTION
- Adds connector-agnostic `az iot ops ns asset mgmt-group` and `az iot ops ns asset mgmt-action` command groups that automatically detect the connector type from the asset's device endpoint, so users no longer need to specify it in the command path.
- Provides the full lifecycle across both groups — add, update, show, list, remove, and export/import round-trips for management groups and their actions — with `--show-template` for discovering the connector-specific configuration schema.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
