### PR TITLE
Retry transient token/connection failures in az iot ops upgrade

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,3 +8,6 @@ unreleased
 ==========
 
 * Initial baseline.
+* `az iot ops upgrade` now retries transient token-acquisition and network
+  failures (e.g. ``Connection reset by peer`` while acquiring an ARM token)
+  instead of aborting; genuine errors still fail fast.

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -43,6 +43,7 @@ from .migration import SecretSyncMigrationManager
 from .resources import RegistryEndpoints
 from .resources.instances import SECRET_SYNC_RESOURCE_TYPE, SPC_RESOURCE_TYPE, Instances
 from .targets import InitTargets
+from ...util.az_client import retry_on_transient_error
 
 logger = get_logger(__name__)
 
@@ -69,17 +70,23 @@ def upgrade_ops_instance(
     no_cm_install: Optional[bool] = None,
     **kwargs,
 ):
-    upgrade_manager = UpgradeManager(
-        cmd=cmd,
-        instance_name=instance_name,
-        resource_group_name=resource_group_name,
-        adr_namespace_resource_id=adr_namespace_resource_id,
-        no_progress=no_progress,
-        force=force,
-        no_cm_install=no_cm_install,
+    upgrade_manager = retry_on_transient_error(
+        lambda: UpgradeManager(
+            cmd=cmd,
+            instance_name=instance_name,
+            resource_group_name=resource_group_name,
+            adr_namespace_resource_id=adr_namespace_resource_id,
+            no_progress=no_progress,
+            force=force,
+            no_cm_install=no_cm_install,
+        ),
+        context="initializing upgrade",
     )
 
-    upgrade_state = upgrade_manager.analyze_cluster(**kwargs)
+    upgrade_state = retry_on_transient_error(
+        lambda: upgrade_manager.analyze_cluster(**kwargs),
+        context="analyzing cluster",
+    )
 
     if not upgrade_state.has_upgrades():
         logger.warning("Nothing to upgrade :)")
@@ -223,7 +230,12 @@ class UpgradeManager:
             for op_type in [ExtensionOperation.DELETE, ExtensionOperation.CREATE, ExtensionOperation.UPDATE]:
                 for ext in operations.get(op_type, []):
                     try:
-                        result = self._apply_single_operation(ext=ext, op_type=op_type, headers=headers)
+                        result = retry_on_transient_error(
+                            lambda ext=ext, op_type=op_type: self._apply_single_operation(
+                                ext=ext, op_type=op_type, headers=headers
+                            ),
+                            context=f"{op_type.value} extension",
+                        )
                         return_payload.append(result)
                         progress.advance(task)
                     except HttpResponseError:
@@ -233,10 +245,13 @@ class UpgradeManager:
 
             if upgrade_state.instance_upgrade:
                 try:
-                    instance_result = self._apply_instance_update(
-                        needs_adr_update=upgrade_state._check_adr_namespace_update(),
-                        needs_spc_update=upgrade_state._check_spc_reference_update(),
-                        headers=headers,
+                    instance_result = retry_on_transient_error(
+                        lambda: self._apply_instance_update(
+                            needs_adr_update=upgrade_state._check_adr_namespace_update(),
+                            needs_spc_update=upgrade_state._check_spc_reference_update(),
+                            headers=headers,
+                        ),
+                        context="instance update",
                     )
                     return_payload.append(instance_result)
                     progress.advance(task)
@@ -247,7 +262,10 @@ class UpgradeManager:
 
             if upgrade_state.registry_endpoint_needed:
                 try:
-                    registry_result = self._create_default_registry_endpoint(headers)
+                    registry_result = retry_on_transient_error(
+                        lambda: self._create_default_registry_endpoint(headers),
+                        context="registry endpoint creation",
+                    )
                     return_payload.append(registry_result)
                     progress.advance(task)
                 except HttpResponseError:
@@ -257,7 +275,10 @@ class UpgradeManager:
 
             if upgrade_state.secretsync_migration_needed:
                 try:
-                    default_spc = self.secretsync_migration.migrate_to_v2(headers)
+                    default_spc = retry_on_transient_error(
+                        lambda: self.secretsync_migration.migrate_to_v2(headers),
+                        context="secretsync migration",
+                    )
                     return_payload.append(default_spc)
                     progress.advance(task)
                 except HttpResponseError:

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -8,7 +8,7 @@
 from collections.abc import MutableMapping  # pylint: disable=import-error
 from enum import Enum
 from time import sleep
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Tuple, TypeVar, Union
 
 from azure.cli.core.azclierror import ValidationError
 from knack.log import get_logger
@@ -304,6 +304,97 @@ def wait_for_terminal_state(poller: "LROPoller", wait_sec: int = POLL_WAIT_SEC, 
         sleep(wait_sec)
         counter = counter + 1
     return poller.result()
+
+
+T = TypeVar("T")
+
+# Bounded retry for transient Azure token-acquisition / connection failures.
+TRANSIENT_RETRY_MAX_ATTEMPTS = 3
+TRANSIENT_RETRY_INITIAL_BACKOFF_SEC = 15
+
+# Lower-cased substrings identifying a transient network / token-acquisition
+# failure (e.g. AzureCliCredential shelling out to `az account get-access-token`
+# which fails with 'Connection reset by peer'). These are environmental flakes,
+# not auth misconfiguration or bad requests, so they are safe to retry.
+#
+# HTTP status errors (429/5xx) are intentionally NOT handled here: the azure-core
+# transport already retries them via its RetryPolicy. This helper only covers the
+# connection/token-acquisition failures that occur outside that policy.
+_TRANSIENT_ERROR_MARKERS = (
+    "connection reset",
+    "connection aborted",
+    "connection refused",
+    "reset by peer",
+    "broken pipe",
+    "timed out",
+    "timeout",
+    "temporary failure in name resolution",
+    "failed to establish a new connection",
+    "failed to resolve",
+    "getaddrinfo failed",
+    "connection error",
+    "eof occurred",
+)
+
+
+def is_transient_error(error: Exception) -> bool:
+    """Return True when the error is a transient network / token-acquisition failure
+    that is safe to retry (as opposed to a genuine auth, validation or request error).
+
+    HTTP status errors (429/5xx) are excluded on purpose: the azure-core transport
+    already retries those. This targets the connection reset / token-acquisition
+    failures that abort a command before the transport's retry policy applies.
+    """
+    from azure.core.exceptions import ServiceRequestError, ServiceResponseError
+
+    # azure-core raises these when the request could not be sent or the response was
+    # not received (connection reset, DNS failure, read timeout, etc.).
+    if isinstance(error, (ServiceRequestError, ServiceResponseError)):
+        return True
+
+    # Builtin connection / timeout errors (e.g. surfaced from AzureCliCredential).
+    if isinstance(error, (ConnectionError, TimeoutError)):
+        return True
+
+    # Fall back to inspecting the (possibly wrapped) error text so we also catch
+    # ClientAuthenticationError / CredentialUnavailableError caused by a transient
+    # `az account get-access-token` connection reset, without retrying real auth errors.
+    message = str(getattr(error, "message", "") or error).lower()
+    return any(marker in message for marker in _TRANSIENT_ERROR_MARKERS)
+
+
+def retry_on_transient_error(
+    func: Callable[[], T],
+    *,
+    max_attempts: int = TRANSIENT_RETRY_MAX_ATTEMPTS,
+    initial_backoff_sec: int = TRANSIENT_RETRY_INITIAL_BACKOFF_SEC,
+    context: Optional[str] = None,
+) -> T:
+    """Invoke ``func`` and retry it on transient network / token-acquisition failures.
+
+    Retries use a linear backoff (``initial_backoff_sec`` * attempt). Non-transient
+    errors are raised immediately. ``func`` must be idempotent; all call sites wrap
+    idempotent ARM reads or PUT/DELETE operations, so re-running converges the same
+    state.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return func()
+        except Exception as error:  # pylint: disable=broad-except
+            if attempt >= max_attempts or not is_transient_error(error):
+                raise
+            backoff = initial_backoff_sec * attempt
+            logger.warning(
+                "Transient error%s (attempt %d/%d): %s. Retrying in %ds...",
+                f" during {context}" if context else "",
+                attempt,
+                max_attempts,
+                error,
+                backoff,
+            )
+            sleep(backoff)
 
 
 def wait_for_terminal_states(

--- a/azext_edge/tests/utility/test_az_client_unit.py
+++ b/azext_edge/tests/utility/test_az_client_unit.py
@@ -38,3 +38,92 @@ def test_get_tenant_id(mocker):
     result = get_tenant_id()
     assert result == tenant_id
     profile_patch.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        # Transient network / token-acquisition failures.
+        (ConnectionResetError("Connection reset by peer"), True),
+        (TimeoutError("timed out"), True),
+        (Exception("Failed to establish a new connection"), True),
+        (Exception("Temporary failure in name resolution"), True),
+        # Non-transient failures must not be retried.
+        (Exception("Please run 'az login' to setup account"), False),
+        (ValueError("invalid instance name"), False),
+    ],
+)
+def test_is_transient_error_message_markers(error, expected):
+    from azext_edge.edge.util.az_client import is_transient_error
+
+    assert is_transient_error(error) is expected
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504, 400, 404])
+def test_is_transient_error_http_status_not_retried_here(status_code):
+    # HTTP status errors are handled by the azure-core transport retry policy, so
+    # this helper must NOT treat them as transient (avoids double-retrying).
+    from azure.core.exceptions import HttpResponseError
+
+    from azext_edge.edge.util.az_client import is_transient_error
+
+    error = HttpResponseError(message="service error")
+    error.status_code = status_code
+    assert is_transient_error(error) is False
+
+
+def test_is_transient_error_service_request(mocker):
+    from azure.core.exceptions import ServiceRequestError, ServiceResponseError
+
+    from azext_edge.edge.util.az_client import is_transient_error
+
+    assert is_transient_error(ServiceRequestError(message="send failed")) is True
+    assert is_transient_error(ServiceResponseError(message="no response")) is True
+
+
+def test_retry_on_transient_error_succeeds_after_retries(mocker):
+    sleep_patch = mocker.patch(f"{AZ_CLIENT_PATH}.sleep")
+    expected = generate_random_string()
+
+    func = mocker.Mock(
+        side_effect=[
+            ConnectionResetError("Connection reset by peer"),
+            ConnectionResetError("Connection reset by peer"),
+            expected,
+        ]
+    )
+
+    from azext_edge.edge.util.az_client import retry_on_transient_error
+
+    result = retry_on_transient_error(func, max_attempts=3, initial_backoff_sec=1, context="unit test")
+    assert result == expected
+    assert func.call_count == 3
+    # Linear backoff: 1 * attempt for each of the two failed attempts.
+    assert sleep_patch.call_count == 2
+    sleep_patch.assert_has_calls([mocker.call(1), mocker.call(2)])
+
+
+def test_retry_on_transient_error_non_transient_fails_fast(mocker):
+    sleep_patch = mocker.patch(f"{AZ_CLIENT_PATH}.sleep")
+    func = mocker.Mock(side_effect=ValueError("bad request"))
+
+    from azext_edge.edge.util.az_client import retry_on_transient_error
+
+    with pytest.raises(ValueError):
+        retry_on_transient_error(func, max_attempts=3, initial_backoff_sec=1)
+    # No retry for a non-transient error.
+    assert func.call_count == 1
+    assert sleep_patch.call_count == 0
+
+
+def test_retry_on_transient_error_exhausts_attempts(mocker):
+    sleep_patch = mocker.patch(f"{AZ_CLIENT_PATH}.sleep")
+    func = mocker.Mock(side_effect=ConnectionResetError("Connection reset by peer"))
+
+    from azext_edge.edge.util.az_client import retry_on_transient_error
+
+    with pytest.raises(ConnectionResetError):
+        retry_on_transient_error(func, max_attempts=3, initial_backoff_sec=1)
+    assert func.call_count == 3
+    # Sleeps between attempts only (attempts - 1).
+    assert sleep_patch.call_count == 2


### PR DESCRIPTION
## Description

`az iot ops upgrade` can abort with exit 1 **before doing any work** when ARM token acquisition (`AzureCliCredential` → `az account get-access-token`) fails with a transient `Connection reset by peer`, or when a subsequent ARM call hits a connection-reset / DNS / read-timeout flake. These are environmental issues, not product or user errors, and today they surface as a hard command failure.

This mirrors, on the product side, a test-side retry we added for the same transient failure (internal bug 38787405 / recurring infra pattern).

## Change

- New bounded helper `retry_on_transient_error` in `azext_edge/edge/util/az_client.py` (default **3 attempts**, linear **15s × attempt** backoff).
  - Retries **only** connection/token-acquisition transients: `ServiceRequestError`, `ServiceResponseError`, builtin `ConnectionError`/`TimeoutError`, and connection/DNS message markers (e.g. `connection reset`, `reset by peer`, `temporary failure in name resolution`).
  - **HTTP 429/5xx are intentionally excluded** — the `azure-core` transport already retries those via its `RetryPolicy` (verified by the existing `test_ops_upgrade_retry_assertion`), so retrying here would double-retry.
  - Non-transient errors (e.g. `az login` needed, validation errors) **fail fast**.
- `upgrade2.py` wraps its **idempotent** operations with the helper:
  - `UpgradeManager` construction + `analyze_cluster` (ARM reads — this is the "before doing any work" token-acquisition point).
  - Each extension create/update/delete, the instance update, default registry-endpoint creation, and secretsync migration (idempotent ARM PUT/DELETE).
- Idempotency: the wrapped calls are ARM reads or PUT/DELETE, so re-running converges the same state.

## Testing

- New unit tests for `is_transient_error` (transient markers, non-transient auth/validation, and that 429/5xx are *not* retried here) and `retry_on_transient_error` (succeeds after retries, fails fast on non-transient, exhausts attempts).
- `pytest azext_edge/tests/utility/test_az_client_unit.py azext_edge/tests/edge/orchestration/test_upgrade2_unit.py` → **212 passed**.
- `flake8` clean; `pylint` introduces no new findings (pre-existing R0917s only).

## History

- Updated `HISTORY.rst`.
