### PR TITLE
fix: reject unsupported connector capabilities on namespaced asset commands

### DIFF
--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -844,6 +844,7 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, ("datasets",), "datasets")
         dataset_section = endpoint.get("datasets", {})
         schema = dataset_section.get("datasetConfigurationSchema")
 
@@ -922,6 +923,8 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            _ensure_capability_supported(endpoint, connector_type, ("datasets",), "datasets")
         dataset_section = endpoint.get("datasets", {}) if endpoint else {}
 
         result = {}
@@ -1002,6 +1005,7 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, ("datasets", "dataPoints"), "datapoints")
         dataset_section = endpoint.get("datasets", {})
         dp_section = dataset_section.get("dataPoints", {})
         schema = dp_section.get("dataPointConfigurationSchema")
@@ -1068,6 +1072,8 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            _ensure_capability_supported(endpoint, connector_type, ("datasets", "dataPoints"), "datapoints")
         dataset_section = endpoint.get("datasets", {}) if endpoint else {}
         dp_section = dataset_section.get("dataPoints", {}) if dataset_section else {}
 
@@ -2534,6 +2540,7 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, ("eventGroups",), "event groups")
         eg_section = endpoint.get("eventGroups", {})
         schema = eg_section.get("eventGroupConfigurationSchema")
 
@@ -2626,6 +2633,8 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            _ensure_capability_supported(endpoint, connector_type, ("eventGroups",), "event groups")
         eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
 
         result = {}
@@ -2725,6 +2734,7 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, ("eventGroups", "events"), "events")
         eg_section = endpoint.get("eventGroups", {})
         events_section = eg_section.get("events", {})
         schema = events_section.get("eventConfigurationSchema")
@@ -2798,6 +2808,8 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            _ensure_capability_supported(endpoint, connector_type, ("eventGroups", "events"), "events")
         eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
         events_section = eg_section.get("events", {}) if eg_section else {}
 
@@ -3484,6 +3496,7 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, ("streams",), "streams")
         stream_section = endpoint.get("streams", {})
         schema = stream_section.get("streamConfigurationSchema")
 
@@ -3583,6 +3596,8 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            _ensure_capability_supported(endpoint, connector_type, ("streams",), "streams")
         stream_section = endpoint.get("streams", {}) if endpoint else {}
 
         result = {}
@@ -4151,6 +4166,14 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type)
+        if is_action:
+            _ensure_capability_supported(
+                endpoint, connector_type, ("managementGroups", "managementGroupActions"), "management actions"
+            )
+        else:
+            _ensure_capability_supported(
+                endpoint, connector_type, ("managementGroups",), "management groups"
+            )
         mg_section = endpoint.get("managementGroups", {})
         if is_action:
             schema = mg_section.get("managementGroupActions", {}).get("actionConfigurationSchema")
@@ -4224,6 +4247,15 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
+        if endpoint is not None:
+            if is_action:
+                _ensure_capability_supported(
+                    endpoint, connector_type, ("managementGroups", "managementGroupActions"), "management actions"
+                )
+            else:
+                _ensure_capability_supported(
+                    endpoint, connector_type, ("managementGroups",), "management groups"
+                )
         mg_section = endpoint.get("managementGroups", {}) if endpoint else {}
         if is_action:
             schema_owner = mg_section.get("managementGroupActions", {}) if mg_section else {}
@@ -5356,6 +5388,28 @@ def _get_metadata_endpoint(metadata: dict, connector_type: str) -> dict:
     raise ValidationError(
         f"Connector metadata does not contain an inbound endpoint entry for '{connector_type}'."
     )
+
+
+def _ensure_capability_supported(
+    endpoint: dict,
+    connector_type: str,
+    section_path: Tuple[str, ...],
+    capability_label: str,
+) -> None:
+    """Raise if the connector metadata endpoint does not support a capability.
+
+    Support is indicated by the presence of the section (and any nested sub-section) in the
+    metadata endpoint. Every key in ``section_path`` must be present; the absence of any key
+    means the connector does not support the capability, which respects the metadata semantics
+    (a missing section means "not supported", not "supported with empty config").
+    """
+    node = endpoint
+    for key in section_path:
+        if not isinstance(node, dict) or key not in node:
+            raise InvalidArgumentValueError(
+                f"The connector of type {connector_type} does not support {capability_label}."
+            )
+        node = node[key]
 
 
 def _collect_sub_item_schemas(section: dict) -> dict:

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -5499,8 +5499,8 @@ def _ensure_capability_supported(
     Support is indicated by the presence of the section (and any nested sub-section) as an
     object in the metadata endpoint. Every key in ``section_path`` must resolve to a dict; a
     missing key or a non-object value (e.g. ``"streams": null``) means the connector does not
-    support the capability, which respects the metadata semantics (a missing/empty section
-    means "not supported", not "supported with empty config").
+    support the capability. An empty object (e.g. ``"streams": {}``) counts as supported: the
+    capability is available but declares no configuration schema.
     """
     node = endpoint
     for key in section_path:

--- a/azext_edge/edge/providers/adr/namespace_assets.py
+++ b/azext_edge/edge/providers/adr/namespace_assets.py
@@ -207,6 +207,9 @@ class NamespaceAssets(Queryable):
         self.ops: "NamespaceAssetsOperations" = self.deviceregistry_mgmt_client.namespace_assets
         self.device_ops: "NamespaceDevicesOperations" = self.deviceregistry_mgmt_client.namespace_devices
         self.resource_ops: "ResourcesOperations" = self.resource_mgmt_client.resources
+        # Per-invocation cache of connector metadata keyed by (connector_type, instance, rg) so a
+        # single command that both verifies capability support and validates config fetches once.
+        self._connector_metadata_cache: Dict[Tuple[str, str, str], dict] = {}
 
     def _validate_imported_items(
         self,
@@ -771,6 +774,10 @@ class NamespaceAssets(Queryable):
         from .namespace_devices import DeviceEndpointType as _DEType
         from .helpers import load_opcua_metadata_file as _load_opcua_metadata_file
 
+        cache_key = ((connector_type or "").lower(), instance_name or "", instance_resource_group or "")
+        if cache_key in self._connector_metadata_cache:
+            return self._connector_metadata_cache[cache_key]
+
         is_opcua = connector_type.lower() == _DEType.OPCUA.value.lower()
         if is_opcua:
             from azure.core.exceptions import ResourceNotFoundError as _AzureNotFoundError
@@ -784,6 +791,7 @@ class NamespaceAssets(Queryable):
                     pass
             if metadata is None:
                 metadata = _load_opcua_metadata_file()
+            self._connector_metadata_cache[cache_key] = metadata
             return metadata
 
         from ..orchestration.resources.connector_templates import ConnectorTemplates
@@ -813,7 +821,28 @@ class NamespaceAssets(Queryable):
             image_ref=connector_metadata_ref,
             cmd=self.cmd,
         )
-        return json.loads(artifact.content.decode("utf-8"))
+        metadata = json.loads(artifact.content.decode("utf-8"))
+        self._connector_metadata_cache[cache_key] = metadata
+        return metadata
+
+    def _ensure_connector_supports(
+        self,
+        connector_type: str,
+        instance_name: str,
+        instance_resource_group: str,
+        section_path: Tuple[str, ...],
+        capability_label: str,
+    ) -> None:
+        """Verify the asset's connector supports a capability, independent of whether config is
+        supplied. Fetches connector metadata (cached) and raises a clear error if the capability's
+        section is absent, matching DOE semantics."""
+        metadata = self._get_connector_metadata(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+        )
+        endpoint = _get_metadata_endpoint(metadata, connector_type)
+        _ensure_capability_supported(endpoint, connector_type, section_path, capability_label)
 
     def _handle_dataset_show_template(
         self,
@@ -923,8 +952,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            _ensure_capability_supported(endpoint, connector_type, ("datasets",), "datasets")
         dataset_section = endpoint.get("datasets", {}) if endpoint else {}
 
         result = {}
@@ -1072,8 +1099,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            _ensure_capability_supported(endpoint, connector_type, ("datasets", "dataPoints"), "datapoints")
         dataset_section = endpoint.get("datasets", {}) if endpoint else {}
         dp_section = dataset_section.get("dataPoints", {}) if dataset_section else {}
 
@@ -1128,6 +1153,14 @@ class NamespaceAssets(Queryable):
                 template_mode=show_template.lower(),
                 dataset_config=dataset_config,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("datasets",),
+            capability_label="datasets",
+        )
 
         # Cluster connectivity check
         _, namespace = self._check_device_props(
@@ -1272,6 +1305,14 @@ class NamespaceAssets(Queryable):
                     dataset_config=dataset_config,
                 )
 
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("datasets",),
+            capability_label="datasets",
+        )
+
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
             instance_name=instance_name,
@@ -1362,6 +1403,14 @@ class NamespaceAssets(Queryable):
                 template_mode=show_template.lower(),
                 datapoint_config=datapoint_config,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("datasets", "dataPoints"),
+            capability_label="datapoints",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -2633,8 +2682,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            _ensure_capability_supported(endpoint, connector_type, ("eventGroups",), "event groups")
         eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
 
         result = {}
@@ -2808,8 +2855,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            _ensure_capability_supported(endpoint, connector_type, ("eventGroups", "events"), "events")
         eg_section = endpoint.get("eventGroups", {}) if endpoint else {}
         events_section = eg_section.get("events", {}) if eg_section else {}
 
@@ -2870,6 +2915,14 @@ class NamespaceAssets(Queryable):
                 template_mode=show_template.lower(),
                 event_group_config=event_group_config,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("eventGroups",),
+            capability_label="event groups",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -3001,6 +3054,14 @@ class NamespaceAssets(Queryable):
                     event_group_config=event_group_config,
                 )
 
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("eventGroups",),
+            capability_label="event groups",
+        )
+
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
             instance_name=instance_name,
@@ -3086,6 +3147,14 @@ class NamespaceAssets(Queryable):
                 template_mode=show_template.lower(),
                 event_config=event_config,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("eventGroups", "events"),
+            capability_label="events",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -3596,8 +3665,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            _ensure_capability_supported(endpoint, connector_type, ("streams",), "streams")
         stream_section = endpoint.get("streams", {}) if endpoint else {}
 
         result = {}
@@ -3657,6 +3724,14 @@ class NamespaceAssets(Queryable):
                 template_mode=show_template.lower(),
                 stream_config=stream_config,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("streams",),
+            capability_label="streams",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -3783,6 +3858,14 @@ class NamespaceAssets(Queryable):
                     template_mode=template_mode,
                     stream_config=stream_config,
                 )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("streams",),
+            capability_label="streams",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -4247,15 +4330,6 @@ class NamespaceAssets(Queryable):
             instance_resource_group=instance_resource_group,
         )
         endpoint = _get_metadata_endpoint(metadata, connector_type) if metadata else None
-        if endpoint is not None:
-            if is_action:
-                _ensure_capability_supported(
-                    endpoint, connector_type, ("managementGroups", "managementGroupActions"), "management actions"
-                )
-            else:
-                _ensure_capability_supported(
-                    endpoint, connector_type, ("managementGroups",), "management groups"
-                )
         mg_section = endpoint.get("managementGroups", {}) if endpoint else {}
         if is_action:
             schema_owner = mg_section.get("managementGroupActions", {}) if mg_section else {}
@@ -4318,6 +4392,14 @@ class NamespaceAssets(Queryable):
                 config=mgmt_group_config,
                 is_action=False,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("managementGroups",),
+            capability_label="management groups",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -4447,6 +4529,14 @@ class NamespaceAssets(Queryable):
                     is_action=False,
                 )
 
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("managementGroups",),
+            capability_label="management groups",
+        )
+
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
             instance_name=instance_name,
@@ -4541,6 +4631,14 @@ class NamespaceAssets(Queryable):
                 config=action_config,
                 is_action=True,
             )
+
+        self._ensure_connector_supports(
+            connector_type=connector_type,
+            instance_name=instance_name,
+            instance_resource_group=instance_resource_group,
+            section_path=("managementGroups", "managementGroupActions"),
+            capability_label="management actions",
+        )
 
         _, namespace = self._check_device_props(
             instance_resource_group=instance_resource_group,
@@ -5398,14 +5496,15 @@ def _ensure_capability_supported(
 ) -> None:
     """Raise if the connector metadata endpoint does not support a capability.
 
-    Support is indicated by the presence of the section (and any nested sub-section) in the
-    metadata endpoint. Every key in ``section_path`` must be present; the absence of any key
-    means the connector does not support the capability, which respects the metadata semantics
-    (a missing section means "not supported", not "supported with empty config").
+    Support is indicated by the presence of the section (and any nested sub-section) as an
+    object in the metadata endpoint. Every key in ``section_path`` must resolve to a dict; a
+    missing key or a non-object value (e.g. ``"streams": null``) means the connector does not
+    support the capability, which respects the metadata semantics (a missing/empty section
+    means "not supported", not "supported with empty config").
     """
     node = endpoint
     for key in section_path:
-        if not isinstance(node, dict) or key not in node:
+        if not isinstance(node, dict) or not isinstance(node.get(key), dict):
             raise InvalidArgumentValueError(
                 f"The connector of type {connector_type} does not support {capability_label}."
             )

--- a/azext_edge/tests/edge/adr/conftest.py
+++ b/azext_edge/tests/edge/adr/conftest.py
@@ -13,6 +13,51 @@ from ...generators import generate_random_string, get_zeroed_subscription
 from ...helpers import run
 
 
+# Generalized asset sub-resource unit test modules. Their commands verify that the asset's
+# connector supports the requested capability (datasets, streams, etc.) on every add/update,
+# even when no config is supplied. That verification fetches connector metadata, so provide a
+# default that advertises support for all capabilities. Tests needing specific metadata (e.g.
+# unsupported-capability guards) override this by patching _get_connector_metadata themselves.
+_GENERALIZED_UNIT_MODULES = {
+    "test_namespace_asset_streams_unit",
+    "test_namespace_asset_events_unit",
+    "test_namespace_asset_datasets_unit",
+    "test_namespace_asset_mgmt_unit",
+}
+
+
+@pytest.fixture(autouse=True)
+def default_connector_metadata(request, mocker):
+    """Default connector metadata advertising every capability, scoped to generalized unit tests."""
+    module_name = request.module.__name__.rsplit(".", 1)[-1]
+    if module_name not in _GENERALIZED_UNIT_MODULES:
+        yield
+        return
+
+    def _fake(connector_type, instance_name=None, instance_resource_group=None):
+        return {
+            "inboundEndpoints": [{
+                "endpointType": connector_type,
+                "datasets": {
+                    "dataPoints": {"destinations": {"supportedDestinations": ["Mqtt"]}},
+                    "destinations": {"supportedDestinations": ["Mqtt"]},
+                },
+                "eventGroups": {
+                    "events": {"destinations": {"supportedDestinations": ["Mqtt"]}},
+                    "destinations": {"supportedDestinations": ["Mqtt"]},
+                },
+                "streams": {"destinations": {"supportedDestinations": ["Mqtt"]}},
+                "managementGroups": {"managementGroupActions": {}},
+            }]
+        }
+
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        side_effect=_fake,
+    )
+    yield
+
+
 @pytest.fixture()
 def require_namespace_init(require_init):
     """Extends require_init to ensure the instance has an ADR namespace reference.

--- a/azext_edge/tests/edge/adr/namespace_helpers.py
+++ b/azext_edge/tests/edge/adr/namespace_helpers.py
@@ -26,6 +26,30 @@ def _save_json_to_file(content: dict, tracked_files: List[str]) -> str:
     )
 
 
+# All accepted input forms for a connector-specific *-config parameter. Parametrize capability
+# guard tests over this so a single test proves the guard fires no matter how config is supplied.
+CONFIG_INPUT_FORMS = ["inline", "json_file", "yaml_file"]
+
+
+def materialize_config(config_dict: dict, config_form: str, tmp_path) -> str:
+    """Render a config dict as one of the accepted input forms (inline JSON, JSON file, YAML file).
+
+    Used to prove that connector-capability guards fire regardless of how the config is supplied.
+    """
+    if config_form == "inline":
+        return json.dumps(config_dict)
+    if config_form == "json_file":
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(config_dict))
+        return str(path)
+    if config_form == "yaml_file":
+        import yaml
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.safe_dump(config_dict))
+        return str(path)
+    raise ValueError(f"Unknown config_form: {config_form}")
+
+
 def _try_show_template(cmd: str) -> dict:
     """Run a --show-template command and return the parsed result.
 

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_int.py
@@ -1055,16 +1055,20 @@ def test_generalized_dataset_lifecycle_mqtt(asset_factory, tracked_files: List[s
 
     base_cmd = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
 
-    # 1. SHOW-TEMPLATE – dataset (best-effort)
-    dataset_config_file = None
+    # 1. SHOW-TEMPLATE – dataset. Generalized commands require connector metadata; skip if the
+    # connector has no template supporting datasets (bare add can no longer run metadata-free).
     dataset_template = _try_show_template(
         f"az iot ops ns asset dataset add {base_cmd} "
         f"--name {dataset_name} --show-template config"
     )
-    if dataset_template:
-        assert "connectorType" in dataset_template
-        assert "datasetConfig" in dataset_template
-        dataset_config_file = _save_json_to_file(dataset_template, tracked_files)
+    if not dataset_template:
+        pytest.skip(
+            "Generalized dataset commands require connector metadata; no connector template "
+            "supporting datasets is installed for this connector."
+        )
+    assert "connectorType" in dataset_template
+    assert "datasetConfig" in dataset_template
+    dataset_config_file = _save_json_to_file(dataset_template, tracked_files)
 
     # 2. ADD dataset
     add_cmd = (
@@ -1092,17 +1096,20 @@ def test_generalized_dataset_lifecycle_mqtt(asset_factory, tracked_files: List[s
     )
     assert_dataset_properties(updated_dataset, name=dataset_name, data_source=updated_source)
 
-    # 6. SHOW-TEMPLATE – datapoint (best-effort)
-    datapoint_config_file = None
+    # 6. SHOW-TEMPLATE – datapoint. Skip if the connector has no template supporting datapoints.
     datapoint_template = _try_show_template(
         f"az iot ops ns asset datapoint add {base_cmd} "
         f"--dataset {dataset_name} --name {datapoint_name} "
         f"--data-source '{dp_data_source}' --show-template config"
     )
-    if datapoint_template:
-        assert "connectorType" in datapoint_template
-        assert "datapointConfig" in datapoint_template
-        datapoint_config_file = _save_json_to_file(datapoint_template, tracked_files)
+    if not datapoint_template:
+        pytest.skip(
+            "Generalized datapoint commands require connector metadata; no connector template "
+            "supporting datapoints is installed for this connector."
+        )
+    assert "connectorType" in datapoint_template
+    assert "datapointConfig" in datapoint_template
+    datapoint_config_file = _save_json_to_file(datapoint_template, tracked_files)
 
     # 7. ADD datapoint
     dp_add_cmd = (

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -2956,6 +2956,55 @@ def test_dataset_generalized_config_unsupported_capability_raises(
 
 
 @pytest.mark.parametrize("command", [add_namespace_asset_dataset, update_namespace_asset_dataset])
+def test_dataset_generalized_no_config_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    command,
+):
+    """Even with no --dataset-config and no --show-template, adding/updating a dataset on a
+    connector that doesn't support datasets must be blocked (DOE parity)."""
+    asset_name = "gen-asset"
+    dataset_name = "target-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_dataset
+    datasets = [generate_dataset(dataset_name=dataset_name)] if is_update else []
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=datasets,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _dataset_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("datasets")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support datasets"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_dataset, update_namespace_asset_dataset])
 @pytest.mark.parametrize("template_mode", ["config", "schema"])
 def test_dataset_generalized_show_template_unsupported_raises(
     mocked_cmd,

--- a/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_datasets_unit.py
@@ -31,7 +31,12 @@ from azext_edge.edge.commands_namespaces import (
     remove_namespace_asset_dataset_point
 )
 
-from .namespace_helpers import check_dataset_configuration, check_destinations
+from .namespace_helpers import (
+    CONFIG_INPUT_FORMS,
+    check_dataset_configuration,
+    check_destinations,
+    materialize_config,
+)
 from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
 )
@@ -2852,5 +2857,257 @@ def test_add_namespace_asset_dataset_point_generalized_raises_on_duplicate(
             datapoint_name=datapoint_name,
             data_source="sensors/new",
             replace=False,
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# unsupported-capability guard tests (datasets + datapoints)
+# ---------------------------------------------------------------------------
+
+
+def _dataset_metadata(connector_type: str, ds_schema=None, dp_schema=None, supported=("Mqtt",)) -> dict:
+    """Build a connector metadata payload for the generalized dataset/datapoint path."""
+    return {
+        "inboundEndpoints": [{
+            "endpointType": f"Microsoft.{connector_type}",
+            "datasets": {
+                "datasetConfigurationSchema": ds_schema,
+                "dataPoints": {"dataPointConfigurationSchema": dp_schema},
+                "destinations": {"supportedDestinations": list(supported)},
+            },
+        }]
+    }
+
+
+def _register_asset_and_device_get(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    connector_type: str,
+) -> None:
+    """Register the single asset GET + device GET used by the generalized front-door."""
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized(mocked_responses, asset, namespace_name, resource_group_name, connector_type)
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_dataset, update_namespace_asset_dataset])
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_dataset_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+    command,
+):
+    """--dataset-config for a connector whose metadata omits 'datasets' must raise a clear
+    'does not support datasets' error. Covers both add and update commands, for every accepted
+    input form (inline JSON, JSON file, YAML file)."""
+    asset_name = "gen-asset"
+    dataset_name = "target-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_dataset
+    datasets = [generate_dataset(dataset_name=dataset_name)] if is_update else []
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=datasets,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _dataset_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("datasets")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"datasetConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support datasets"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            dataset_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_dataset, update_namespace_asset_dataset])
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_dataset_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+    command,
+):
+    """--show-template (config or schema) for a connector without a 'datasets' section must raise
+    rather than returning an empty template. Covers both add and update commands."""
+    asset_name = "gen-asset"
+    dataset_name = "target-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_dataset
+    datasets = [generate_dataset(dataset_name=dataset_name)] if is_update else []
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=datasets,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _dataset_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("datasets")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support datasets"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            show_template=template_mode,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_add_datapoint_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+):
+    """--datapoint-config for a connector whose metadata omits 'datasets.dataPoints' must raise a
+    clear 'does not support datapoints' error, for every accepted input form."""
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[{"name": dataset_name, "dataSource": "s/src", "dataPoints": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # datasets exists (datasets supported) but the nested 'dataPoints' capability is absent.
+    metadata = _dataset_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["datasets"].pop("dataPoints")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"datapointConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support datapoints"):
+        add_namespace_asset_dataset_point(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            datapoint_name="temp-dp",
+            data_source="sensors/temp",
+            datapoint_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_add_datapoint_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+):
+    """--show-template (config or schema) on the add-datapoint path for a connector without
+    'datasets.dataPoints' must raise rather than returning an empty template."""
+    asset_name = "gen-asset"
+    dataset_name = "sensor-ds"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        connector_type=connector_type,
+        datasets=[{"name": dataset_name, "dataSource": "s/src", "dataPoints": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _dataset_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["datasets"].pop("dataPoints")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support datapoints"):
+        add_namespace_asset_dataset_point(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            dataset_name=dataset_name,
+            datapoint_name="temp-dp",
+            data_source="sensors/temp",
+            show_template=template_mode,
             wait_sec=0,
         )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_int.py
@@ -812,14 +812,17 @@ def test_generalized_event_lifecycle_custom(asset_factory, tracked_files: List[s
         f"--name {eg_name} --show-template config"
     )
 
-    eg_config_arg = ""
-    if eg_template:
-        assert "connectorType" in eg_template
-        assert "eventGroupConfig" in eg_template
-        eg_config = eg_template.copy()
-        eg_config["eventGroupConfig"].pop("destinations", None)
-        eg_config_file = _save_json_to_file(eg_config, tracked_files)
-        eg_config_arg = f"--event-group-config {eg_config_file}"
+    if not eg_template:
+        pytest.skip(
+            "Generalized event commands require connector metadata; no connector template "
+            "supporting event groups is installed for this connector."
+        )
+    assert "connectorType" in eg_template
+    assert "eventGroupConfig" in eg_template
+    eg_config = eg_template.copy()
+    eg_config["eventGroupConfig"].pop("destinations", None)
+    eg_config_file = _save_json_to_file(eg_config, tracked_files)
+    eg_config_arg = f"--event-group-config {eg_config_file}"
 
     # 2. ADD event-group
     added_eg = run(
@@ -844,14 +847,17 @@ def test_generalized_event_lifecycle_custom(asset_factory, tracked_files: List[s
         f"--data-source '{ev_data_source}' --show-template config"
     )
 
-    event_config_arg = ""
-    if event_template:
-        assert "connectorType" in event_template
-        assert "eventConfig" in event_template
-        event_config = event_template.copy()
-        event_config["eventConfig"].pop("destinations", None)
-        event_config_file = _save_json_to_file(event_config, tracked_files)
-        event_config_arg = f"--event-config {event_config_file}"
+    if not event_template:
+        pytest.skip(
+            "Generalized event commands require connector metadata; no connector template "
+            "supporting events is installed for this connector."
+        )
+    assert "connectorType" in event_template
+    assert "eventConfig" in event_template
+    event_config = event_template.copy()
+    event_config["eventConfig"].pop("destinations", None)
+    event_config_file = _save_json_to_file(event_config, tracked_files)
+    event_config_arg = f"--event-config {event_config_file}"
 
     # 5. ADD event
     added_events = run(

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
@@ -39,7 +39,12 @@ from azext_edge.edge.commands_namespaces import (
 from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
 )
-from .namespace_helpers import check_event_configuration, check_destinations
+from .namespace_helpers import (
+    CONFIG_INPUT_FORMS,
+    check_destinations,
+    check_event_configuration,
+    materialize_config,
+)
 from ...generators import generate_random_string
 
 
@@ -2248,5 +2253,219 @@ def test_add_event_group_generalized_connector_type_mismatch_raises(
             instance_resource_group="rg",
             group_name="new-eg",
             event_group_config=mismatched_config,
+            wait_sec=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# unsupported-capability guard tests (event groups + events)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_event_group, update_namespace_asset_event_group])
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_event_group_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+    command,
+):
+    """--event-group-config for a connector whose metadata omits 'eventGroups' must raise a
+    clear 'does not support event groups' error. Covers both add and update commands, for every
+    accepted input form (inline JSON, JSON file, YAML file)."""
+    asset_name = "gen-asset"
+    group_name = "target-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    # update must find an existing event group so the capability guard (not "not found") is reached.
+    is_update = command is update_namespace_asset_event_group
+    event_groups = [generate_event_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=event_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _event_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("eventGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"eventGroupConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support event groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            event_group_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_event_group, update_namespace_asset_event_group])
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_event_group_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+    command,
+):
+    """--show-template (config or schema) for a connector without an 'eventGroups' section must
+    raise rather than returning an empty template. Covers both add and update commands."""
+    asset_name = "gen-asset"
+    group_name = "target-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_event_group
+    event_groups = [generate_event_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=event_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _event_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("eventGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support event groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            show_template=template_mode,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_add_event_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+):
+    """--event-config for a connector whose metadata omits 'eventGroups.events' must raise a
+    clear 'does not support events' error, for every accepted input form."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[{"name": "sensor-eg", "dataSource": "s/src", "events": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # eventGroups exists (groups supported) but the nested 'events' capability is absent.
+    metadata = _event_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["eventGroups"].pop("events")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"eventConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support events"):
+        add_namespace_asset_event_group_event(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="sensor-eg",
+            event_name="temp-ev",
+            event_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_add_event_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+):
+    """--show-template (config or schema) on the add-event path for a connector without
+    'eventGroups.events' must raise rather than returning an empty template."""
+    asset_name = "gen-asset"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=[{"name": "sensor-eg", "dataSource": "s/src", "events": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _event_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["eventGroups"].pop("events")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support events"):
+        add_namespace_asset_event_group_event(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name="sensor-eg",
+            event_name="temp-ev",
+            show_template=template_mode,
             wait_sec=0,
         )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_events_unit.py
@@ -2321,6 +2321,54 @@ def test_event_group_generalized_config_unsupported_capability_raises(
 
 
 @pytest.mark.parametrize("command", [add_namespace_asset_event_group, update_namespace_asset_event_group])
+def test_event_group_generalized_no_config_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    command,
+):
+    """Even with no --event-group-config and no --show-template, adding/updating an event group on
+    a connector that doesn't support event groups must be blocked (DOE parity)."""
+    asset_name = "gen-asset"
+    group_name = "target-eg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_event_group
+    event_groups = [generate_event_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_connector_events(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        event_groups=event_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _event_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("eventGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support event groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_event_group, update_namespace_asset_event_group])
 @pytest.mark.parametrize("template_mode", ["config", "schema"])
 def test_event_group_generalized_show_template_unsupported_raises(
     mocked_cmd,

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_export_import_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_export_import_int.py
@@ -16,6 +16,7 @@ from .export_import_helpers import (
     ensure_device_and_endpoint, ensure_asset_for_format_tests,
     validate_export_result, verify_items_by_name, do_replace_import_test,
 )
+from .namespace_helpers import _try_show_template
 
 pytestmark = [pytest.mark.rpsaas, pytest.mark.long_running]
 
@@ -250,6 +251,13 @@ def test_namespace_asset_mgmt_group_export_import_generalized(
         cmd_args = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
 
         with log.step(3, "Add Management Groups"):
+            # Generalized commands require connector metadata; skip when the connector has no
+            # template supporting management groups (a bare add can no longer run metadata-free).
+            if not _try_show_template(f"{cmd_prefix} add {cmd_args} --name probe --show-template config"):
+                pytest.skip(
+                    "Generalized management commands require connector metadata; no connector "
+                    "template supporting management groups is installed for this connector."
+                )
             for name in mg_names:
                 log.run_command(
                     f"{cmd_prefix} add {cmd_args} --name {name} --data-source mgmt/{name}"
@@ -320,6 +328,16 @@ def test_namespace_asset_mgmt_action_export_import_generalized(
                 log, instance_name, resource_group, asset_type, device_name,
                 endpoint_name, tracked_resources, "mgmt", format_test_asset_cache,
             )
+            # Generalized commands require connector metadata; skip when the connector has no
+            # template supporting management actions (a bare add can no longer run metadata-free).
+            _probe_args = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
+            if not _try_show_template(
+                f"az iot ops ns asset mgmt-group add {_probe_args} --name probe --show-template config"
+            ):
+                pytest.skip(
+                    "Generalized management commands require connector metadata; no connector "
+                    "template supporting management actions is installed for this connector."
+                )
             # Create the parent management group via the generalized command group.
             log.run_command(
                 f"az iot ops ns asset mgmt-group add --asset {asset_name} "

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_int.py
@@ -520,8 +520,13 @@ def test_generalized_management_lifecycle(asset_factory, tracked_files: List[str
         f"--instance {instance_name} -g {resource_group} "
         f"--name {mg_name} --show-template config"
     )
+    if not mg_template:
+        pytest.skip(
+            "Generalized management commands require connector metadata; no connector template "
+            "supporting management groups is installed for this connector."
+        )
     mg_config_arg = ""
-    if mg_template and mg_template.get("mgmtGroupConfig", {}).get("managementGroupConfiguration"):
+    if mg_template.get("mgmtGroupConfig", {}).get("managementGroupConfiguration"):
         assert "connectorType" in mg_template
         mg_config_file = _save_json_to_file(mg_template, tracked_files)
         mg_config_arg = f"--mgmt-group-config {mg_config_file}"
@@ -582,8 +587,13 @@ def test_generalized_management_lifecycle(asset_factory, tracked_files: List[str
         f"--instance {instance_name} -g {resource_group} --group {mg_name} "
         f"--name {action_name} --target-uri '{target_uri}' --show-template config"
     )
+    if not act_template:
+        pytest.skip(
+            "Generalized management commands require connector metadata; no connector template "
+            "supporting management actions is installed for this connector."
+        )
     act_config_arg = ""
-    if act_template and act_template.get("actionConfig", {}).get("actionConfiguration"):
+    if act_template.get("actionConfig", {}).get("actionConfiguration"):
         assert "connectorType" in act_template
         act_config_file = _save_json_to_file(act_template, tracked_files)
         act_config_arg = f"--action-config {act_config_file}"

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
@@ -2461,6 +2461,56 @@ def test_management_group_generalized_config_unsupported_capability_raises(
 @pytest.mark.parametrize(
     "command", [add_namespace_asset_management_group, update_namespace_asset_management_group]
 )
+def test_management_group_generalized_no_config_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    command,
+):
+    """Even with no --mgmt-group-config and no --show-template, adding/updating a management group
+    on a connector that doesn't support management groups must be blocked (DOE parity)."""
+    asset_name = "gen-asset"
+    group_name = "target-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_management_group
+    management_groups = [generate_management_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=management_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _mgmt_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("managementGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support management groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize(
+    "command", [add_namespace_asset_management_group, update_namespace_asset_management_group]
+)
 @pytest.mark.parametrize("template_mode", ["config", "schema"])
 def test_management_group_generalized_show_template_unsupported_raises(
     mocked_cmd,

--- a/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_mgmt_unit.py
@@ -35,6 +35,7 @@ from azext_edge.edge.commands_namespaces import (
 from .test_namespace_assets_unit import (
     get_namespace_asset_mgmt_uri, get_namespace_asset_record, add_device_get_call
 )
+from .namespace_helpers import CONFIG_INPUT_FORMS, materialize_config
 from ...generators import generate_random_string
 
 
@@ -2372,3 +2373,243 @@ def test_add_namespace_asset_management_group_action_generalized_show_template_c
     assert "actionConfiguration" in action_cfg
     # Management actions have no destinations
     assert "destinations" not in action_cfg
+
+
+# ---------------------------------------------------------------------------
+# unsupported-capability guard tests (management groups + actions)
+# ---------------------------------------------------------------------------
+
+
+def _register_asset_and_device_get(
+    mocked_responses: responses,
+    asset: dict,
+    namespace_name: str,
+    resource_group_name: str,
+    asset_name: str,
+    connector_type: str,
+) -> None:
+    """Register the single asset GET + device GET used by the generalized front-door."""
+    mocked_responses.add(
+        responses.GET,
+        get_namespace_asset_mgmt_uri(namespace_name, resource_group_name, asset_name),
+        json=asset, status=200,
+    )
+    _add_device_get_for_generalized_mgmt(
+        mocked_responses, asset, namespace_name, resource_group_name, connector_type
+    )
+
+
+@pytest.mark.parametrize(
+    "command", [add_namespace_asset_management_group, update_namespace_asset_management_group]
+)
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_management_group_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+    command,
+):
+    """--mgmt-group-config for a connector whose metadata omits 'managementGroups' must raise a
+    clear 'does not support management groups' error. Covers both add and update commands, for
+    every accepted input form (inline JSON, JSON file, YAML file)."""
+    asset_name = "gen-asset"
+    group_name = "target-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_management_group
+    management_groups = [generate_management_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=management_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _mgmt_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("managementGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"managementGroupConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support management groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            mgmt_group_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize(
+    "command", [add_namespace_asset_management_group, update_namespace_asset_management_group]
+)
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_management_group_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+    command,
+):
+    """--show-template (config or schema) for a connector without a 'managementGroups' section
+    must raise rather than returning an empty template. Covers both add and update commands."""
+    asset_name = "gen-asset"
+    group_name = "target-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_management_group
+    management_groups = [generate_management_group(group_name=group_name)] if is_update else []
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=management_groups,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _mgmt_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("managementGroups")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support management groups"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            show_template=template_mode,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_add_management_action_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+):
+    """--action-config for a connector whose metadata omits 'managementGroups.managementGroupActions'
+    must raise a clear 'does not support management actions' error, for every accepted input form."""
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[{"name": group_name, "actions": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # managementGroups exists (groups supported) but the nested actions capability is absent.
+    metadata = _mgmt_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["managementGroups"].pop("managementGroupActions")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    config = materialize_config(
+        {"actionConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support management actions"):
+        add_namespace_asset_management_group_action(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            action_name="reboot-act",
+            target_uri="ns=2;s=Reboot",
+            action_config=config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_add_management_action_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+):
+    """--show-template (config or schema) on the add-action path for a connector without
+    'managementGroups.managementGroupActions' must raise rather than returning an empty template."""
+    asset_name = "gen-asset"
+    group_name = "sensor-mg"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    asset = _build_asset_with_mgmt_groups(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        management_groups=[{"name": group_name, "actions": []}],
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _mgmt_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["managementGroups"].pop("managementGroupActions")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support management actions"):
+        add_namespace_asset_management_group_action(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            group_name=group_name,
+            action_name="reboot-act",
+            target_uri="ns=2;s=Reboot",
+            show_template=template_mode,
+            wait_sec=0,
+        )

--- a/azext_edge/tests/edge/adr/test_namespace_asset_stream_export_import_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_stream_export_import_int.py
@@ -15,6 +15,7 @@ from .export_import_helpers import (
     ensure_device_and_endpoint,
     validate_export_result,
 )
+from .namespace_helpers import _try_show_template
 
 pytestmark = [pytest.mark.rpsaas, pytest.mark.long_running]
 
@@ -130,6 +131,13 @@ def test_namespace_asset_stream_export_import_generalized(
         cmd_args = f"--asset {asset_name} --instance {instance_name} -g {resource_group}"
 
         with log.step(3, "Add Streams"):
+            # Generalized commands require connector metadata; skip when the connector has no
+            # template supporting streams (a bare add can no longer run metadata-free).
+            if not _try_show_template(f"{cmd_prefix} add {cmd_args} --name probe --show-template config"):
+                pytest.skip(
+                    "Generalized stream commands require connector metadata; no connector "
+                    "template supporting streams is installed for this connector."
+                )
             for name in stream_names:
                 log.run_command(f"{cmd_prefix} add {cmd_args} --name {name}")
             result = log.run_command(f"{cmd_prefix} list {cmd_args}")

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_int.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_int.py
@@ -341,14 +341,17 @@ def test_generalized_stream_lifecycle_custom(asset_factory, tracked_files: List[
         f"--name {stream_name} --show-template config"
     )
 
-    stream_config_arg = ""
-    if stream_template:
-        assert "connectorType" in stream_template
-        assert "streamConfig" in stream_template
-        stream_config = stream_template.copy()
-        stream_config["streamConfig"].pop("destinations", None)
-        stream_config_file = _save_json_to_file(stream_config, tracked_files)
-        stream_config_arg = f"--stream-config {stream_config_file}"
+    if not stream_template:
+        pytest.skip(
+            "Generalized stream commands require connector metadata; no connector template "
+            "supporting streams is installed for this connector."
+        )
+    assert "connectorType" in stream_template
+    assert "streamConfig" in stream_template
+    stream_config = stream_template.copy()
+    stream_config["streamConfig"].pop("destinations", None)
+    stream_config_file = _save_json_to_file(stream_config, tracked_files)
+    stream_config_arg = f"--stream-config {stream_config_file}"
 
     # 2. ADD stream
     added_stream = run(

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
@@ -28,7 +28,12 @@ from azext_edge.edge.commands_namespaces import (
 from .test_namespace_assets_unit import (
     add_device_get_call, get_namespace_asset_mgmt_uri, get_namespace_asset_record
 )
-from .namespace_helpers import check_destinations, check_stream_configuration
+from .namespace_helpers import (
+    CONFIG_INPUT_FORMS,
+    check_destinations,
+    check_stream_configuration,
+    materialize_config,
+)
 from ...generators import generate_random_string
 
 
@@ -1400,6 +1405,119 @@ def test_add_namespace_asset_stream_generalized_raises_on_duplicate(
             instance_resource_group="rg",
             stream_name=stream_name,
             replace=False,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_stream, update_namespace_asset_stream])
+@pytest.mark.parametrize("config_form", CONFIG_INPUT_FORMS)
+def test_namespace_asset_stream_generalized_config_unsupported_capability_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    tmp_path,
+    config_form: str,
+    command,
+):
+    """Supplying --stream-config for a connector whose metadata has no 'streams' section must
+    raise a clear 'does not support streams' error instead of silently accepting it.
+
+    Covers both add and update commands, for every accepted input form (inline JSON, JSON file,
+    YAML file).
+    """
+    asset_name = "gen-asset"
+    stream_name = "target-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    # update must find an existing stream so the capability guard (not "not found") is reached.
+    is_update = command is update_namespace_asset_stream
+    existing_streams = [generate_stream(stream_name=stream_name)] if is_update else []
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=existing_streams,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # Metadata endpoint exists but omits the 'streams' section entirely (capability unsupported).
+    metadata = _stream_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("streams")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    stream_config = materialize_config(
+        {"streamConfiguration": {"anything": "goes"}}, config_form, tmp_path
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support streams"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            stream_config=stream_config,
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_stream, update_namespace_asset_stream])
+@pytest.mark.parametrize("template_mode", ["config", "schema"])
+def test_namespace_asset_stream_generalized_show_template_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    template_mode: str,
+    command,
+):
+    """--show-template (config or schema) for a connector without a 'streams' section must raise
+    rather than returning an empty template. Covers both add and update commands."""
+    asset_name = "gen-asset"
+    stream_name = "target-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_stream
+    existing_streams = [generate_stream(stream_name=stream_name)] if is_update else []
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=existing_streams,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _stream_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("streams")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support streams"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            show_template=template_mode,
             wait_sec=0,
         )
 

--- a/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
+++ b/azext_edge/tests/edge/adr/test_namespace_asset_streams_unit.py
@@ -1522,6 +1522,104 @@ def test_namespace_asset_stream_generalized_show_template_unsupported_raises(
         )
 
 
+@pytest.mark.parametrize("command", [add_namespace_asset_stream, update_namespace_asset_stream])
+def test_namespace_asset_stream_generalized_null_section_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    command,
+):
+    """A connector whose metadata declares 'streams' as a non-object (e.g. null) must be treated
+    as unsupported and raise a clear error, not break with an AttributeError downstream."""
+    asset_name = "gen-asset"
+    stream_name = "target-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_stream
+    existing_streams = [generate_stream(stream_name=stream_name)] if is_update else []
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=existing_streams,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    # 'streams' key exists but is null (not an object) -> capability is not supported.
+    metadata = _stream_metadata(connector_type)
+    metadata["inboundEndpoints"][0]["streams"] = None
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support streams"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            stream_config='{"streamConfiguration": {"anything": "goes"}}',
+            wait_sec=0,
+        )
+
+
+@pytest.mark.parametrize("command", [add_namespace_asset_stream, update_namespace_asset_stream])
+def test_namespace_asset_stream_generalized_no_config_unsupported_raises(
+    mocked_cmd,
+    mocked_responses: responses,
+    mocked_check_cluster_connectivity,
+    mocked_get_namespace_for_instance,
+    mocker,
+    command,
+):
+    """Even with no --stream-config and no --show-template, adding/updating a stream on a
+    connector that doesn't support streams must be blocked (DOE parity)."""
+    asset_name = "gen-asset"
+    stream_name = "target-stream"
+    connector_type = "Custom.Test"
+    ns_resource = mocked_get_namespace_for_instance.return_value
+    namespace_name = ns_resource["name"]
+    resource_group_name = ns_resource["resource_group"]
+
+    is_update = command is update_namespace_asset_stream
+    existing_streams = [generate_stream(stream_name=stream_name)] if is_update else []
+    asset = _build_asset_with_connector_streams(
+        asset_name=asset_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        streams=existing_streams,
+    )
+    _register_asset_and_device_get(
+        mocked_responses, asset, namespace_name, resource_group_name, asset_name, connector_type
+    )
+
+    metadata = _stream_metadata(connector_type)
+    metadata["inboundEndpoints"][0].pop("streams")
+    mocker.patch(
+        "azext_edge.edge.providers.adr.namespace_assets.NamespaceAssets._get_connector_metadata",
+        return_value=metadata,
+    )
+
+    with pytest.raises(InvalidArgumentValueError, match="does not support streams"):
+        command(
+            cmd=mocked_cmd,
+            asset_name=asset_name,
+            instance_name="inst",
+            instance_resource_group="rg",
+            stream_name=stream_name,
+            wait_sec=0,
+        )
+
+
 def test_add_namespace_asset_stream_generalized_show_template_config(
     mocked_cmd,
     mocked_responses: responses,


### PR DESCRIPTION
- Asset sub-resource commands (datasets, data points, events, event groups, streams, management groups, and actions) now return a clear error when a connector doesn't support that capability, instead of silently accepting invalid input.
- The check applies consistently on both add and update, whether configuration is supplied inline or via a JSON/YAML file, and when viewing templates.
- Added unit tests covering every capability and input path, and verified the behavior against a live instance.

<img width="1322" height="90" alt="image" src="https://github.com/user-attachments/assets/83ce63f0-6a29-4f10-971a-1ecbb4fc589b" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
