### PR TITLE
fix: match FIC issuer to token iss

### DIFF
--- a/azext_edge/edge/providers/orchestration/clone.py
+++ b/azext_edge/edge/providers/orchestration/clone.py
@@ -483,11 +483,7 @@ class InstanceRestore:
         oidc_issuer = self.instances._ensure_oidc_issuer(
             cluster_resource, use_self_hosted_issuer=use_self_hosted_issuer
         )
-        oidc_issuer = resolve_oidc_issuer(
-            arm_issuer=oidc_issuer,
-            namespace=self.namespace,
-            service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
-        )
+        oidc_issuer = resolve_oidc_issuer(arm_issuer=oidc_issuer)
 
         for mid in self.user_assigned_mis:
             parsed_uami_id = parse_resource_id(mid)

--- a/azext_edge/edge/providers/orchestration/clone.py
+++ b/azext_edge/edge/providers/orchestration/clone.py
@@ -72,6 +72,7 @@ from .resources.instances import (
     SERVICE_ACCOUNT_SECRETSYNC,
     SERVICE_ACCOUNT_SCHEMA,
     get_fc_name,
+    resolve_oidc_issuer,
 )
 
 if TYPE_CHECKING:
@@ -481,6 +482,11 @@ class InstanceRestore:
         cluster_resource = self.connected_cluster.resource
         oidc_issuer = self.instances._ensure_oidc_issuer(
             cluster_resource, use_self_hosted_issuer=use_self_hosted_issuer
+        )
+        oidc_issuer = resolve_oidc_issuer(
+            arm_issuer=oidc_issuer,
+            namespace=self.namespace,
+            service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
         )
 
         for mid in self.user_assigned_mis:

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -116,7 +116,12 @@ def _get_service_account_issuer(namespace: str, service_account_name: str) -> Op
             response,
             client.AuthenticationV1TokenRequest,
         )
-    return decode_access_token(token_response.status.token).get("iss")
+
+    try:
+        issuer = decode_access_token(token_response.status.token).get("iss")
+    except (AttributeError, IndexError, ValueError):
+        return None
+    return issuer if isinstance(issuer, str) else None
 
 
 def resolve_oidc_issuer(arm_issuer: str, namespace: str, service_account_name: str) -> str:

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -4,12 +4,14 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import json
 import re
 from contextlib import nullcontext
 from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlsplit
 
+import requests
 import yaml
-from azure.cli.core.auth.util import decode_access_token
 from azure.cli.core.azclierror import (
     AzureResponseError,
     InvalidArgumentValueError,
@@ -17,14 +19,9 @@ from azure.cli.core.azclierror import (
 )
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from knack.log import get_logger
-from kubernetes import client
-from kubernetes.client.exceptions import ApiException
-from kubernetes.config.config_exception import ConfigException
 from rich import print
 from rich.console import Console
-from urllib3.exceptions import HTTPError
 
-from ...base import load_config_context
 from ....util.az_client import (
     ResourceIdContainer,
     get_iotops_mgmt_client,
@@ -74,6 +71,9 @@ KEYVAULT_ROLE_ID_SECRETS_USER = "4633458b-17de-408a-b874-0445c86b69e6"
 KEYVAULT_ROLE_ID_READER = "21090545-7ca7-4776-b22c-e363652d74d2"
 
 COMPAT_FEAT_KEY_SET = {"opcua.mode"}
+OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration"
+OIDC_DISCOVERY_TIMEOUT_SECONDS = 5
+OIDC_DISCOVERY_MAX_RESPONSE_BYTES = 64 * 1024  # cap the response size to 64KB
 
 
 def get_user_msg_warn_ra(prefix: str, principal_id: str, scope: str) -> str:
@@ -98,46 +98,76 @@ def get_cred_subject(namespace: str, service_account_name: str):
     return f"system:serviceaccount:{namespace}:{service_account_name}"
 
 
-def _get_service_account_issuer(namespace: str, service_account_name: str) -> Optional[str]:
-    token_request = client.AuthenticationV1TokenRequest(
-        spec=client.V1TokenRequestSpec(
-            audiences=["api://AzureADTokenExchange"],
-        )
-    )
-    core_v1_api = client.CoreV1Api()
-    with core_v1_api.create_namespaced_service_account_token(
-        name=service_account_name,
-        namespace=namespace,
-        body=token_request,
-        _preload_content=False,
-        _request_timeout=5,
-    ) as response:
-        token_response = core_v1_api.api_client.deserialize(
-            response,
-            client.AuthenticationV1TokenRequest,
-        )
+def oidc_issuers_match(first: str, second: str) -> bool:
+    if first == second:
+        return True
+    return first == f"{second}/" or second == f"{first}/"
 
+
+def _is_https_url(url: str) -> bool:
     try:
-        issuer = decode_access_token(token_response.status.token).get("iss")
-    except (AttributeError, IndexError, ValueError):
+        parsed = urlsplit(url)
+    except (AttributeError, ValueError):
+        return False
+    return parsed.scheme.lower() == "https" and parsed.hostname is not None
+
+
+def _read_public_discovery_issuer(discovery_url: str) -> Optional[str]:
+    try:
+        with requests.get(
+            discovery_url,
+            allow_redirects=False,
+            stream=True,
+            timeout=OIDC_DISCOVERY_TIMEOUT_SECONDS,
+            verify=True,
+        ) as response:
+            if response.status_code != 200:
+                return None
+            # Bound the decoded body since the URL comes from ARM data.
+            content = bytearray()
+            for chunk in response.iter_content(chunk_size=OIDC_DISCOVERY_MAX_RESPONSE_BYTES):
+                content.extend(chunk)
+                if len(content) > OIDC_DISCOVERY_MAX_RESPONSE_BYTES:
+                    return None
+            issuer = json.loads(content).get("issuer")
+    except (requests.RequestException, ValueError, AttributeError, TypeError):
         return None
-    return issuer if isinstance(issuer, str) else None
+    return issuer if isinstance(issuer, str) and issuer else None
 
 
-def resolve_oidc_issuer(arm_issuer: str, namespace: str, service_account_name: str) -> str:
-    try:
-        load_config_context()
-        kubernetes_issuer = _get_service_account_issuer(
-            namespace=namespace,
-            service_account_name=service_account_name,
-        )
-    except (ApiException, ConfigException, HTTPError, OSError, yaml.YAMLError):
-        return arm_issuer
+def _get_public_discovery_issuer(arm_issuer: str) -> Optional[str]:
+    if not _is_https_url(arm_issuer):
+        return None
+    discovery_urls = [f"{arm_issuer}{OIDC_DISCOVERY_PATH}"]
+    if arm_issuer.endswith("/"):
+        discovery_urls.append(f"{arm_issuer[:-1]}{OIDC_DISCOVERY_PATH}")
 
-    if not kubernetes_issuer or kubernetes_issuer.rstrip("/") != arm_issuer.rstrip("/"):
-        return arm_issuer
+    for discovery_url in discovery_urls:
+        issuer = _read_public_discovery_issuer(discovery_url)
+        if issuer and oidc_issuers_match(arm_issuer, issuer):
+            return issuer
+    return None
 
-    return kubernetes_issuer
+
+def resolve_oidc_issuer(arm_issuer: str) -> str:
+    discovery_issuer = _get_public_discovery_issuer(arm_issuer)
+
+    if discovery_issuer:
+        if discovery_issuer != arm_issuer:
+            logger.warning(
+                "The OIDC issuer reported by ARM '%s' differs from the cluster issuer '%s' by a trailing slash. "
+                "The federated identity credential will use the cluster issuer.",
+                arm_issuer,
+                discovery_issuer,
+            )
+        return discovery_issuer
+
+    logger.warning(
+        "Could not verify the OIDC issuer reported by ARM '%s'. The ARM value will be used for the federated "
+        "identity credential, but workload identity token exchange may fail if it differs from the cluster issuer.",
+        arm_issuer,
+    )
+    return arm_issuer
 
 
 def get_enable_syntax(instance_name: str, resource_group_name: str) -> str:
@@ -441,11 +471,7 @@ class Instances(Queryable):
                 )
                 return
 
-            oidc_issuer = resolve_oidc_issuer(
-                arm_issuer=oidc_issuer,
-                namespace=namespace,
-                service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
-            )
+            oidc_issuer = resolve_oidc_issuer(arm_issuer=oidc_issuer)
             if not federated_credential_name:
                 federated_credential_name = get_fc_name(
                     cluster_name=cluster_resource["name"],

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -75,6 +75,7 @@ COMPAT_FEAT_KEY_SET = {"opcua.mode"}
 OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration"
 OIDC_DISCOVERY_TIMEOUT_SECONDS = 5
 OIDC_DISCOVERY_MAX_RESPONSE_BYTES = 64 * 1024  # cap the response size to 64KB
+OIDC_DISCOVERY_CHUNK_SIZE_BYTES = 8 * 1024
 
 
 def get_user_msg_warn_ra(prefix: str, principal_id: str, scope: str) -> str:
@@ -129,7 +130,7 @@ def _read_public_discovery_issuer(discovery_url: str, deadline: float) -> Option
                 return None
             # Bound the decoded body since the URL comes from ARM data.
             content = bytearray()
-            for chunk in response.iter_content(chunk_size=OIDC_DISCOVERY_MAX_RESPONSE_BYTES):
+            for chunk in response.iter_content(chunk_size=OIDC_DISCOVERY_CHUNK_SIZE_BYTES):
                 if time.monotonic() > deadline:
                     return None
                 content.extend(chunk)

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -6,6 +6,7 @@
 
 import json
 import re
+import time
 from contextlib import nullcontext
 from typing import Dict, Iterable, List, Optional
 from urllib.parse import urlsplit
@@ -112,13 +113,16 @@ def _is_https_url(url: str) -> bool:
     return parsed.scheme.lower() == "https" and parsed.hostname is not None
 
 
-def _read_public_discovery_issuer(discovery_url: str) -> Optional[str]:
+def _read_public_discovery_issuer(discovery_url: str, deadline: float) -> Optional[str]:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return None
     try:
         with requests.get(
             discovery_url,
             allow_redirects=False,
             stream=True,
-            timeout=OIDC_DISCOVERY_TIMEOUT_SECONDS,
+            timeout=remaining,
             verify=True,
         ) as response:
             if response.status_code != 200:
@@ -126,11 +130,14 @@ def _read_public_discovery_issuer(discovery_url: str) -> Optional[str]:
             # Bound the decoded body since the URL comes from ARM data.
             content = bytearray()
             for chunk in response.iter_content(chunk_size=OIDC_DISCOVERY_MAX_RESPONSE_BYTES):
+                if time.monotonic() > deadline:
+                    return None
                 content.extend(chunk)
                 if len(content) > OIDC_DISCOVERY_MAX_RESPONSE_BYTES:
                     return None
             issuer = json.loads(content).get("issuer")
-    except (requests.RequestException, ValueError, AttributeError, TypeError):
+    except Exception:
+        logger.debug("Failed to read the OIDC discovery document from '%s'.", discovery_url, exc_info=True)
         return None
     return issuer if isinstance(issuer, str) and issuer else None
 
@@ -138,12 +145,19 @@ def _read_public_discovery_issuer(discovery_url: str) -> Optional[str]:
 def _get_public_discovery_issuer(arm_issuer: str) -> Optional[str]:
     if not _is_https_url(arm_issuer):
         return None
-    discovery_urls = [f"{arm_issuer}{OIDC_DISCOVERY_PATH}"]
+    # Probe the normalized "/.well-known" URL first so a trailing-slash issuer does not spend the
+    # shared time budget on the "//.well-known" URL.
     if arm_issuer.endswith("/"):
-        discovery_urls.append(f"{arm_issuer[:-1]}{OIDC_DISCOVERY_PATH}")
+        discovery_urls = [
+            f"{arm_issuer[:-1]}{OIDC_DISCOVERY_PATH}",
+            f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        ]
+    else:
+        discovery_urls = [f"{arm_issuer}{OIDC_DISCOVERY_PATH}"]
 
+    deadline = time.monotonic() + OIDC_DISCOVERY_TIMEOUT_SECONDS
     for discovery_url in discovery_urls:
-        issuer = _read_public_discovery_issuer(discovery_url)
+        issuer = _read_public_discovery_issuer(discovery_url, deadline)
         if issuer and oidc_issuers_match(arm_issuer, issuer):
             return issuer
     return None
@@ -163,8 +177,8 @@ def resolve_oidc_issuer(arm_issuer: str) -> str:
         return discovery_issuer
 
     logger.warning(
-        "Could not verify the OIDC issuer reported by ARM '%s'. The ARM value will be used for the federated "
-        "identity credential, but workload identity token exchange may fail if it differs from the cluster issuer.",
+        "Could not verify the OIDC issuer '%s' from this host. The ARM-reported value will be used "
+        "for the federated identity credential. This may still work if Microsoft Entra can reach the issuer.",
         arm_issuer,
     )
     return arm_issuer

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext
 from typing import Dict, Iterable, List, Optional
 
 import yaml
+from azure.cli.core.auth.util import decode_access_token
 from azure.cli.core.azclierror import (
     AzureResponseError,
     InvalidArgumentValueError,
@@ -16,9 +17,14 @@ from azure.cli.core.azclierror import (
 )
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from knack.log import get_logger
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+from kubernetes.config.config_exception import ConfigException
 from rich import print
 from rich.console import Console
+from urllib3.exceptions import HTTPError
 
+from ...base import load_config_context
 from ....util.az_client import (
     ResourceIdContainer,
     get_iotops_mgmt_client,
@@ -90,6 +96,43 @@ def get_fc_name(cluster_name: str, oidc_issuer: str, subject: str) -> str:
 
 def get_cred_subject(namespace: str, service_account_name: str):
     return f"system:serviceaccount:{namespace}:{service_account_name}"
+
+
+def _get_service_account_issuer(namespace: str, service_account_name: str) -> Optional[str]:
+    token_request = client.AuthenticationV1TokenRequest(
+        spec=client.V1TokenRequestSpec(
+            audiences=["api://AzureADTokenExchange"],
+        )
+    )
+    core_v1_api = client.CoreV1Api()
+    with core_v1_api.create_namespaced_service_account_token(
+        name=service_account_name,
+        namespace=namespace,
+        body=token_request,
+        _preload_content=False,
+        _request_timeout=5,
+    ) as response:
+        token_response = core_v1_api.api_client.deserialize(
+            response,
+            client.AuthenticationV1TokenRequest,
+        )
+    return decode_access_token(token_response.status.token).get("iss")
+
+
+def resolve_oidc_issuer(arm_issuer: str, namespace: str, service_account_name: str) -> str:
+    try:
+        load_config_context()
+        kubernetes_issuer = _get_service_account_issuer(
+            namespace=namespace,
+            service_account_name=service_account_name,
+        )
+    except (ApiException, ConfigException, HTTPError, OSError, yaml.YAMLError):
+        return arm_issuer
+
+    if not kubernetes_issuer or kubernetes_issuer.rstrip("/") != arm_issuer.rstrip("/"):
+        return arm_issuer
+
+    return kubernetes_issuer
 
 
 def get_enable_syntax(instance_name: str, resource_group_name: str) -> str:
@@ -393,6 +436,11 @@ class Instances(Queryable):
                 )
                 return
 
+            oidc_issuer = resolve_oidc_issuer(
+                arm_issuer=oidc_issuer,
+                namespace=namespace,
+                service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
+            )
             if not federated_credential_name:
                 federated_credential_name = get_fc_name(
                     cluster_name=cluster_resource["name"],

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -36,7 +36,6 @@ from azext_edge.edge.providers.orchestration.resources.instances import (
     get_fc_name,
     get_spc_name,
     parse_feature_kvp_nargs,
-    resolve_oidc_issuer,
 )
 from azext_edge.edge.util.machinery import scoped_semver_import
 from ....generators import (
@@ -676,6 +675,7 @@ def test_secretsync_enable(
     custom_role_id: Optional[str],
     tags: Optional[dict],
     mocked_get_tenant_id: Mock,
+    mocked_resolve_oidc_issuer: Mock,
 ):
     oidc_issuer_def = {
         "oidcIssuerProfile": {
@@ -874,6 +874,7 @@ def test_secretsync_enable(
         wait_sec=0.1,
     )
     assert result == spc_payload
+    mocked_resolve_oidc_issuer.assert_called_once_with(arm_issuer=oidc_issuer)
     spc_create_request = json.loads(spc_create.calls[0].request.body)
     assert spc_create_request["extendedLocation"] == instance_record["extendedLocation"]
     assert spc_create_request["location"] == cluster_location
@@ -908,35 +909,6 @@ def test_secretsync_enable(
             assert ra_put_request["properties"]["roleDefinitionId"] == role_ids[i]
             assert ra_put_request["properties"]["principalId"] == principal_id
             assert ra_put_request["properties"]["principalType"] == "ServicePrincipal"
-
-
-def test_resolve_oidc_issuer_uses_kubernetes_issuer_for_trailing_slash(mocker):
-    arm_issuer = "https://localhost/issuer/"
-    kubernetes_issuer = "https://localhost/issuer"
-    mocker.patch(
-        "azext_edge.edge.providers.orchestration.resources.instances.load_config_context", autospec=True
-    )
-    mocker.patch(
-        "azext_edge.edge.providers.orchestration.resources.instances._get_service_account_issuer",
-        autospec=True,
-        return_value=kubernetes_issuer,
-    )
-
-    assert resolve_oidc_issuer(arm_issuer, "namespace", "service-account") == kubernetes_issuer
-
-
-def test_resolve_oidc_issuer_keeps_arm_issuer_when_issuers_differ(mocker):
-    arm_issuer = "https://localhost/issuer/"
-    mocker.patch(
-        "azext_edge.edge.providers.orchestration.resources.instances.load_config_context", autospec=True
-    )
-    mocker.patch(
-        "azext_edge.edge.providers.orchestration.resources.instances._get_service_account_issuer",
-        autospec=True,
-        return_value="https://other/issuer",
-    )
-
-    assert resolve_oidc_issuer(arm_issuer, "namespace", "service-account") == arm_issuer
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -83,7 +83,7 @@ def mocked_resolve_oidc_issuer(mocker):
     yield mocker.patch(
         "azext_edge.edge.providers.orchestration.resources.instances.resolve_oidc_issuer",
         autospec=True,
-        wraps=lambda arm_issuer, **_: arm_issuer,
+        side_effect=lambda arm_issuer, **_: arm_issuer,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -36,6 +36,7 @@ from azext_edge.edge.providers.orchestration.resources.instances import (
     get_fc_name,
     get_spc_name,
     parse_feature_kvp_nargs,
+    resolve_oidc_issuer,
 )
 from azext_edge.edge.util.machinery import scoped_semver_import
 from ....generators import (
@@ -74,6 +75,15 @@ def mocked_get_tenant_id(mocker):
     yield mocker.patch(
         "azext_edge.edge.providers.orchestration.resources.instances.get_tenant_id",
         return_value=generate_random_string(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def mocked_resolve_oidc_issuer(mocker):
+    yield mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.resolve_oidc_issuer",
+        autospec=True,
+        wraps=lambda arm_issuer, **_: arm_issuer,
     )
 
 
@@ -898,6 +908,35 @@ def test_secretsync_enable(
             assert ra_put_request["properties"]["roleDefinitionId"] == role_ids[i]
             assert ra_put_request["properties"]["principalId"] == principal_id
             assert ra_put_request["properties"]["principalType"] == "ServicePrincipal"
+
+
+def test_resolve_oidc_issuer_uses_kubernetes_issuer_for_trailing_slash(mocker):
+    arm_issuer = "https://localhost/issuer/"
+    kubernetes_issuer = "https://localhost/issuer"
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.load_config_context", autospec=True
+    )
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances._get_service_account_issuer",
+        autospec=True,
+        return_value=kubernetes_issuer,
+    )
+
+    assert resolve_oidc_issuer(arm_issuer, "namespace", "service-account") == kubernetes_issuer
+
+
+def test_resolve_oidc_issuer_keeps_arm_issuer_when_issuers_differ(mocker):
+    arm_issuer = "https://localhost/issuer/"
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.load_config_context", autospec=True
+    )
+    mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances._get_service_account_issuer",
+        autospec=True,
+        return_value="https://other/issuer",
+    )
+
+    assert resolve_oidc_issuer(arm_issuer, "namespace", "service-account") == arm_issuer
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
@@ -4,12 +4,16 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
+import json
+import time
+
 import requests
 import responses
 
 from azext_edge.edge.providers.orchestration.resources.instances import (
     OIDC_DISCOVERY_MAX_RESPONSE_BYTES,
     OIDC_DISCOVERY_PATH,
+    _read_public_discovery_issuer,
     resolve_oidc_issuer,
 )
 
@@ -33,11 +37,6 @@ def test_resolve_oidc_issuer_corrects_one_trailing_slash(mocked_responses: respo
     discovery_issuer = arm_issuer[:-1]
     mocked_responses.add(
         method=responses.GET,
-        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
-        status=404,
-    )
-    mocked_responses.add(
-        method=responses.GET,
         url=f"{discovery_issuer}{OIDC_DISCOVERY_PATH}",
         json={"issuer": discovery_issuer},
         status=200,
@@ -46,7 +45,6 @@ def test_resolve_oidc_issuer_corrects_one_trailing_slash(mocked_responses: respo
 
     assert resolve_oidc_issuer(arm_issuer) == discovery_issuer
     assert [call.request.url for call in mocked_responses.calls] == [
-        f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
         f"{discovery_issuer}{OIDC_DISCOVERY_PATH}",
     ]
     warning.assert_called_once()
@@ -58,6 +56,24 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_for_malformed_discovery(mocked_res
         method=responses.GET,
         url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
         body="not-json",
+        status=200,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_keeps_arm_issuer_for_deeply_nested_discovery(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    discovery_issuer = f"{arm_issuer}/"
+    nested_array = "[" * 10_000 + "]" * 10_000
+    body = f'{{"issuer": "{discovery_issuer}", "nested": {nested_array}}}'
+    assert len(body.encode("utf-8")) < OIDC_DISCOVERY_MAX_RESPONSE_BYTES
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        body=body,
         status=200,
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
@@ -126,16 +142,27 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_when_discovery_is_unreachable(mock
 
 def test_resolve_oidc_issuer_rejects_oversized_discovery(mocked_responses: responses, mocker):
     arm_issuer = "https://issuer.example/cluster"
+    discovery_issuer = f"{arm_issuer}/"
+    body = json.dumps({"issuer": discovery_issuer, "padding": "x" * OIDC_DISCOVERY_MAX_RESPONSE_BYTES})
+    assert len(body.encode("utf-8")) > OIDC_DISCOVERY_MAX_RESPONSE_BYTES
     mocked_responses.add(
         method=responses.GET,
         url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
-        body=b"x" * (OIDC_DISCOVERY_MAX_RESPONSE_BYTES + 1),
+        body=body,
         status=200,
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
     assert resolve_oidc_issuer(arm_issuer) == arm_issuer
     warning.assert_called_once()
+
+
+def test_read_public_discovery_issuer_skips_probe_when_budget_exhausted(mocker):
+    request_get = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.requests.get")
+    discovery_url = f"https://issuer.example/cluster{OIDC_DISCOVERY_PATH}"
+    # deadline in the past
+    assert _read_public_discovery_issuer(discovery_url, deadline=time.monotonic() - 1) is None
+    request_get.assert_not_called()
 
 
 def test_resolve_oidc_issuer_ignores_redirects(mocked_responses: responses, mocker):

--- a/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import requests
+import responses
+
+from azext_edge.edge.providers.orchestration.resources.instances import (
+    OIDC_DISCOVERY_MAX_RESPONSE_BYTES,
+    OIDC_DISCOVERY_PATH,
+    resolve_oidc_issuer,
+)
+
+
+def test_resolve_oidc_issuer_uses_exact_public_discovery(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        json={"issuer": arm_issuer},
+        status=200,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_not_called()
+
+
+def test_resolve_oidc_issuer_corrects_one_trailing_slash(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster/"
+    discovery_issuer = arm_issuer[:-1]
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        status=404,
+    )
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{discovery_issuer}{OIDC_DISCOVERY_PATH}",
+        json={"issuer": discovery_issuer},
+        status=200,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == discovery_issuer
+    assert [call.request.url for call in mocked_responses.calls] == [
+        f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        f"{discovery_issuer}{OIDC_DISCOVERY_PATH}",
+    ]
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_keeps_arm_issuer_for_malformed_discovery(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        body="not-json",
+        status=200,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_rejects_more_than_one_trailing_slash(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster//"
+    discovery_issuer = arm_issuer.rstrip("/")
+    for discovery_url in (
+        f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        f"{arm_issuer[:-1]}{OIDC_DISCOVERY_PATH}",
+    ):
+        mocked_responses.add(
+            method=responses.GET,
+            url=discovery_url,
+            json={"issuer": discovery_issuer},
+            status=200,
+        )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_rejects_non_https_issuer(mocker):
+    arm_issuer = "http://issuer.example/cluster"
+    request_get = mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.requests.get",
+        autospec=True,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    request_get.assert_not_called()
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_keeps_arm_issuer_for_malformed_issuer_url(mocker):
+    arm_issuer = "https://[oops"
+    request_get = mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.requests.get",
+        autospec=True,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    request_get.assert_not_called()
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_keeps_arm_issuer_when_discovery_is_unreachable(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        body=requests.ConnectionError(),
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_rejects_oversized_discovery(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        body=b"x" * (OIDC_DISCOVERY_MAX_RESPONSE_BYTES + 1),
+        status=200,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    warning.assert_called_once()
+
+
+def test_resolve_oidc_issuer_ignores_redirects(mocked_responses: responses, mocker):
+    arm_issuer = "https://issuer.example/cluster"
+    mocked_responses.add(
+        method=responses.GET,
+        url=f"{arm_issuer}{OIDC_DISCOVERY_PATH}",
+        headers={"Location": "https://issuer.example/redirect"},
+        status=302,
+    )
+    warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
+
+    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert len(mocked_responses.calls) == 1
+    warning.assert_called_once()

--- a/azext_edge/tests/edge/orchestration/test_clone_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_clone_unit.py
@@ -191,6 +191,15 @@ def mock_pathlib_path(mocker):
     yield patched
 
 
+@pytest.fixture(autouse=True)
+def mocked_clone_resolve_oidc_issuer(mocker):
+    yield mocker.patch(
+        "azext_edge.edge.providers.orchestration.clone.resolve_oidc_issuer",
+        autospec=True,
+        wraps=lambda arm_issuer, **_: arm_issuer,
+    )
+
+
 def get_deploy_url(cluster_sub_id: str, cluster_rg: str, deployment_name: str, page_num: Optional[int] = 1) -> str:
     page_num = "" if not page_num else f"_{page_num}"
     return (
@@ -1293,6 +1302,34 @@ def test_clone_deploy_subjects(
 
     assert deploy_body_payload["properties"]["parameters"] == expected_deploy_params
     assert deploy_body_payload["properties"]["template"]
+
+
+def test_clone_resolves_oidc_issuer(
+    mocker,
+    mocked_clone_resolve_oidc_issuer,
+):
+    arm_issuer = "https://localhost/issuer/"
+    restore = mocker.Mock()
+    restore.user_assigned_mis = [
+        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity"
+    ]
+    restore.connected_cluster.resource = {}
+    restore.instances._ensure_oidc_issuer.return_value = arm_issuer
+    restore.namespace = "namespace"
+
+    msi_client = mocker.patch(
+        "azext_edge.edge.providers.orchestration.clone.get_msi_mgmt_client",
+        autospec=True,
+    ).return_value
+    msi_client.federated_identity_credentials.list.return_value = []
+
+    InstanceRestore._handle_federation(restore)
+
+    mocked_clone_resolve_oidc_issuer.assert_called_once_with(
+        arm_issuer=arm_issuer,
+        namespace="namespace",
+        service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
+    )
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/test_clone_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_clone_unit.py
@@ -1327,8 +1327,6 @@ def test_clone_resolves_oidc_issuer(
 
     mocked_clone_resolve_oidc_issuer.assert_called_once_with(
         arm_issuer=arm_issuer,
-        namespace="namespace",
-        service_account_name=SERVICE_ACCOUNT_SECRETSYNC,
     )
 
 

--- a/azext_edge/tests/edge/orchestration/test_clone_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_clone_unit.py
@@ -196,7 +196,7 @@ def mocked_clone_resolve_oidc_issuer(mocker):
     yield mocker.patch(
         "azext_edge.edge.providers.orchestration.clone.resolve_oidc_issuer",
         autospec=True,
-        wraps=lambda arm_issuer, **_: arm_issuer,
+        side_effect=lambda arm_issuer, **_: arm_issuer,
     )
 
 


### PR DESCRIPTION
## Summary

SecretSync used the OIDC issuer reported by ARM when creating a federated identity credential (FIC). In some configurations the ARM issuer ends with `/` while the service account token `iss` does not. Entra requires an exact match, so secret retrieval fails with `AADSTS700211` (HTTP 401).

## Fix
Resolve the canonical issuer from the cluster's **public OIDC discovery document** (`{issuer}/.well-known/openid-configuration`). By the OIDC contract, the discovery `issuer` is the same value the token carries as `iss` - and the same document Entra fetches unauthenticated to validate the FIC.

- Resolve via a plain unauthenticated HTTPS GET - **no kubeconfig, cluster RBAC, or service account token**. This also works from an ARM-only / CI context and in the clone flow before the target cluster exists.
- Use the discovery issuer **verbatim** in the FIC; accept it only when it is exact or differs from the ARM value by exactly one trailing slash.
- Probe the verbatim URL and, for trailing-slash ARM issuers, also the one-slash-removed URL, use whichever returns a matching issuer (the single-slash form is what succeeds against Azure's OIDC endpoint).
- Warn and keep the ARM value when discovery cannot verify - no new hard-fail on an ARM-only command.
- Harden the request: HTTPS-only, TLS verification, short timeout, bounded response body, and no redirect following (the URL originates from ARM data).
- Use the resolved issuer consistently for FIC lookup, naming, and creation, and apply the same handling to the clone flow.

## Some clarifications...

**Q: Why read the discovery document instead of minting a service account token?**
A: The discovery `issuer` equals the token `iss` by contract, so it yields the same canonical value without requiring cluster access, kubeconfig, RBAC (`serviceaccounts/token`), or the service account to exist. It also works from CI / ARM-only contexts and in clone (before the cluster is deployed).

**Q: Why not always remove the trailing slash?**
A: This is not a failure that happens every time. Some clusters include `/` in their issuer. Normalizing unconditionally could break working configurations, so the canonical discovery value is used verbatim.

**Q: Does this change the common case?**
A: No. When ARM and the discovery issuer already match, the same issuer is used with no warning.

**Q: Why does the FIC lookup remain exact?**
A: Entra treats issuers with and without `/` as different values. The resolved issuer is used for both lookup and creation.

**Q: Does this update existing FICs?**
A: No. Repairing already-created FICs is outside this change's scope (tracked as a follow-up).

## Repro and Tests

### Before:
token iss and ARM issuerUrl mismatch:

iss:
<img width="982" height="161" alt="image" src="https://github.com/user-attachments/assets/288d9ce3-b890-476b-9dce-c17729e09043" />

ARM issueUrl (and FIC):
<img width="1947" height="108" alt="image" src="https://github.com/user-attachments/assets/27a2085c-111f-4424-95ef-a315712d879f" />

Note the trailing slash after `fc`

Result: 401
<img width="1918" height="130" alt="image" src="https://github.com/user-attachments/assets/9835c47a-c00f-4828-aabf-e99e8af47c03" />

### After
token ISS and ARM IssuerUrl remains unchanged, but FIC is normalized
<img width="1937" height="110" alt="Screenshot 2026-07-15 190404" src="https://github.com/user-attachments/assets/6ccae5d2-39e7-4481-93fb-51b1523bc0ac" />
No trailing slash

Result:
<img width="1942" height="526" alt="image" src="https://github.com/user-attachments/assets/3695273a-c02c-40f8-afa4-4fe0a90f2379" />
