### PR TITLE
fix(check): report cluster access-denied per resource instead of false negatives

### DIFF
--- a/azext_edge/edge/providers/base.py
+++ b/azext_edge/edge/providers/base.py
@@ -46,6 +46,15 @@ def load_config_context(context_name: Optional[str] = None):
     DEFAULT_NAMESPACE = current_config.get("namespace") or "azure-iot-operations"
 
 
+class ClusterAccessDeniedError(Exception):
+    """Raised when a cluster API call is rejected with HTTP 401/403 due to missing permissions."""
+
+    def __init__(self, status: Optional[int], resource: Optional[str] = None):
+        self.status = int(status or 403)
+        self.resource = resource
+        super().__init__(f"Access denied (HTTP {self.status})" + (f" for '{resource}'" if resource else ""))
+
+
 _namespaced_service_cache: dict = {}
 
 
@@ -110,7 +119,12 @@ _custom_object_cache: dict = {}
 
 
 def get_custom_objects(
-    group: str, version: str, plural: str, namespace: Optional[str] = None, use_cache: bool = True
+    group: str,
+    version: str,
+    plural: str,
+    namespace: Optional[str] = None,
+    use_cache: bool = True,
+    raise_on_access_error: bool = False,
 ) -> Union[dict, None]:
     target_resource_key = (group, version, plural, namespace)
     if use_cache:
@@ -128,6 +142,8 @@ def get_custom_objects(
         _custom_object_cache[target_resource_key] = f(**kwargs)
     except ApiException as ae:
         logger.debug(str(ae))
+        if raise_on_access_error and int(ae.status or 0) in (401, 403):
+            raise ClusterAccessDeniedError(status=ae.status, resource=plural)
     else:
         return _custom_object_cache[target_resource_key]
 

--- a/azext_edge/edge/providers/base.py
+++ b/azext_edge/edge/providers/base.py
@@ -48,7 +48,7 @@ def load_config_context(context_name: Optional[str] = None):
 
 
 class ClusterAccessDeniedError(Exception):
-    """Raised when a cluster API call is rejected with HTTP 401/403 due to missing permissions."""
+    """Raised when a cluster API call is rejected with HTTP 401/403 (authentication/authorization failure)."""
 
     def __init__(self, status: Optional[int], resource: Optional[str] = None):
         self.status = int(status or 403)
@@ -73,7 +73,7 @@ def reraise_cluster_access_errors() -> Iterator[None]:
         _reraise_access_errors.reset(token)
 
 
-def _reraise_if_access_denied(ae: ApiException, resource: Optional[str] = None) -> None:
+def reraise_if_access_denied(ae: ApiException, resource: Optional[str] = None) -> None:
     if _reraise_access_errors.get() and int(getattr(ae, "status", 0) or 0) in (401, 403):
         raise ClusterAccessDeniedError(status=ae.status, resource=resource)
 
@@ -98,7 +98,7 @@ def get_namespaced_service(name: str, namespace: str, as_dict: bool = False) -> 
         _namespaced_service_cache[target_service_key] = v1_service
     except ApiException as ae:
         logger.debug(str(ae))
-        _reraise_if_access_denied(ae, resource=f"service/{name}")
+        reraise_if_access_denied(ae, resource=f"service/{name}")
     else:
         return retrieve_namespaced_service_from_cache(target_service_key)
 
@@ -134,7 +134,7 @@ def get_namespaced_pods_by_prefix(
         _namespaced_pods_cache[target_pods_key] = pods_list.items
     except ApiException as ae:
         logger.debug(str(ae))
-        _reraise_if_access_denied(ae, resource="pods")
+        reraise_if_access_denied(ae, resource="pods")
         return []
     else:
         return filter_pods_from_cache(target_pods_key)
@@ -166,7 +166,7 @@ def get_custom_objects(
         _custom_object_cache[target_resource_key] = f(**kwargs)
     except ApiException as ae:
         logger.debug(str(ae))
-        _reraise_if_access_denied(ae, resource=plural)
+        reraise_if_access_denied(ae, resource=plural)
     else:
         return _custom_object_cache[target_resource_key]
 
@@ -188,7 +188,7 @@ def get_cluster_custom_api(group: str, version: str, raise_on_404: bool = False)
         logger.debug(msg=str(ae))
         if int(ae.status) == 404 and raise_on_404:
             raise ResourceNotFoundError(f"{group}/{version} resource API is not detected on the cluster.")
-        _reraise_if_access_denied(ae, resource=f"{group}/{version}")
+        reraise_if_access_denied(ae, resource=f"{group}/{version}")
     else:
         return _cluster_resource_api_cache[target_resource_api_key]
 
@@ -317,7 +317,7 @@ def get_namespaced_secret(namespace: str, secret_name: str) -> dict:
     except ApiException as ae:
         error_msg = str(ae)
         logger.debug(msg=error_msg)
-        _reraise_if_access_denied(ae, resource=f"secret/{secret_name}")
+        reraise_if_access_denied(ae, resource=f"secret/{secret_name}")
     else:
         if result:
             return generic.sanitize_for_serialization(obj=result)

--- a/azext_edge/edge/providers/base.py
+++ b/azext_edge/edge/providers/base.py
@@ -6,6 +6,7 @@
 
 import socket
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Dict, Iterator, List, Optional, Union
 from urllib.request import urlopen
 
@@ -55,6 +56,28 @@ class ClusterAccessDeniedError(Exception):
         super().__init__(f"Access denied (HTTP {self.status})" + (f" for '{resource}'" if resource else ""))
 
 
+_reraise_access_errors: ContextVar[bool] = ContextVar("aio_reraise_cluster_access_errors", default=False)
+
+
+@contextmanager
+def reraise_cluster_access_errors() -> Iterator[None]:
+    """
+    Within this context, the shared cluster read helpers raise ClusterAccessDeniedError on HTTP
+    401/403 instead of swallowing the error and returning an empty result. This lets the check
+    command surface a precise per-resource 'access denied' rather than a misleading false negative.
+    """
+    token = _reraise_access_errors.set(True)
+    try:
+        yield
+    finally:
+        _reraise_access_errors.reset(token)
+
+
+def _reraise_if_access_denied(ae: ApiException, resource: Optional[str] = None) -> None:
+    if _reraise_access_errors.get() and int(getattr(ae, "status", 0) or 0) in (401, 403):
+        raise ClusterAccessDeniedError(status=ae.status, resource=resource)
+
+
 _namespaced_service_cache: dict = {}
 
 
@@ -75,6 +98,7 @@ def get_namespaced_service(name: str, namespace: str, as_dict: bool = False) -> 
         _namespaced_service_cache[target_service_key] = v1_service
     except ApiException as ae:
         logger.debug(str(ae))
+        _reraise_if_access_denied(ae, resource=f"service/{name}")
     else:
         return retrieve_namespaced_service_from_cache(target_service_key)
 
@@ -110,6 +134,7 @@ def get_namespaced_pods_by_prefix(
         _namespaced_pods_cache[target_pods_key] = pods_list.items
     except ApiException as ae:
         logger.debug(str(ae))
+        _reraise_if_access_denied(ae, resource="pods")
         return []
     else:
         return filter_pods_from_cache(target_pods_key)
@@ -124,7 +149,6 @@ def get_custom_objects(
     plural: str,
     namespace: Optional[str] = None,
     use_cache: bool = True,
-    raise_on_access_error: bool = False,
 ) -> Union[dict, None]:
     target_resource_key = (group, version, plural, namespace)
     if use_cache:
@@ -142,8 +166,7 @@ def get_custom_objects(
         _custom_object_cache[target_resource_key] = f(**kwargs)
     except ApiException as ae:
         logger.debug(str(ae))
-        if raise_on_access_error and int(ae.status or 0) in (401, 403):
-            raise ClusterAccessDeniedError(status=ae.status, resource=plural)
+        _reraise_if_access_denied(ae, resource=plural)
     else:
         return _custom_object_cache[target_resource_key]
 
@@ -165,6 +188,7 @@ def get_cluster_custom_api(group: str, version: str, raise_on_404: bool = False)
         logger.debug(msg=str(ae))
         if int(ae.status) == 404 and raise_on_404:
             raise ResourceNotFoundError(f"{group}/{version} resource API is not detected on the cluster.")
+        _reraise_if_access_denied(ae, resource=f"{group}/{version}")
     else:
         return _cluster_resource_api_cache[target_resource_api_key]
 
@@ -293,6 +317,7 @@ def get_namespaced_secret(namespace: str, secret_name: str) -> dict:
     except ApiException as ae:
         error_msg = str(ae)
         logger.debug(msg=error_msg)
+        _reraise_if_access_denied(ae, resource=f"secret/{secret_name}")
     else:
         if result:
             return generic.sanitize_for_serialization(obj=result)

--- a/azext_edge/edge/providers/check/base/deployment.py
+++ b/azext_edge/edge/providers/check/base/deployment.py
@@ -28,13 +28,25 @@ logger = get_logger(__name__)
 def _build_access_denied_result(resource: ListableEnum, error: ClusterAccessDeniedError, as_list: bool = False) -> dict:
     """Build a precise per-resource 'access denied' check result for a 401/403 on a single kind."""
     kind = getattr(resource, "value", str(resource))
+    # Prefer the actual denied read (error.resource) since an evaluator may read more than one kind;
+    # fall back to the evaluator kind when the denied read is unlabeled.
+    denied_name = str(error.resource or kind)
     check_manager = CheckManager(check_name=f"eval{kind}Access", check_desc=f"Evaluate {kind}")
-    target = str(error.resource or kind)
+    target = denied_name
     check_manager.add_target(target_name=target)
-    denied_text = (
-        f"[red]Access denied[/red] (HTTP {error.status}). "
-        f"Principal lacks permission to read [bright_blue]{kind}[/bright_blue]."
-    )
+    if error.status == 401:
+        # 401 is an authentication failure (e.g. expired/invalid kubeconfig token), not a permissions issue.
+        denied_text = (
+            f"[red]Access denied[/red] (HTTP {error.status}). Could not authenticate to the cluster while "
+            f"reading [bright_blue]{denied_name}[/bright_blue]."
+        )
+        remediation_text = "Verify your cluster credentials (kubeconfig token may be expired or invalid)."
+    else:
+        denied_text = (
+            f"[red]Access denied[/red] (HTTP {error.status}). "
+            f"Principal lacks permission to read [bright_blue]{denied_name}[/bright_blue]."
+        )
+        remediation_text = "Grant read access to this resource to evaluate it."
     check_manager.add_target_eval(
         target_name=target,
         status=CheckTaskStatus.error.value,
@@ -43,7 +55,7 @@ def _build_access_denied_result(resource: ListableEnum, error: ClusterAccessDeni
     check_manager.add_display(target_name=target, display=Padding(denied_text, (0, 0, 0, 8)))
     check_manager.add_display(
         target_name=target,
-        display=Padding("Grant read access to this resource to evaluate it.", (0, 0, 0, 10)),
+        display=Padding(remediation_text, (0, 0, 0, 10)),
     )
     result = check_manager.as_dict(as_list)
     # Marker so rolled-up views (e.g. the summary) can surface the permission reason inline

--- a/azext_edge/edge/providers/check/base/deployment.py
+++ b/azext_edge/edge/providers/check/base/deployment.py
@@ -15,8 +15,14 @@ from rich.padding import Padding
 
 from ....common import CheckTaskStatus, ListableEnum
 from ....providers.edge_api import EdgeResourceApi
-from ...base import ClusterAccessDeniedError, client, load_config_context
-from ..common import NON_ERROR_STATUSES, CoreServiceResourceKinds, ResourceOutputDetailLevel
+from ...base import ClusterAccessDeniedError, client, load_config_context, reraise_if_access_denied
+from ..common import (
+    NON_ERROR_STATUSES,
+    CoreServiceResourceKinds,
+    ResourceOutputDetailLevel,
+    build_access_denied_remediation,
+    build_access_denied_text,
+)
 from .check_manager import CheckManager
 from .node import check_nodes
 from .resource import enumerate_ops_service_resources
@@ -34,19 +40,8 @@ def _build_access_denied_result(resource: ListableEnum, error: ClusterAccessDeni
     check_manager = CheckManager(check_name=f"eval{kind}Access", check_desc=f"Evaluate {kind}")
     target = denied_name
     check_manager.add_target(target_name=target)
-    if error.status == 401:
-        # 401 is an authentication failure (e.g. expired/invalid kubeconfig token), not a permissions issue.
-        denied_text = (
-            f"[red]Access denied[/red] (HTTP {error.status}). Could not authenticate to the cluster while "
-            f"reading [bright_blue]{denied_name}[/bright_blue]."
-        )
-        remediation_text = "Verify your cluster credentials (kubeconfig token may be expired or invalid)."
-    else:
-        denied_text = (
-            f"[red]Access denied[/red] (HTTP {error.status}). "
-            f"Principal lacks permission to read [bright_blue]{denied_name}[/bright_blue]."
-        )
-        remediation_text = "Grant read access to this resource to evaluate it."
+    denied_text = build_access_denied_text(error.status, denied_name)
+    remediation_text = build_access_denied_remediation(error.status)
     check_manager.add_target_eval(
         target_name=target,
         status=CheckTaskStatus.error.value,
@@ -120,7 +115,12 @@ def check_pre_deployment(
             }
         )
     for c in desired_checks:
-        output = desired_checks[c]()
+        try:
+            output = desired_checks[c]()
+        except ClusterAccessDeniedError as access_error:
+            # Principal lacks access to a precheck resource (nodes / k8s version / storage classes):
+            # report a precise access-denied result instead of a generic connectivity error.
+            output = _build_access_denied_result(access_error.resource or c, access_error, as_list)
         result.append(output)
     return result
 
@@ -189,6 +189,7 @@ def _check_k8s_version(as_list: bool = False) -> Dict[str, Any]:
         version_details: VersionInfo = version_client.get_code()
     except (ApiException, ImportError) as ae:
         logger.debug(str(ae))
+        reraise_if_access_denied(ae, resource="kubernetes version")
         api_error_text = UNABLE_TO_DETERMINE_VERSION_MSG
         check_manager.add_target_eval(
             target_name=target_k8s_version,
@@ -242,6 +243,7 @@ def _check_storage_classes(acs_config: dict, as_list: bool = False) -> Dict[str,
         storage_classes: V1StorageClassList = storage_client.list_storage_class()
     except ApiException as ae:
         logger.debug(str(ae))
+        reraise_if_access_denied(ae, resource="storage classes")
         api_error_text = "Unable to fetch storage classes"
         check_manager.add_target_eval(
             target_name=target,

--- a/azext_edge/edge/providers/check/base/deployment.py
+++ b/azext_edge/edge/providers/check/base/deployment.py
@@ -15,7 +15,7 @@ from rich.padding import Padding
 
 from ....common import CheckTaskStatus, ListableEnum
 from ....providers.edge_api import EdgeResourceApi
-from ...base import client, load_config_context
+from ...base import ClusterAccessDeniedError, client, load_config_context
 from ..common import NON_ERROR_STATUSES, CoreServiceResourceKinds, ResourceOutputDetailLevel
 from .check_manager import CheckManager
 from .node import check_nodes
@@ -23,6 +23,34 @@ from .resource import enumerate_ops_service_resources
 from .user_strings import UNABLE_TO_DETERMINE_VERSION_MSG
 
 logger = get_logger(__name__)
+
+
+def _build_access_denied_result(resource: ListableEnum, error: ClusterAccessDeniedError, as_list: bool = False) -> dict:
+    """Build a precise per-resource 'access denied' check result for a 401/403 on a single kind."""
+    kind = getattr(resource, "value", str(resource))
+    check_manager = CheckManager(check_name=f"eval{kind}Access", check_desc=f"Evaluate {kind}")
+    target = str(error.resource or kind)
+    check_manager.add_target(target_name=target)
+    denied_text = (
+        f"[red]Access denied[/red] (HTTP {error.status}). "
+        f"Principal lacks permission to read [bright_blue]{kind}[/bright_blue]."
+    )
+    check_manager.add_target_eval(
+        target_name=target,
+        status=CheckTaskStatus.error.value,
+        value=f"Access denied (HTTP {error.status}) reading '{target}'",
+    )
+    check_manager.add_display(target_name=target, display=Padding(denied_text, (0, 0, 0, 8)))
+    check_manager.add_display(
+        target_name=target,
+        display=Padding("Grant read access to this resource to evaluate it.", (0, 0, 0, 10)),
+    )
+    result = check_manager.as_dict(as_list)
+    # Marker so rolled-up views (e.g. the summary) can surface the permission reason inline
+    # instead of showing an ambiguous error icon.
+    result["accessDenied"] = error.status
+    return result
+
 
 
 def validate_cluster_prechecks(**kwargs) -> None:
@@ -119,7 +147,14 @@ def check_post_deployment(
             append_resource = True
 
         if append_resource:
-            results.append(evaluate_func(detail_level=detail_level, as_list=as_list, resource_name=resource_name))
+            try:
+                results.append(
+                    evaluate_func(detail_level=detail_level, as_list=as_list, resource_name=resource_name)
+                )
+            except ClusterAccessDeniedError as access_error:
+                # Principal lacks permission to read this specific resource kind: report a precise
+                # per-resource 'access denied' result instead of a misleading 'unable to fetch'.
+                results.append(_build_access_denied_result(resource, access_error, as_list))
     return results
 
 

--- a/azext_edge/edge/providers/check/base/deployment.py
+++ b/azext_edge/edge/providers/check/base/deployment.py
@@ -52,7 +52,6 @@ def _build_access_denied_result(resource: ListableEnum, error: ClusterAccessDeni
     return result
 
 
-
 def validate_cluster_prechecks(**kwargs) -> None:
     context_name = kwargs.get("context_name")
     load_config_context(context_name=context_name)

--- a/azext_edge/edge/providers/check/base/node.py
+++ b/azext_edge/edge/providers/check/base/node.py
@@ -47,6 +47,9 @@ def check_nodes(
         nodes: V1NodeList = core_client.list_node()
     except ApiException as ae:
         logger.debug(str(ae))
+        from ...base import reraise_if_access_denied
+
+        reraise_if_access_denied(ae, resource="nodes")
         api_error_text = UNABLE_TO_FETCH_NODES_MSG
         check_manager.add_target_eval(
             target_name=target,

--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -117,7 +117,9 @@ def get_resources_by_name(
     resource_name: str,
     namespace: str = None,
 ) -> List[dict]:
-    resources: list = (api_info.get_resources(kind=kind, namespace=namespace) or {}).get("items", [])
+    resources: list = (
+        api_info.get_resources(kind=kind, namespace=namespace, raise_on_access_error=True) or {}
+    ).get("items", [])
     resources = filter_resources_by_name(resources, resource_name)
     return resources
 

--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -18,7 +18,13 @@ from azext_edge.edge.providers.k8s.config_map import get_config_map
 
 from .check_manager import CheckManager
 from .display import process_value_color
-from ..common import COLOR_STR_FORMAT, PADDING_SIZE, ResourceOutputDetailLevel, ValidationResourceType
+from ..common import (
+    COLOR_STR_FORMAT,
+    PADDING_SIZE,
+    ResourceOutputDetailLevel,
+    ValidationResourceType,
+    build_access_denied_text,
+)
 from ...base import get_cluster_custom_api, get_namespaced_secret, ClusterAccessDeniedError
 from ...edge_api import EdgeResourceApi
 from ....common import CheckTaskStatus, ResourceState
@@ -49,16 +55,7 @@ def enumerate_ops_service_resources(
     try:
         api_resources: V1APIResourceList = get_cluster_custom_api(group=api_info.group, version=api_info.version)
     except ClusterAccessDeniedError as access_error:
-        if access_error.status == 401:
-            denied_text = (
-                f"[red]Access denied[/red] (HTTP {access_error.status}). Could not authenticate to the cluster "
-                f"while reading [bright_blue]{target_api}[/bright_blue] API resources."
-            )
-        else:
-            denied_text = (
-                f"[red]Access denied[/red] (HTTP {access_error.status}). Principal lacks permission to read "
-                f"[bright_blue]{target_api}[/bright_blue] API resources."
-            )
+        denied_text = build_access_denied_text(access_error.status, f"{target_api} API resources")
         check_manager.add_target_eval(
             target_name=target_api,
             status=CheckTaskStatus.error.value,
@@ -502,14 +499,21 @@ def process_custom_resource_status(
                 )
 
 
-def validate_runtime_resource_ref(name: str, namespace: str, ref_type: ValidationResourceType) -> bool:
+def validate_runtime_resource_ref(
+    name: str, namespace: str, ref_type: ValidationResourceType
+) -> Union[bool, ClusterAccessDeniedError]:
     ref_obj = None
-    if ref_type == ValidationResourceType.secret:
-        ref_obj = get_namespaced_secret(secret_name=name, namespace=namespace)
-    elif ref_type == ValidationResourceType.configmap:
-        ref_obj = get_config_map(name=name, namespace=namespace)
-    else:
-        raise ValueError(f"Unsupported ref type: {ref_type}")
+    try:
+        if ref_type == ValidationResourceType.secret:
+            ref_obj = get_namespaced_secret(secret_name=name, namespace=namespace)
+        elif ref_type == ValidationResourceType.configmap:
+            ref_obj = get_config_map(name=name, namespace=namespace)
+        else:
+            raise ValueError(f"Unsupported ref type: {ref_type}")
+    except ClusterAccessDeniedError as access_error:
+        # Preserve the caller's other findings: report the denied reference inline (via the
+        # returned error) instead of unwinding the whole evaluator.
+        return access_error
 
     return bool(ref_obj)
 

--- a/azext_edge/edge/providers/check/base/resource.py
+++ b/azext_edge/edge/providers/check/base/resource.py
@@ -19,7 +19,7 @@ from azext_edge.edge.providers.k8s.config_map import get_config_map
 from .check_manager import CheckManager
 from .display import process_value_color
 from ..common import COLOR_STR_FORMAT, PADDING_SIZE, ResourceOutputDetailLevel, ValidationResourceType
-from ...base import get_cluster_custom_api, get_namespaced_secret
+from ...base import get_cluster_custom_api, get_namespaced_secret, ClusterAccessDeniedError
 from ...edge_api import EdgeResourceApi
 from ....common import CheckTaskStatus, ResourceState
 
@@ -46,7 +46,28 @@ def enumerate_ops_service_resources(
     check_manager = CheckManager(check_name=check_name, check_desc=check_desc)
     check_manager.add_target(target_name=target_api)
 
-    api_resources: V1APIResourceList = get_cluster_custom_api(group=api_info.group, version=api_info.version)
+    try:
+        api_resources: V1APIResourceList = get_cluster_custom_api(group=api_info.group, version=api_info.version)
+    except ClusterAccessDeniedError as access_error:
+        if access_error.status == 401:
+            denied_text = (
+                f"[red]Access denied[/red] (HTTP {access_error.status}). Could not authenticate to the cluster "
+                f"while reading [bright_blue]{target_api}[/bright_blue] API resources."
+            )
+        else:
+            denied_text = (
+                f"[red]Access denied[/red] (HTTP {access_error.status}). Principal lacks permission to read "
+                f"[bright_blue]{target_api}[/bright_blue] API resources."
+            )
+        check_manager.add_target_eval(
+            target_name=target_api,
+            status=CheckTaskStatus.error.value,
+            value=f"Access denied (HTTP {access_error.status}) reading '{target_api}'",
+        )
+        check_manager.add_display(target_name=target_api, display=Padding(denied_text, (0, 0, 0, 8)))
+        result = check_manager.as_dict(as_list)
+        result["accessDenied"] = access_error.status
+        return result, resource_kind_map
 
     if not api_resources:
         check_manager.add_target_eval(target_name=target_api, status=CheckTaskStatus.error.value)
@@ -117,9 +138,7 @@ def get_resources_by_name(
     resource_name: str,
     namespace: str = None,
 ) -> List[dict]:
-    resources: list = (
-        api_info.get_resources(kind=kind, namespace=namespace, raise_on_access_error=True) or {}
-    ).get("items", [])
+    resources: list = (api_info.get_resources(kind=kind, namespace=namespace) or {}).get("items", [])
     resources = filter_resources_by_name(resources, resource_name)
     return resources
 

--- a/azext_edge/edge/providers/check/common.py
+++ b/azext_edge/edge/providers/check/common.py
@@ -213,3 +213,26 @@ PADDING_SIZE = 4
 DEFAULT_PROPERTY_DISPLAY_COLOR = "cyan"
 
 COLOR_STR_FORMAT = "[{color}]{value}[/{color}]"
+
+
+def build_access_denied_text(status: int, resource: str) -> str:
+    """
+    Colorized access-denied message that distinguishes authentication (401) from
+    authorization (403), so callers don't duplicate the wording.
+    """
+    if int(status) == 401:
+        return (
+            f"[red]Access denied[/red] (HTTP {status}). Could not authenticate to the cluster "
+            f"while reading [bright_blue]{resource}[/bright_blue]."
+        )
+    return (
+        f"[red]Access denied[/red] (HTTP {status}). "
+        f"Principal lacks permission to read [bright_blue]{resource}[/bright_blue]."
+    )
+
+
+def build_access_denied_remediation(status: int) -> str:
+    """Remediation hint matching the access-denied cause (401 authn vs 403 authz)."""
+    if int(status) == 401:
+        return "Verify your cluster credentials (kubeconfig token may be expired or invalid)."
+    return "Grant read access to this resource to evaluate it."

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -608,53 +608,72 @@ def evaluate_brokers(
 
             pods: List[dict] = []
 
-            for prefix in [
-                AIO_BROKER_DIAGNOSTICS_PROBE_PREFIX,
-                AIO_BROKER_FRONTEND_PREFIX,
-                AIO_BROKER_BACKEND_PREFIX,
-                AIO_BROKER_AUTH_PREFIX,
-                AIO_BROKER_HEALTH_MANAGER,
-                AIO_BROKER_DIAGNOSTICS_SERVICE,
-                AIO_BROKER_OPERATOR,
-                # AIO_BROKER_FLUENT_BIT,
-                # TODO: Fluent Bit is deployed to all nodes and stays in a pending state until an
-                # AIO workload is running on the node. For clusters with many nodes, usually
-                # some instances of Fluent Bit will be in a pending state. This is expected.
-            ]:
-                prefixed_pods = get_namespaced_pods_by_prefix(
-                    prefix=prefix,
-                    namespace=namespace,
-                    label_selector=MQ_NAME_LABEL,
-                )
-
-                if not prefixed_pods:
-                    add_display_and_eval(
-                        check_manager=check_manager,
-                        target_name=target_brokers,
-                        display_text=f"{prefix}* {colorize_string(color='yellow', value='not detected')}.",
-                        eval_status=CheckTaskStatus.warning.value,
-                        eval_value=None,
-                        resource_name=prefix,
+            try:
+                for prefix in [
+                    AIO_BROKER_DIAGNOSTICS_PROBE_PREFIX,
+                    AIO_BROKER_FRONTEND_PREFIX,
+                    AIO_BROKER_BACKEND_PREFIX,
+                    AIO_BROKER_AUTH_PREFIX,
+                    AIO_BROKER_HEALTH_MANAGER,
+                    AIO_BROKER_DIAGNOSTICS_SERVICE,
+                    AIO_BROKER_OPERATOR,
+                    # AIO_BROKER_FLUENT_BIT,
+                    # TODO: Fluent Bit is deployed to all nodes and stays in a pending state until an
+                    # AIO workload is running on the node. For clusters with many nodes, usually
+                    # some instances of Fluent Bit will be in a pending state. This is expected.
+                ]:
+                    prefixed_pods = get_namespaced_pods_by_prefix(
+                        prefix=prefix,
                         namespace=namespace,
-                        padding=(0, 0, 0, broker_properties_padding),
-                    )
-                else:
-                    pods.extend(
-                        get_namespaced_pods_by_prefix(
-                            prefix=prefix,
-                            namespace="",
-                            label_selector=MQ_NAME_LABEL,
-                        )
+                        label_selector=MQ_NAME_LABEL,
                     )
 
-            evaluate_pod_health(
-                check_manager=check_manager,
-                target=target_brokers,
-                namespace=namespace,
-                padding=broker_properties_padding,
-                pods=pods,
-                detail_level=detail_level,
-            )
+                    if not prefixed_pods:
+                        add_display_and_eval(
+                            check_manager=check_manager,
+                            target_name=target_brokers,
+                            display_text=f"{prefix}* {colorize_string(color='yellow', value='not detected')}.",
+                            eval_status=CheckTaskStatus.warning.value,
+                            eval_value=None,
+                            resource_name=prefix,
+                            namespace=namespace,
+                            padding=(0, 0, 0, broker_properties_padding),
+                        )
+                    else:
+                        pods.extend(
+                            get_namespaced_pods_by_prefix(
+                                prefix=prefix,
+                                namespace="",
+                                label_selector=MQ_NAME_LABEL,
+                            )
+                        )
+
+                evaluate_pod_health(
+                    check_manager=check_manager,
+                    target=target_brokers,
+                    namespace=namespace,
+                    padding=broker_properties_padding,
+                    pods=pods,
+                    detail_level=detail_level,
+                )
+            except ClusterAccessDeniedError as access_error:
+                # Denied on the secondary pod reads: keep the broker findings and report inline.
+                denied_resource = str(access_error.resource or "pods")
+                check_manager.add_target_eval(
+                    target_name=target_brokers,
+                    namespace=namespace,
+                    status=CheckTaskStatus.error.value,
+                    value=f"Access denied (HTTP {access_error.status}) reading {denied_resource}",
+                    resource_name=denied_resource,
+                )
+                check_manager.add_display(
+                    target_name=target_brokers,
+                    namespace=namespace,
+                    display=Padding(
+                        "\n" + build_access_denied_text(access_error.status, denied_resource),
+                        (0, 0, 0, broker_properties_padding),
+                    ),
+                )
 
     return check_manager.as_dict(as_list)
 

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -1188,9 +1188,28 @@ def _evaluate_broker_diagnostics_service(
     namespace: str,
     detail_level: int = ResourceOutputDetailLevel.summary.value,
 ) -> None:
-    diagnostics_service = get_namespaced_service(
-        name=AIO_BROKER_DIAGNOSTICS_SERVICE, namespace=namespace, as_dict=True
-    )
+    try:
+        diagnostics_service = get_namespaced_service(
+            name=AIO_BROKER_DIAGNOSTICS_SERVICE, namespace=namespace, as_dict=True
+        )
+    except ClusterAccessDeniedError as access_error:
+        # Denied on the secondary diagnostics service read: keep the broker findings and report inline.
+        check_manager.add_target_eval(
+            target_name=target_brokers,
+            namespace=namespace,
+            status=CheckTaskStatus.error.value,
+            value=f"Access denied (HTTP {access_error.status}) reading service/{AIO_BROKER_DIAGNOSTICS_SERVICE}",
+            resource_name=f"service/{AIO_BROKER_DIAGNOSTICS_SERVICE}",
+        )
+        check_manager.add_display(
+            target_name=target_brokers,
+            namespace=namespace,
+            display=Padding(
+                "\n" + build_access_denied_text(access_error.status, f"service {AIO_BROKER_DIAGNOSTICS_SERVICE}"),
+                (0, 0, 0, 12),
+            ),
+        )
+        return
     if not diagnostics_service:
         check_manager.add_target_eval(
             target_name=target_brokers,

--- a/azext_edge/edge/providers/check/mq.py
+++ b/azext_edge/edge/providers/check/mq.py
@@ -42,12 +42,36 @@ from .common import (
     CheckResult,
     ResourceOutputDetailLevel,
     ValidationResourceType,
+    build_access_denied_text,
 )
 
 from ...providers.edge_api import MQ_ACTIVE_API, MqResourceKinds
 from ..support.mq import MQ_NAME_LABEL
 
-from ..base import get_namespaced_pods_by_prefix, get_namespaced_service
+from ..base import ClusterAccessDeniedError, get_namespaced_pods_by_prefix, get_namespaced_service
+
+
+def _render_ref_validation(ref_result, ref_type: ValidationResourceType, name: str):
+    """
+    Map a validate_runtime_resource_ref result to (display_text, eval_status).
+
+    A ClusterAccessDeniedError result renders a precise inline 'access denied' row so the
+    evaluator keeps its other findings instead of unwinding on a denied reference read.
+    """
+    if isinstance(ref_result, ClusterAccessDeniedError):
+        return (
+            build_access_denied_text(ref_result.status, f"{ref_type.value} reference {name}"),
+            CheckTaskStatus.error.value,
+        )
+    if ref_result:
+        return (
+            f"[green]Valid[/green] {ref_type.value} reference {{[green]{name}[/green]}}.",
+            CheckTaskStatus.success.value,
+        )
+    return (
+        f"[red]Invalid[/red] {ref_type.value} reference {{[red]{name}[/red]}}.",
+        CheckTaskStatus.error.value,
+    )
 
 
 def check_mq_deployment(
@@ -1008,9 +1032,30 @@ def _evaluate_listener_service(
         conditions=["listener_service"],
     )
 
-    associated_service: dict = get_namespaced_service(
-        name=listener_spec_service_name, namespace=namespace, as_dict=True
-    )
+    associated_service: dict = None
+    try:
+        associated_service = get_namespaced_service(
+            name=listener_spec_service_name, namespace=namespace, as_dict=True
+        )
+    except ClusterAccessDeniedError as access_error:
+        # Denied on the secondary service read: keep the listener findings and report inline.
+        processed_services[listener_spec_service_name] = True
+        check_manager.add_display(
+            target_name=target_listeners,
+            namespace=namespace,
+            display=Padding(
+                "\n" + build_access_denied_text(access_error.status, f"service {listener_spec_service_name}"),
+                (0, 0, 0, 12),
+            ),
+        )
+        check_manager.add_target_eval(
+            target_name=target_listener_service,
+            namespace=namespace,
+            status=CheckTaskStatus.error.value,
+            value={"listener_service": f"Access denied (HTTP {access_error.status})"},
+            resource_name=f"service/{listener_spec_service_name}",
+        )
+        return
     processed_services[listener_spec_service_name] = True
     if not associated_service:
         listener_service_eval_status = CheckTaskStatus.warning.value
@@ -1332,19 +1377,17 @@ def _check_authentication_method(
             trusted_client_ca_cert_value = {
                 "spec.authenticationMethods[*].x509Settings.trustedClientCaCert": trusted_client_ca_cert
             }
-            is_valid = validate_runtime_resource_ref(
+            ref_result = validate_runtime_resource_ref(
                 namespace=namespace,
                 name=trusted_client_ca_cert,
                 ref_type=ValidationResourceType.configmap,
             )
 
-            if is_valid:
-                configmap_validate_text = f"[green]Valid[/green] {ValidationResourceType.configmap.value} reference {{[green]{trusted_client_ca_cert}[/green]}}."
-            else:
-                configmap_validate_text = f"[red]Invalid[/red] {ValidationResourceType.configmap.value} reference {{[red]{trusted_client_ca_cert}[/red]}}."
+            configmap_validate_text, trusted_client_ca_cert_status = _render_ref_validation(
+                ref_result, ValidationResourceType.configmap, trusted_client_ca_cert
+            )
 
             trusted_client_ca_cert_display = "Trusted Client CA Cert: {}"
-            trusted_client_ca_cert_status = CheckTaskStatus.success.value if is_valid else CheckTaskStatus.error.value
 
             sub_check_results.append(
                 CheckResult(
@@ -1491,21 +1534,17 @@ def _evaluate_custom_authentication_method(
         # check x509
         secret_ref = auth.get("x509", {}).get("secretRef")
         secret_ref_value = {"spec.authenticationMethods[*].customSettings.auth.x509.secretRef": secret_ref}
-        is_valid = validate_runtime_resource_ref(
+        ref_result = validate_runtime_resource_ref(
             namespace=namespace,
             name=secret_ref,
             ref_type=ValidationResourceType.secret,
         )
 
-        if is_valid:
-            secret_validate_text = f"[green]Valid[/green] {ValidationResourceType.secret.value} reference {{[green]{secret_ref}[/green]}}."
-        else:
-            secret_validate_text = (
-                f"[red]Invalid[/red] {ValidationResourceType.secret.value} reference {{[red]{secret_ref}[/red]}}."
-            )
+        secret_validate_text, secret_ref_status = _render_ref_validation(
+            ref_result, ValidationResourceType.secret, secret_ref
+        )
 
         secret_ref_display = "X.509 Client Certificate Secret reference: {}"
-        secret_ref_status = CheckTaskStatus.success.value if is_valid else CheckTaskStatus.error.value
 
         sub_check_results.append(
             CheckResult(
@@ -1530,19 +1569,17 @@ def _evaluate_custom_authentication_method(
 
     if ca_cert_config_map:
         ca_cert_config_map_value = {"spec.authenticationMethods[*].customSettings.caCertConfigMap": ca_cert_config_map}
-        is_valid = validate_runtime_resource_ref(
+        ref_result = validate_runtime_resource_ref(
             namespace=namespace,
             name=ca_cert_config_map,
             ref_type=ValidationResourceType.configmap,
         )
 
-        if is_valid:
-            configmap_validate_text = f"[green]Valid[/green] {ValidationResourceType.configmap.value} reference {{[green]{ca_cert_config_map}[/green]}}."
-        else:
-            configmap_validate_text = f"[red]Invalid[/red] {ValidationResourceType.configmap.value} reference {{[red]{ca_cert_config_map}[/red]}}."
+        configmap_validate_text, ca_cert_config_map_status = _render_ref_validation(
+            ref_result, ValidationResourceType.configmap, ca_cert_config_map
+        )
 
         ca_cert_config_map_display = "CA Certificate Config Map: {}"
-        ca_cert_config_map_status = CheckTaskStatus.success.value if is_valid else CheckTaskStatus.error.value
 
         sub_check_results.append(
             CheckResult(

--- a/azext_edge/edge/providers/check/summary.py
+++ b/azext_edge/edge/providers/check/summary.py
@@ -128,7 +128,7 @@ def check_summary(
                 footer = ":locked:" + colorize_string(
                     color="red",
                     value=(
-                        " Some resources could not be evaluated - principal lacks cluster permissions. "
+                        " Some resources could not be evaluated - cluster access denied. "
                         f"See details: az iot ops check --svc {check.svc}"
                     ),
                 )

--- a/azext_edge/edge/providers/check/summary.py
+++ b/azext_edge/edge/providers/check/summary.py
@@ -94,6 +94,7 @@ def check_summary(
         # create grid for service check results
         grid = Table.grid(padding=(0, 0, 0, 2))
         add_footer = False
+        access_denied = False
 
         # parse check results
         for obj in result:
@@ -104,6 +105,12 @@ def check_summary(
             emoji = status_obj.emoji
             color = status_obj.color
             description = obj.get("description")
+            denied_status = obj.get("accessDenied")
+            if denied_status:
+                access_denied = True
+                description = f"{description} " + colorize_string(
+                    color="red", value=f"(access denied - HTTP {denied_status})"
+                )
             check_manager.add_target_eval(
                 target_name=target,
                 status=status,
@@ -117,9 +124,18 @@ def check_summary(
 
         # service check suggestion footer
         if add_footer:
-            footer = ":magnifying_glass_tilted_left:" + colorize_string(
-                f" See details by running: az iot ops check --svc {check.svc}"
-            )
+            if access_denied:
+                footer = ":locked:" + colorize_string(
+                    color="red",
+                    value=(
+                        " Some resources could not be evaluated - principal lacks cluster permissions. "
+                        f"See details: az iot ops check --svc {check.svc}"
+                    ),
+                )
+            else:
+                footer = ":magnifying_glass_tilted_left:" + colorize_string(
+                    f" See details by running: az iot ops check --svc {check.svc}"
+                )
             check_manager.add_display(target_name=target, display=NewLine())
             check_manager.add_display(target_name=target, display=Padding(footer, (0, 0, 0, PADDING)))
 

--- a/azext_edge/edge/providers/checks.py
+++ b/azext_edge/edge/providers/checks.py
@@ -10,6 +10,7 @@ from azure.cli.core.azclierror import ArgumentUsageError
 from rich.console import Console
 
 from ..common import OPCUA_SERVICE, ListableEnum, OpsServiceType
+from .base import reraise_cluster_access_errors
 from .check.akri import check_akri_deployment
 from .check.base import check_pre_deployment, display_as_list
 from .check.common import COLOR_STR_FORMAT, ResourceOutputDetailLevel
@@ -65,9 +66,15 @@ def run_checks(
                 OpsServiceType.dataflow.value: check_dataflows_deployment,
                 None: check_summary,
             }
-            service_result = service_check_dict[ops_service](
-                detail_level=detail_level, resource_name=resource_name, as_list=as_list, resource_kinds=resource_kinds
-            )
+            # Within this context, cluster reads raise ClusterAccessDeniedError on HTTP 401/403 so the
+            # checks surface a precise per-resource 'access denied' instead of a misleading false negative.
+            with reraise_cluster_access_errors():
+                service_result = service_check_dict[ops_service](
+                    detail_level=detail_level,
+                    resource_name=resource_name,
+                    as_list=as_list,
+                    resource_kinds=resource_kinds,
+                )
             if isinstance(service_result, list):
                 for obj in service_result:
                     result["postDeployment"].append(obj)

--- a/azext_edge/edge/providers/checks.py
+++ b/azext_edge/edge/providers/checks.py
@@ -55,7 +55,10 @@ def run_checks(
         result["title"] = f"Evaluation for {title_subject}" if ops_service else "IoT Operations Summary"
 
         if pre_deployment:
-            result["preDeployment"] = check_pre_deployment(as_list)
+            # Same access-denied gate as post-deployment so precheck reads (nodes, k8s version)
+            # surface a precise 401/403 result instead of a generic connectivity error.
+            with reraise_cluster_access_errors():
+                result["preDeployment"] = check_pre_deployment(as_list)
         if post_deployment:
             result["postDeployment"] = []
             service_check_dict = {

--- a/azext_edge/edge/providers/edge_api/base.py
+++ b/azext_edge/edge/providers/edge_api/base.py
@@ -48,8 +48,7 @@ class EdgeResourceApi:
                 self._kinds[resource.kind.lower()] = rn
             return frozenset(self._kinds.keys())
 
-    def get_resources(self, kind: Union[str, Enum], namespace: Optional[str] = None, use_cache: Optional[bool] = False,
-                      raise_on_access_error: bool = False):
+    def get_resources(self, kind: Union[str, Enum], namespace: Optional[str] = None, use_cache: Optional[bool] = False):
         if isinstance(kind, Enum):
             kind = kind.value
 
@@ -60,7 +59,6 @@ class EdgeResourceApi:
                 plural=self._kinds[kind],
                 namespace=namespace,
                 use_cache=use_cache,
-                raise_on_access_error=raise_on_access_error,
             )
 
 

--- a/azext_edge/edge/providers/edge_api/base.py
+++ b/azext_edge/edge/providers/edge_api/base.py
@@ -48,7 +48,8 @@ class EdgeResourceApi:
                 self._kinds[resource.kind.lower()] = rn
             return frozenset(self._kinds.keys())
 
-    def get_resources(self, kind: Union[str, Enum], namespace: Optional[str] = None, use_cache: Optional[bool] = False):
+    def get_resources(self, kind: Union[str, Enum], namespace: Optional[str] = None, use_cache: Optional[bool] = False,
+                      raise_on_access_error: bool = False):
         if isinstance(kind, Enum):
             kind = kind.value
 
@@ -59,6 +60,7 @@ class EdgeResourceApi:
                 plural=self._kinds[kind],
                 namespace=namespace,
                 use_cache=use_cache,
+                raise_on_access_error=raise_on_access_error,
             )
 
 

--- a/azext_edge/edge/providers/k8s/config_map.py
+++ b/azext_edge/edge/providers/k8s/config_map.py
@@ -14,6 +14,8 @@ generic = client.ApiClient()
 
 
 def get_config_map(name: str, namespace: str) -> Optional[dict]:
+    from ..base import _reraise_if_access_denied
+
     try:
         v1_core_api = client.CoreV1Api()
         result = v1_core_api.read_namespaced_config_map(name=name, namespace=namespace)
@@ -21,6 +23,7 @@ def get_config_map(name: str, namespace: str) -> Optional[dict]:
         logger.debug(msg=str(ae))
         if int(ae.status) == 404:
             return
+        _reraise_if_access_denied(ae, resource=f"configmap/{name}")
         raise ae
     else:
         if result:

--- a/azext_edge/edge/providers/k8s/config_map.py
+++ b/azext_edge/edge/providers/k8s/config_map.py
@@ -14,7 +14,7 @@ generic = client.ApiClient()
 
 
 def get_config_map(name: str, namespace: str) -> Optional[dict]:
-    from ..base import _reraise_if_access_denied
+    from ..base import reraise_if_access_denied
 
     try:
         v1_core_api = client.CoreV1Api()
@@ -23,7 +23,7 @@ def get_config_map(name: str, namespace: str) -> Optional[dict]:
         logger.debug(msg=str(ae))
         if int(ae.status) == 404:
             return
-        _reraise_if_access_denied(ae, resource=f"configmap/{name}")
+        reraise_if_access_denied(ae, resource=f"configmap/{name}")
         raise ae
     else:
         if result:

--- a/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
@@ -258,3 +258,97 @@ def test_get_config_map_reraise_within_context(mocker, status):
 
     with pytest.raises(ApiException):
         get_config_map(name=f"cm-{status}", namespace=f"ns-{status}")
+
+
+def _target_display_text(result: dict, target: str) -> str:
+    texts = []
+    for ns_data in result["targets"].get(target, {}).values():
+        for d in ns_data.get("displays", []):
+            texts.append(str(getattr(d, "renderable", d)))
+    return " ".join(texts)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_evaluate_brokers_pod_read_denied_preserves_findings(mocker, status):
+    # A denial on the secondary pod reads must NOT unwind evaluate_brokers: the broker findings
+    # are preserved and an inline access-denied row is added.
+    from azext_edge.edge.providers.check.mq import evaluate_brokers
+    from azext_edge.tests.edge.checks.conftest import generate_resource_stub
+    from azext_edge.edge.common import ResourceState
+
+    broker = generate_resource_stub(
+        spec={
+            "diagnostics": {},
+            "cardinality": {
+                "backendChain": {"partitions": 1, "redundancyFactor": 2, "workers": 1},
+                "frontend": {"replicas": 1},
+            },
+            "mode": "distributed",
+        },
+        status={"healthState": {"status": ResourceState.available.value, "description": "ok"}},
+    )
+    mocker.patch(
+        "azext_edge.edge.providers.edge_api.base.EdgeResourceApi.get_resources",
+        return_value={"items": [broker]},
+    )
+    # diagnostics service read succeeds; pod reads are denied
+    mocker.patch("azext_edge.edge.providers.check.mq.get_namespaced_service", return_value={"spec": {}})
+    mocker.patch(
+        "azext_edge.edge.providers.check.mq.get_namespaced_pods_by_prefix",
+        side_effect=ClusterAccessDeniedError(status=status, resource="pods"),
+    )
+
+    # must not raise
+    result = evaluate_brokers(as_list=True)
+    target = "brokers.mqttbroker.iotoperations.azure.com"
+    text = _target_display_text(result, target)
+    assert "Access denied" in text
+    assert str(status) in text
+    # broker findings preserved: at least one non-denial evaluation remains
+    evals = [e for ns_data in result["targets"][target].values() for e in ns_data.get("evaluations", [])]
+    assert any("Access denied" not in str(e.get("value")) for e in evals)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_broker_diagnostics_service_denied_reports_inline(mocker, status):
+    # A denied diagnostics service read renders an inline access-denied row without raising.
+    from azext_edge.edge.providers.check.mq import _evaluate_broker_diagnostics_service
+    from azext_edge.edge.providers.check.base import CheckManager
+
+    mocker.patch(
+        "azext_edge.edge.providers.check.mq.get_namespaced_service",
+        side_effect=ClusterAccessDeniedError(status=status, resource="service/aio-broker-diagnostics-service"),
+    )
+    check_manager = CheckManager(check_name="evalBrokers", check_desc="Evaluate MQTT Brokers")
+    check_manager.add_target(target_name="brokers", namespace="ns")
+    _evaluate_broker_diagnostics_service(check_manager=check_manager, target_brokers="brokers", namespace="ns")
+
+    text = _target_display_text(check_manager.as_dict(as_list=True), "brokers")
+    assert "Access denied" in text
+    assert str(status) in text
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_listener_service_denied_reports_inline(mocker, status):
+    # A denied listener service read renders an inline access-denied row without raising.
+    from azext_edge.edge.providers.check.mq import _evaluate_listener_service
+    from azext_edge.edge.providers.check.base import CheckManager
+
+    mocker.patch(
+        "azext_edge.edge.providers.check.mq.get_namespaced_service",
+        side_effect=ClusterAccessDeniedError(status=status, resource="service/my-listener-svc"),
+    )
+    check_manager = CheckManager(check_name="evalBrokerListeners", check_desc="Evaluate MQTT Broker Listeners")
+    check_manager.add_target(target_name="listeners", namespace="ns")
+    _evaluate_listener_service(
+        check_manager=check_manager,
+        listener_name="my-listener",
+        listener_spec={"serviceName": "my-listener-svc", "serviceType": "ClusterIp", "name": "my-listener"},
+        processed_services={},
+        target_listeners="listeners",
+        namespace="ns",
+    )
+
+    text = _target_display_text(check_manager.as_dict(as_list=True), "listeners")
+    assert "Access denied" in text
+    assert str(status) in text

--- a/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
@@ -121,7 +121,7 @@ def test_enumerate_discovery_access_denied(mocker, status):
         as_list=True,
     )
     assert result["accessDenied"] == status
-    assert resource_map == {}
+    assert not resource_map
     assert result["status"] == "error"
 
 

--- a/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
@@ -1,0 +1,163 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from azext_edge.edge.providers.base import (
+    ClusterAccessDeniedError,
+    get_custom_objects,
+    reraise_cluster_access_errors,
+)
+from azext_edge.edge.providers.check.base.deployment import (
+    _build_access_denied_result,
+    check_post_deployment,
+)
+from azext_edge.edge.providers.check.base.resource import (
+    enumerate_ops_service_resources,
+    get_resources_by_name,
+)
+from azext_edge.edge.providers.check.common import CoreServiceResourceKinds
+from azext_edge.edge.providers.check.summary import check_summary
+from azext_edge.edge.providers.edge_api import MQ_ACTIVE_API, EdgeResourceApi
+
+
+def _mock_custom_objects_api(mocker, status: int):
+    api = mocker.Mock()
+    api.list_namespaced_custom_object.side_effect = ApiException(status=status, reason="denied")
+    api.list_cluster_custom_object.side_effect = ApiException(status=status, reason="denied")
+    mocker.patch("azext_edge.edge.providers.base.client.CustomObjectsApi", return_value=api)
+    return api
+
+
+def _display_text(result: dict, target: str) -> str:
+    displays = result["targets"][target]["_all_"].get("displays", [])
+    return " ".join(str(getattr(d, "renderable", d)) for d in displays)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_get_custom_objects_raises_within_context(mocker, status):
+    # Within the check context, a 401/403 read must raise ClusterAccessDeniedError (propagation gate).
+    _mock_custom_objects_api(mocker, status)
+    with reraise_cluster_access_errors():
+        with pytest.raises(ClusterAccessDeniedError) as exc_info:
+            get_custom_objects(group="g", version="v", plural="widgets", namespace="ns", use_cache=False)
+    assert exc_info.value.status == status
+    assert exc_info.value.resource == "widgets"
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_get_custom_objects_swallows_outside_context(mocker, status):
+    # Outside the check context, behavior is unchanged (tolerant): returns None, never raises.
+    _mock_custom_objects_api(mocker, status)
+    assert get_custom_objects(group="g", version="v", plural="widgets", namespace="ns", use_cache=False) is None
+
+
+def test_get_resources_by_name_propagates_403(mocker):
+    # A 403 originating at the client must flow through get_resources_by_name as ClusterAccessDeniedError,
+    # labeled with the actual plural being read.
+    _mock_custom_objects_api(mocker, 403)
+    api = EdgeResourceApi(group="deviceregistry.microsoft.com", version="v1", moniker="deviceregistry")
+    api._kinds = {"asset": "assets"}
+    with reraise_cluster_access_errors():
+        with pytest.raises(ClusterAccessDeniedError) as exc_info:
+            get_resources_by_name(api_info=api, kind="asset", resource_name=None)
+    assert exc_info.value.status == 403
+    assert exc_info.value.resource == "assets"
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_check_post_deployment_builds_access_denied_result(status):
+    # An evaluator raising ClusterAccessDeniedError yields a per-resource access-denied result
+    # (with the accessDenied marker) instead of aborting the command.
+    def denied_evaluator(**kwargs):
+        raise ClusterAccessDeniedError(status=status, resource="brokers")
+
+    results = check_post_deployment(
+        evaluate_funcs={CoreServiceResourceKinds.RUNTIME_RESOURCE: denied_evaluator},
+        as_list=True,
+    )
+    assert len(results) == 1
+    result = results[0]
+    assert result["accessDenied"] == status
+    assert result["status"] == "error"
+    assert "reading 'brokers'" in str(result["targets"]["brokers"]["_all_"]["evaluations"][0]["value"])
+
+
+@pytest.mark.parametrize(
+    "status, expected_phrase, unexpected_phrase",
+    [
+        (403, "lacks permission", "authenticate"),
+        (401, "authenticate", "lacks permission"),
+    ],
+)
+def test_build_access_denied_result_wording(status, expected_phrase, unexpected_phrase):
+    # 403 asserts a permissions cause; 401 (authentication) must not.
+    error = ClusterAccessDeniedError(status=status, resource="assetendpointprofiles")
+    result = _build_access_denied_result(CoreServiceResourceKinds.RUNTIME_RESOURCE, error, as_list=True)
+    assert result["accessDenied"] == status
+    # Nested read: the result names the actual denied resource, not the outer evaluator kind.
+    assert "assetendpointprofiles" in result["targets"]
+    text = _display_text(result, "assetendpointprofiles")
+    assert expected_phrase in text
+    assert unexpected_phrase not in text
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_enumerate_discovery_access_denied(mocker, status):
+    # A denied API-discovery call produces an access-denied enumeration result with the marker,
+    # rather than the misleading "API resources not detected".
+    mocker.patch(
+        "azext_edge.edge.providers.check.base.resource.get_cluster_custom_api",
+        side_effect=ClusterAccessDeniedError(status=status, resource=f"{MQ_ACTIVE_API.group}/{MQ_ACTIVE_API.version}"),
+    )
+    result, resource_map = enumerate_ops_service_resources(
+        api_info=MQ_ACTIVE_API,
+        check_name="mq",
+        check_desc="MQ",
+        as_list=True,
+    )
+    assert result["accessDenied"] == status
+    assert resource_map == {}
+    assert result["status"] == "error"
+
+
+def test_summary_footer_flips_on_access_denied(mocker):
+    # When a service reports an access-denied resource, the summary footer flips to the
+    # permissions/access-denied footer instead of the generic "See details" one.
+    denied_service_result = [
+        {
+            "name": "evalBrokerAccess",
+            "description": "Evaluate Broker",
+            "status": "error",
+            "targets": {"brokers": {"_all_": {"status": "error", "evaluations": [], "conditions": None}}},
+            "accessDenied": 403,
+        }
+    ]
+    healthy_service_result = [
+        {
+            "name": "svc",
+            "description": "Evaluate service",
+            "status": "success",
+            "targets": {"svc": {"_all_": {"status": "success", "evaluations": [], "conditions": None}}},
+        }
+    ]
+
+    mocker.patch("azext_edge.edge.providers.check.mq.check_post_deployment", return_value=denied_service_result)
+    mocker.patch("azext_edge.edge.providers.check.akri.check_post_deployment", return_value=healthy_service_result)
+    mocker.patch(
+        "azext_edge.edge.providers.check.deviceregistry.check_post_deployment",
+        return_value=healthy_service_result,
+    )
+    mocker.patch("azext_edge.edge.providers.check.opcua.check_post_deployment", return_value=healthy_service_result)
+    mocker.patch("azext_edge.edge.providers.check.dataflow.check_post_deployment", return_value=healthy_service_result)
+
+    result = check_summary(resource_name=None, resource_kinds=None, as_list=True)
+
+    broker_text = _display_text(result, MQ_ACTIVE_API.as_str())
+    assert "access denied" in broker_text.lower()
+    # generic footer should not be used for the denied service
+    assert "See details by running" not in broker_text

--- a/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
+++ b/azext_edge/tests/edge/checks/base/test_access_denied_unit.py
@@ -161,3 +161,100 @@ def test_summary_footer_flips_on_access_denied(mocker):
     assert "access denied" in broker_text.lower()
     # generic footer should not be used for the denied service
     assert "See details by running" not in broker_text
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_validate_runtime_resource_ref_returns_error_on_denial(mocker, status):
+    # A denied secondary reference read must NOT unwind the evaluator: the helper returns the
+    # ClusterAccessDeniedError so the caller can render an inline row and keep its other findings.
+    from azext_edge.edge.providers.check.base.resource import validate_runtime_resource_ref
+    from azext_edge.edge.providers.check.common import ValidationResourceType
+
+    mocker.patch(
+        "azext_edge.edge.providers.check.base.resource.get_namespaced_secret",
+        side_effect=ClusterAccessDeniedError(status=status, resource="secret/my-secret"),
+    )
+    result = validate_runtime_resource_ref(
+        name="my-secret", namespace="ns", ref_type=ValidationResourceType.secret
+    )
+    assert isinstance(result, ClusterAccessDeniedError)
+    assert result.status == status
+
+
+@pytest.mark.parametrize(
+    "ref_result, expected_phrase, expected_status",
+    [
+        (True, "Valid", "success"),
+        (False, "Invalid", "error"),
+        (ClusterAccessDeniedError(status=403, resource="secret/x"), "Access denied", "error"),
+    ],
+)
+def test_render_ref_validation(ref_result, expected_phrase, expected_status):
+    # The shared renderer maps valid/invalid/access-denied to the right text and status.
+    from azext_edge.edge.providers.check.mq import _render_ref_validation
+    from azext_edge.edge.providers.check.common import ValidationResourceType
+
+    text, status = _render_ref_validation(ref_result, ValidationResourceType.secret, "my-secret")
+    assert expected_phrase in text
+    assert status == expected_status
+
+
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.parametrize("helper", ["service", "pods", "secret", "cluster_api"])
+def test_shared_read_helpers_reraise_within_context(mocker, helper, status):
+    # Each shared read helper must raise ClusterAccessDeniedError on 401/403 inside the check
+    # context, and preserve its tolerant behavior (swallow -> empty result) outside it.
+    from functools import partial
+    from azext_edge.edge.providers import base
+
+    if helper == "service":
+        api = mocker.Mock()
+        api.read_namespaced_service.side_effect = ApiException(status=status, reason="denied")
+        mocker.patch("azext_edge.edge.providers.base.client.CoreV1Api", return_value=api)
+        call = partial(base.get_namespaced_service, name=f"svc-{status}", namespace=f"ns-{status}")
+        outside_expected = None
+    elif helper == "pods":
+        api = mocker.Mock()
+        api.list_namespaced_pod.side_effect = ApiException(status=status, reason="denied")
+        mocker.patch("azext_edge.edge.providers.base.client.CoreV1Api", return_value=api)
+        call = partial(base.get_namespaced_pods_by_prefix, prefix="p", namespace=f"ns-pods-{status}")
+        outside_expected = []
+    elif helper == "secret":
+        api = mocker.Mock()
+        api.read_namespaced_secret.side_effect = ApiException(status=status, reason="denied")
+        mocker.patch("azext_edge.edge.providers.base.client.CoreV1Api", return_value=api)
+        call = partial(base.get_namespaced_secret, namespace=f"ns-{status}", secret_name=f"sec-{status}")
+        outside_expected = None
+    else:  # cluster_api (API discovery)
+        api = mocker.Mock()
+        api.get_api_resources.side_effect = ApiException(status=status, reason="denied")
+        mocker.patch("azext_edge.edge.providers.base.client.CustomObjectsApi", return_value=api)
+        call = partial(base.get_cluster_custom_api, group=f"grp-{status}", version="v1")
+        outside_expected = None
+
+    with reraise_cluster_access_errors():
+        with pytest.raises(ClusterAccessDeniedError) as exc_info:
+            call()
+    assert exc_info.value.status == status
+
+    # outside the context -> swallowed, no raise
+    assert call() == outside_expected
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_get_config_map_reraise_within_context(mocker, status):
+    # The configmap helper raises ClusterAccessDeniedError inside the context; outside it keeps
+    # its original behavior of re-raising the ApiException on a non-404.
+    from azext_edge.edge.providers.k8s.config_map import get_config_map
+
+    api = mocker.Mock()
+    api.read_namespaced_config_map.side_effect = ApiException(status=status, reason="denied")
+    mocker.patch("azext_edge.edge.providers.k8s.config_map.client.CoreV1Api", return_value=api)
+
+    with reraise_cluster_access_errors():
+        with pytest.raises(ClusterAccessDeniedError) as exc_info:
+            get_config_map(name=f"cm-{status}", namespace=f"ns-{status}")
+    assert exc_info.value.status == status
+
+    with pytest.raises(ApiException):
+        get_config_map(name=f"cm-{status}", namespace=f"ns-{status}")


### PR DESCRIPTION
- `az iot ops check` now detects Kubernetes 401/403 responses when reading Azure IoT Operations resources and reports a precise per-resource "Access denied (HTTP 403)" (with a permissions footer in the summary), instead of misleading "Unable to fetch … in any namespace" false negatives.
- Handling is per resource, so partial-access principals still see valid results for resources they can read, while only the forbidden ones are flagged — no full-command abort.

Before change overall output:

<img width="951" height="811" alt="image" src="https://github.com/user-attachments/assets/03762485-3620-4c8e-b54e-57c79149b31e" />

It does not show clear message and fails the check.

After change applied:
1. For overall command:
<img width="1068" height="1006" alt="image" src="https://github.com/user-attachments/assets/0f0cf29b-b1b0-48cb-8981-8ee2edfcc741" />


2. For per service:
<img width="981" height="996" alt="image" src="https://github.com/user-attachments/assets/99585df1-c77d-48e2-9757-3b531ab1e81c" />

It shows detailed error.







---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
