### PR TITLE
build: version increments for 2607 release

### DIFF
--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "2.8.0a2"
+VERSION = "2.8.0"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -11,4 +11,4 @@ VERSION = "2.8.0a2"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)
-AIO_RELEASE = "2606"
+AIO_RELEASE = "2607"

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -1467,7 +1467,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
         },
         "variables": {
             "VERSIONS": {"iotOperations": "1.4.41"},
-            "TRAINS": {"iotOperations": "integration"},
+            "TRAINS": {"iotOperations": "stable"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "CUSTOM_LOCATION_NAMESPACE": "[parameters('clusterNamespace')]",

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -49,12 +49,12 @@ class TemplateBlueprint(NamedTuple):
 
 
 TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
-    commit_id="e31ffadb87599430564995ed783fa7a9b59fbb3a",
+    commit_id="18e6821d7dac3e85dbf6ff4d0bba1510aaf3aab0",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
-        "metadata": {"_generator": {"name": "bicep", "version": "0.44.1.10279", "templateHash": "7441326017904271928"}},
+        "metadata": {"_generator": {"name": "bicep", "version": "0.45.15.27210", "templateHash": "381872897952304332"}},
         "definitions": {
             "_1.AdvancedConfig": {
                 "type": "object",
@@ -75,6 +75,14 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
                             "telemetry": {
                                 "type": "object",
                                 "properties": {"enabled": {"type": "string", "nullable": True}},
+                                "nullable": True,
+                            },
+                            "secretTargets": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {"type": "string", "nullable": True},
+                                    "authorizedSecretsAll": {"type": "string", "nullable": True},
+                                },
                                 "nullable": True,
                             },
                         },
@@ -676,7 +684,7 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"certManager": "0.13.3", "secretStore": "1.5.0"},
+            "VERSIONS": {"certManager": "0.14.0", "secretStore": "1.5.1"},
             "TRAINS": {"certManager": "stable", "secretStore": "stable"},
         },
         "resources": {
@@ -702,6 +710,8 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
                     "configurationSettings": {
                         "AgentOperationTimeoutInMinutes": "20",
                         "global.telemetry.enabled": "[coalesce(tryGet(tryGet(tryGet(parameters('advancedConfig'), 'certManager'), 'telemetry'), 'enabled'), 'true')]",
+                        "trust-manager.secretTargets.enabled": "[coalesce(tryGet(tryGet(tryGet(parameters('advancedConfig'), 'certManager'), 'secretTargets'), 'enabled'), 'false')]",
+                        "trust-manager.secretTargets.authorizedSecretsAll": "[coalesce(tryGet(tryGet(tryGet(parameters('advancedConfig'), 'certManager'), 'secretTargets'), 'authorizedSecretsAll'), 'false')]",
                     },
                 },
             },
@@ -754,13 +764,13 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
 )
 
 TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
-    commit_id="bb2836289a5eca24eed43ae65b687afde3e630f8",
+    commit_id="8e8643fb4af5ae0724f4987e8bf85c094b6cee6f",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
         "metadata": {
-            "_generator": {"name": "bicep", "version": "0.44.1.10279", "templateHash": "9460116843817118827"}
+            "_generator": {"name": "bicep", "version": "0.45.15.27210", "templateHash": "10091655467238651388"}
         },
         "definitions": {
             "_1.AdvancedConfig": {
@@ -782,6 +792,14 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
                             "telemetry": {
                                 "type": "object",
                                 "properties": {"enabled": {"type": "string", "nullable": True}},
+                                "nullable": True,
+                            },
+                            "secretTargets": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {"type": "string", "nullable": True},
+                                    "authorizedSecretsAll": {"type": "string", "nullable": True},
+                                },
                                 "nullable": True,
                             },
                         },
@@ -1444,11 +1462,12 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "brokerConfig": {"$ref": "#/definitions/_1.BrokerConfig", "nullable": True},
             "trustConfig": {"$ref": "#/definitions/_1.TrustConfig", "defaultValue": {"source": "SelfSigned"}},
             "defaultDataflowInstanceCount": {"type": "int", "defaultValue": 1},
+            "enableGdsManager": {"type": "bool", "defaultValue": True},
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.3.137"},
-            "TRAINS": {"iotOperations": "stable"},
+            "VERSIONS": {"iotOperations": "1.4.41"},
+            "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "CUSTOM_LOCATION_NAMESPACE": "[parameters('clusterNamespace')]",
@@ -1478,6 +1497,8 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
                 "connectors.values.mqttBroker.address": "[format('mqtts://{0}:{1}', variables('MQTT_SETTINGS').brokerListenerHost, variables('MQTT_SETTINGS').brokerListenerPort)]",
                 "connectors.values.mqttBroker.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
                 "connectors.values.securityPki.applicationUri": "[format('urn:microsoft.com:aio:opc:ua:broker:{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                "connectors.values.securityPki.subjectName": "[format('CN=aio-opc-opcuabroker-{0}', variables('AIO_EXTENSION_SUFFIX'))]",
+                "connectors.values.gdsManager.enabled": "[if(parameters('enableGdsManager'), 'true', 'false')]",
                 "dataFlows.values.tinyKube.mqttBroker.hostName": "[variables('MQTT_SETTINGS').brokerListenerHost]",
                 "dataFlows.values.tinyKube.mqttBroker.port": "[variables('MQTT_SETTINGS').brokerListenerPort]",
                 "dataFlows.values.tinyKube.mqttBroker.authentication.serviceAccountTokenAudience": "[variables('MQTT_SETTINGS').serviceAccountAudience]",
@@ -1533,7 +1554,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "aioInstance": {
                 "type": "Microsoft.IoTOperations/instances",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH')))]",
                 "location": "[parameters('clusterLocation')]",
                 "extendedLocation": "[variables('extendedLocation')]",
@@ -1548,7 +1569,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "broker": {
                 "type": "Microsoft.IoTOperations/instances/brokers",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {
@@ -1572,7 +1593,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "brokerAuthn": {
                 "type": "Microsoft.IoTOperations/instances/brokers/authentications",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}/{2}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default', 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {
@@ -1589,7 +1610,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "brokerListener": {
                 "type": "Microsoft.IoTOperations/instances/brokers/listeners",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}/{2}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default', 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {
@@ -1616,7 +1637,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "dataflowProfile": {
                 "type": "Microsoft.IoTOperations/instances/dataflowProfiles",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {"instanceCount": "[parameters('defaultDataflowInstanceCount')]"},
@@ -1624,7 +1645,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "dataflowEndpoint": {
                 "type": "Microsoft.IoTOperations/instances/dataflowEndpoints",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {
@@ -1647,7 +1668,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             },
             "artifactRegistryEndpoint": {
                 "type": "Microsoft.IoTOperations/instances/registryEndpoints",
-                "apiVersion": "2026-03-01",
+                "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), 'default')]",
                 "extendedLocation": "[variables('extendedLocation')]",
                 "properties": {

--- a/azext_edge/edge/providers/support/connectors.py
+++ b/azext_edge/edge/providers/support/connectors.py
@@ -17,7 +17,7 @@ from .base import (
     process_v1_pods,
     process_replicasets,
 )
-from .common import NAME_LABEL_FORMAT
+from .common import NAME_LABEL_FORMAT, RESOURCE_NAME_FIELD_FORMAT
 
 logger = get_logger(__name__)
 
@@ -33,6 +33,7 @@ AIO_MEDIA_PREFIX = "aio-media"
 
 # TODO: once this label is stabled, we can remove the other labels
 OPCUA_NAME_LABEL = NAME_LABEL_FORMAT.format(label="microsoft-iotoperations-opcuabroker")
+GDS_CA_STATE_FIELD_SELECTOR = RESOURCE_NAME_FIELD_FORMAT.format(name="aio-opc-ua-gds-ca-state")
 
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
@@ -126,10 +127,17 @@ def fetch_services():
 
 
 def fetch_configmaps():
-    return process_config_maps(
+    processed = process_config_maps(
         directory_path=CONNECTORS_DIRECTORY_PATH,
         label_selector=OPCUA_NAME_LABEL,
     )
+    processed.extend(
+        process_config_maps(
+            directory_path=CONNECTORS_DIRECTORY_PATH,
+            field_selector=GDS_CA_STATE_FIELD_SELECTOR,
+        )
+    )
+    return processed
 
 
 def fetch_daemonsets():

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -154,7 +154,7 @@ EXTENSION_CONFIGS = {
         (EXTENSION_TYPE_SSC, "1.5.1", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.4.41", "integration"),
+        (EXTENSION_TYPE_OPS, "1.4.41", "stable"),
     ],
 }
 

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -150,11 +150,11 @@ def test_template_blueprint(content: dict):
 
 EXTENSION_CONFIGS = {
     "enablement": [
-        (EXTENSION_TYPE_CM, "0.13.3", "stable"),
-        (EXTENSION_TYPE_SSC, "1.5.0", "stable"),
+        (EXTENSION_TYPE_CM, "0.14.0", "stable"),
+        (EXTENSION_TYPE_SSC, "1.5.1", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.3.137", "stable"),
+        (EXTENSION_TYPE_OPS, "1.4.41", "integration"),
     ],
 }
 

--- a/azext_edge/tests/edge/support/test_connectors_unit.py
+++ b/azext_edge/tests/edge/support/test_connectors_unit.py
@@ -11,9 +11,11 @@ from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.support.connectors import (
     OPC_APP_LABEL,
     CONNECTORS_DIRECTORY_PATH,
+    GDS_CA_STATE_FIELD_SELECTOR,
     OPC_NAME_LABEL,
     OPC_NAME_VAR_LABEL,
     OPCUA_NAME_LABEL,
+    fetch_configmaps,
 )
 from azext_edge.tests.edge.support.test_support_unit import (
     assert_list_config_maps,
@@ -158,3 +160,24 @@ def test_create_bundle_connectors(
         label_selector=OPCUA_NAME_LABEL,
         directory_path=CONNECTORS_DIRECTORY_PATH,
     )
+
+
+def test_fetch_configmaps_includes_gds_state(mocker):
+    opcua_config_map = {"zinfo": "configmap.opcua.yaml"}
+    gds_config_map = {"zinfo": "configmap.aio-opc-ua-gds-ca-state.yaml"}
+    mocked_process_config_maps = mocker.patch(
+        "azext_edge.edge.providers.support.connectors.process_config_maps",
+        side_effect=[[opcua_config_map], [gds_config_map]],
+    )
+
+    assert fetch_configmaps() == [opcua_config_map, gds_config_map]
+    assert mocked_process_config_maps.call_args_list == [
+        mocker.call(
+            directory_path=CONNECTORS_DIRECTORY_PATH,
+            label_selector=OPCUA_NAME_LABEL,
+        ),
+        mocker.call(
+            directory_path=CONNECTORS_DIRECTORY_PATH,
+            field_selector=GDS_CA_STATE_FIELD_SELECTOR,
+        ),
+    ]


### PR DESCRIPTION
## Version Increments
<img width="1486" height="918" alt="image" src="https://github.com/user-attachments/assets/14ea8513-7055-4f65-8140-37a0e3269105" />

 - Update `AIO_RELEASE` from `2606` to `2607`.
 - Update Cert Manager from `0.13.3` to `0.14.0` (`stable`).
 - Update Secret Store from `1.5.0` to `1.5.1` (`stable`).
 - Update IoT Operations from `1.3.137/stable` to `1.4.41/integration`.
 - Keep CLI version `2.8.0a2` until the stable-train update.
 
 ## Template Updates
 
 - Sync the embedded enablement and instance templates with `releases/v1.4.x/2607`.
 - Update source commit IDs, Bicep generator metadata, and template hashes.


### Please note there are structural changes like below:
<img width="600" height="88" alt="image" src="https://github.com/user-attachments/assets/b72b0c97-4d17-4886-8004-dfc2f2ded4e5" />, therefore

 - Include structural changes from the regenerated templates:
   - Cert Manager `secretTargets` configuration.
   - GDS Manager parameter and GDS/PKI settings.
   - IoT Operations resource API versions updated to `2026-07-01`.
