### PR TITLE
fix: repair existing SecretSync FIC issuer mismatch

### DIFF
--- a/azext_edge/edge/providers/orchestration/clone.py
+++ b/azext_edge/edge/providers/orchestration/clone.py
@@ -483,7 +483,7 @@ class InstanceRestore:
         oidc_issuer = self.instances._ensure_oidc_issuer(
             cluster_resource, use_self_hosted_issuer=use_self_hosted_issuer
         )
-        oidc_issuer = resolve_oidc_issuer(arm_issuer=oidc_issuer)
+        oidc_issuer, _ = resolve_oidc_issuer(arm_issuer=oidc_issuer)
 
         for mid in self.user_assigned_mis:
             parsed_uami_id = parse_resource_id(mid)

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -8,7 +8,7 @@ import json
 import re
 import time
 from contextlib import nullcontext
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlsplit
 
 import requests
@@ -164,7 +164,7 @@ def _get_public_discovery_issuer(arm_issuer: str) -> Optional[str]:
     return None
 
 
-def resolve_oidc_issuer(arm_issuer: str) -> str:
+def resolve_oidc_issuer(arm_issuer: str) -> Tuple[str, bool]:
     discovery_issuer = _get_public_discovery_issuer(arm_issuer)
 
     if discovery_issuer:
@@ -175,14 +175,14 @@ def resolve_oidc_issuer(arm_issuer: str) -> str:
                 arm_issuer,
                 discovery_issuer,
             )
-        return discovery_issuer
+        return discovery_issuer, True
 
     logger.warning(
         "Could not verify the OIDC issuer '%s' from this host. The ARM-reported value will be used "
         "for the federated identity credential. This may still work if Microsoft Entra can reach the issuer.",
         arm_issuer,
     )
-    return arm_issuer
+    return arm_issuer, False
 
 
 def get_enable_syntax(instance_name: str, resource_group_name: str) -> str:
@@ -473,14 +473,14 @@ class Instances(Queryable):
             namespace = custom_location["properties"]["namespace"]
             cred_subject = get_cred_subject(namespace=namespace, service_account_name=SERVICE_ACCOUNT_SECRETSYNC)
             arm_oidc_issuer = self._ensure_oidc_issuer(cluster_resource, use_self_hosted_issuer)
-            oidc_issuer = resolve_oidc_issuer(arm_issuer=arm_oidc_issuer)
+            oidc_issuer, issuer_verified = resolve_oidc_issuer(arm_issuer=arm_oidc_issuer)
 
             secretsync_resources = resource_map.connected_cluster.get_cl_resources_by_type(
                 custom_location_id=instance["extendedLocation"]["name"],
                 resource_types={SPC_RESOURCE_TYPE, SECRET_SYNC_RESOURCE_TYPE},
             )
             if secretsync_resources:
-                if oidc_issuer != arm_oidc_issuer:
+                if issuer_verified:
                     self._repair_federated_cred_issuer(
                         mi_resource_id_container=mi_resource_id_container,
                         issuer_url=oidc_issuer,
@@ -1061,12 +1061,25 @@ class Instances(Queryable):
         issuer_url: str,
         subject: str,
     ):
-        federated_cred = self._find_federated_cred(
-            mi_resource_id_container=mi_resource_id_container,
-            issuer_url=issuer_url,
-            subject=subject,
-            match_trailing_slash=True,
-        )
+        try:
+            federated_cred = self._find_federated_cred(
+                mi_resource_id_container=mi_resource_id_container,
+                issuer_url=issuer_url,
+                subject=subject,
+                match_trailing_slash=True,
+            )
+        except HttpResponseError as http_exc:
+            raise ValidationError(
+                "Failed to inspect federated identity credentials for identity "
+                f"'{mi_resource_id_container.resource_name}' while checking the SecretSync issuer.\n"
+                "Ensure you have permission to read federated identity credentials, then rerun the command.\n"
+                "Inspect the credentials manually with:\n"
+                f"az identity federated-credential list "
+                f"--identity-name '{mi_resource_id_container.resource_name}' "
+                f"--resource-group '{mi_resource_id_container.resource_group_name}' "
+                f"--subscription '{mi_resource_id_container.subscription_id}'\n"
+                f"Error: {http_exc}"
+            )
         if not federated_cred:
             return
 
@@ -1075,18 +1088,32 @@ class Instances(Queryable):
             return
 
         self.msi_mgmt_client._config.subscription_id = mi_resource_id_container.subscription_id
-        self.msi_mgmt_client.federated_identity_credentials.create_or_update(
-            resource_group_name=mi_resource_id_container.resource_group_name,
-            resource_name=mi_resource_id_container.resource_name,
-            federated_identity_credential_resource_name=federated_cred["name"],
-            parameters={
-                "properties": {
-                    "subject": cred_props["subject"],
-                    "audiences": cred_props["audiences"],
-                    "issuer": issuer_url,
-                }
-            },
-        )
+        try:
+            self.msi_mgmt_client.federated_identity_credentials.create_or_update(
+                resource_group_name=mi_resource_id_container.resource_group_name,
+                resource_name=mi_resource_id_container.resource_name,
+                federated_identity_credential_resource_name=federated_cred["name"],
+                parameters={
+                    "properties": {
+                        "subject": cred_props["subject"],
+                        "audiences": cred_props["audiences"],
+                        "issuer": issuer_url,
+                    }
+                },
+            )
+        except HttpResponseError as http_exc:
+            raise ValidationError(
+                f"Failed to repair federated identity credential '{federated_cred['name']}' "
+                f"for identity '{mi_resource_id_container.resource_name}'.\n"
+                "Update its issuer manually, then rerun the command:\n"
+                f"az identity federated-credential update "
+                f"--name '{federated_cred['name']}' "
+                f"--identity-name '{mi_resource_id_container.resource_name}' "
+                f"--resource-group '{mi_resource_id_container.resource_group_name}' "
+                f"--issuer '{issuer_url}' "
+                f"--subscription '{mi_resource_id_container.subscription_id}'\n"
+                f"Error: {http_exc}"
+            )
 
     def unfederate_msi(
         self,

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -1072,13 +1072,14 @@ class Instances(Queryable):
             raise ValidationError(
                 "Failed to inspect federated identity credentials for identity "
                 f"'{mi_resource_id_container.resource_name}' while checking the SecretSync issuer.\n"
-                "Ensure you have permission to read federated identity credentials, then rerun the command.\n"
-                "Inspect the credentials manually with:\n"
+                f"Error: {http_exc}\n\n"
+                "Ensure you have permission to read federated identity credentials. "
+                "You can inspect them manually with:\n"
                 f"az identity federated-credential list "
                 f"--identity-name '{mi_resource_id_container.resource_name}' "
                 f"--resource-group '{mi_resource_id_container.resource_group_name}' "
-                f"--subscription '{mi_resource_id_container.subscription_id}'\n"
-                f"Error: {http_exc}"
+                f"--subscription '{mi_resource_id_container.subscription_id}'\n\n"
+                "Please resolve the error, then rerun the command to apply the repair."
             )
         if not federated_cred:
             return
@@ -1105,14 +1106,14 @@ class Instances(Queryable):
             raise ValidationError(
                 f"Failed to repair federated identity credential '{federated_cred['name']}' "
                 f"for identity '{mi_resource_id_container.resource_name}'.\n"
-                "Update its issuer manually, then rerun the command:\n"
+                f"Error: {http_exc}\n\n"
+                "Update its issuer manually with:\n"
                 f"az identity federated-credential update "
                 f"--name '{federated_cred['name']}' "
                 f"--identity-name '{mi_resource_id_container.resource_name}' "
                 f"--resource-group '{mi_resource_id_container.resource_group_name}' "
                 f"--issuer '{issuer_url}' "
-                f"--subscription '{mi_resource_id_container.subscription_id}'\n"
-                f"Error: {http_exc}"
+                f"--subscription '{mi_resource_id_container.subscription_id}'"
             )
 
     def unfederate_msi(

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -472,13 +472,20 @@ class Instances(Queryable):
             custom_location = self.get_associated_cl(instance)
             namespace = custom_location["properties"]["namespace"]
             cred_subject = get_cred_subject(namespace=namespace, service_account_name=SERVICE_ACCOUNT_SECRETSYNC)
-            oidc_issuer = self._ensure_oidc_issuer(cluster_resource, use_self_hosted_issuer)
+            arm_oidc_issuer = self._ensure_oidc_issuer(cluster_resource, use_self_hosted_issuer)
+            oidc_issuer = resolve_oidc_issuer(arm_issuer=arm_oidc_issuer)
 
             secretsync_resources = resource_map.connected_cluster.get_cl_resources_by_type(
                 custom_location_id=instance["extendedLocation"]["name"],
                 resource_types={SPC_RESOURCE_TYPE, SECRET_SYNC_RESOURCE_TYPE},
             )
             if secretsync_resources:
+                if oidc_issuer != arm_oidc_issuer:
+                    self._repair_federated_cred_issuer(
+                        mi_resource_id_container=mi_resource_id_container,
+                        issuer_url=oidc_issuer,
+                        subject=cred_subject,
+                    )
                 status.stop()
                 logger.warning(
                     f"Instance '{instance['name']}' already has associated secret sync resources.\n"
@@ -486,7 +493,6 @@ class Instances(Queryable):
                 )
                 return
 
-            oidc_issuer = resolve_oidc_issuer(arm_issuer=oidc_issuer)
             if not federated_credential_name:
                 federated_credential_name = get_fc_name(
                     cluster_name=cluster_resource["name"],
@@ -1049,6 +1055,39 @@ class Instances(Queryable):
             },
         )
 
+    def _repair_federated_cred_issuer(
+        self,
+        mi_resource_id_container: ResourceIdContainer,
+        issuer_url: str,
+        subject: str,
+    ):
+        federated_cred = self._find_federated_cred(
+            mi_resource_id_container=mi_resource_id_container,
+            issuer_url=issuer_url,
+            subject=subject,
+            match_trailing_slash=True,
+        )
+        if not federated_cred:
+            return
+
+        cred_props: dict = federated_cred["properties"]
+        if cred_props.get("issuer") == issuer_url:
+            return
+
+        self.msi_mgmt_client._config.subscription_id = mi_resource_id_container.subscription_id
+        self.msi_mgmt_client.federated_identity_credentials.create_or_update(
+            resource_group_name=mi_resource_id_container.resource_group_name,
+            resource_name=mi_resource_id_container.resource_name,
+            federated_identity_credential_resource_name=federated_cred["name"],
+            parameters={
+                "properties": {
+                    "subject": cred_props["subject"],
+                    "audiences": cred_props["audiences"],
+                    "issuer": issuer_url,
+                }
+            },
+        )
+
     def unfederate_msi(
         self,
         mi_resource_id_container: ResourceIdContainer,
@@ -1063,7 +1102,11 @@ class Instances(Queryable):
         )
 
     def _find_federated_cred(
-        self, mi_resource_id_container: ResourceIdContainer, issuer_url: str, subject: str
+        self,
+        mi_resource_id_container: ResourceIdContainer,
+        issuer_url: str,
+        subject: str,
+        match_trailing_slash: bool = False,
     ) -> Optional[dict]:
         # TODO - @digimaun
         self.msi_mgmt_client._config.subscription_id = mi_resource_id_container.subscription_id
@@ -1071,10 +1114,22 @@ class Instances(Queryable):
             resource_group_name=mi_resource_id_container.resource_group_name,
             resource_name=mi_resource_id_container.resource_name,
         )
+        trailing_slash_match = None
         for cred in cred_iteratable:
             cred_props: dict = cred["properties"]
-            if cred_props.get("issuer") == issuer_url and cred_props.get("subject") == subject:
+            if cred_props.get("subject") != subject:
+                continue
+            cred_issuer = cred_props.get("issuer")
+            if cred_issuer == issuer_url:
                 return cred
+            if (
+                match_trailing_slash
+                and trailing_slash_match is None
+                and isinstance(cred_issuer, str)
+                and oidc_issuers_match(cred_issuer, issuer_url)
+            ):
+                trailing_slash_match = cred
+        return trailing_slash_match
 
 
 def ensure_feature_key_compat(features: Dict[str, str]):

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 import pytest
 import responses
 from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
+from azure.core.exceptions import HttpResponseError
 
 from azext_edge.edge.commands_edge import (
     instance_identity_assign,
@@ -83,7 +84,7 @@ def mocked_resolve_oidc_issuer(mocker):
     yield mocker.patch(
         "azext_edge.edge.providers.orchestration.resources.instances.resolve_oidc_issuer",
         autospec=True,
-        side_effect=lambda arm_issuer, **_: arm_issuer,
+        side_effect=lambda arm_issuer, **_: (arm_issuer, False),
     )
 
 
@@ -916,6 +917,7 @@ def test_secretsync_enable(
     "scenario",
     [
         "repair",
+        "verified_exact_arm",
         "exact",
         "unrelated",
         "fallback",
@@ -962,18 +964,21 @@ def test_secretsync_enable_repairs_existing_fic(
     resource_map.connected_cluster.resource = {"name": generate_random_string()}
     resource_map.connected_cluster.get_cl_resources_by_type.return_value = {SPC_RESOURCE_TYPE: [{}]}
 
-    arm_issuer = "https://issuer.example/cluster/"
-    discovery_issuer = arm_issuer[:-1]
+    discovery_issuer = "https://issuer.example/cluster"
+    slash_issuer = f"{discovery_issuer}/"
+    arm_issuer = discovery_issuer if scenario in {"fallback", "verified_exact_arm"} else slash_issuer
     instances._ensure_oidc_issuer.return_value = arm_issuer
     mocked_resolve_oidc_issuer.side_effect = None
-    mocked_resolve_oidc_issuer.return_value = arm_issuer if scenario == "fallback" else discovery_issuer
+    resolved_issuer = arm_issuer if scenario in {"fallback", "verified_exact_arm"} else discovery_issuer
+    issuer_verified = scenario != "fallback"
+    mocked_resolve_oidc_issuer.return_value = resolved_issuer, issuer_verified
 
     subject = f"system:serviceaccount:{namespace}:{SERVICE_ACCOUNT_SECRETSYNC}"
     audiences = ["api://AzureADTokenExchange"]
-    slash_cred = {
-        "name": "slash-cred",
+    mismatched_cred = {
+        "name": "mismatched-cred",
         "properties": {
-            "issuer": arm_issuer,
+            "issuer": slash_issuer,
             "subject": subject,
             "audiences": audiences,
         },
@@ -981,7 +986,7 @@ def test_secretsync_enable_repairs_existing_fic(
     exact_cred = {
         "name": "exact-cred",
         "properties": {
-            "issuer": discovery_issuer,
+            "issuer": resolved_issuer,
             "subject": subject,
             "audiences": audiences,
         },
@@ -989,12 +994,12 @@ def test_secretsync_enable_repairs_existing_fic(
     if scenario == "exact":
         existing_creds = [exact_cred]
     elif scenario == "unrelated":
-        slash_cred["properties"]["subject"] = f"{subject}-other"
-        existing_creds = [slash_cred]
+        mismatched_cred["properties"]["subject"] = f"{subject}-other"
+        existing_creds = [mismatched_cred]
     elif scenario == "exact_preferred":
-        existing_creds = [slash_cred, exact_cred]
+        existing_creds = [mismatched_cred, exact_cred]
     else:
-        existing_creds = [slash_cred]
+        existing_creds = [mismatched_cred]
     instances.msi_mgmt_client.federated_identity_credentials.list.return_value = existing_creds
 
     status = mocker.patch(
@@ -1020,22 +1025,78 @@ def test_secretsync_enable_repairs_existing_fic(
     if scenario == "fallback":
         fic_ops.list.assert_not_called()
         fic_ops.create_or_update.assert_not_called()
-    elif scenario == "repair":
+    elif scenario in {"repair", "verified_exact_arm"}:
         fic_ops.create_or_update.assert_called_once_with(
             resource_group_name=resource_group_name,
             resource_name=uami_name,
-            federated_identity_credential_resource_name=slash_cred["name"],
+            federated_identity_credential_resource_name=mismatched_cred["name"],
             parameters={
                 "properties": {
                     "subject": subject,
                     "audiences": audiences,
-                    "issuer": discovery_issuer,
+                    "issuer": resolved_issuer,
                 }
             },
         )
     else:
         fic_ops.list.assert_called_once()
         fic_ops.create_or_update.assert_not_called()
+
+
+@pytest.mark.parametrize("operation", ["list", "update"])
+def test_repair_federated_cred_issuer_surfaces_actionable_error(mocker, operation: str):
+    instances = Instances.__new__(Instances)
+    instances.msi_mgmt_client = mocker.Mock()
+
+    subscription_id = generate_uuid()
+    resource_group_name = "rg(prod)"
+    uami_name = generate_random_string()
+    mi_resource_id_container = mocker.Mock(
+        subscription_id=subscription_id,
+        resource_group_name=resource_group_name,
+        resource_name=uami_name,
+    )
+    issuer_url = "https://issuer.example/cluster"
+    subject = f"system:serviceaccount:{generate_random_string()}:{SERVICE_ACCOUNT_SECRETSYNC}"
+    credential_name = generate_random_string()
+    fic_ops = instances.msi_mgmt_client.federated_identity_credentials
+
+    if operation == "list":
+        fic_ops.list.side_effect = HttpResponseError(message="Permission denied")
+    else:
+        fic_ops.list.return_value = [
+            {
+                "name": credential_name,
+                "properties": {
+                    "issuer": f"{issuer_url}/",
+                    "subject": subject,
+                    "audiences": ["api://AzureADTokenExchange"],
+                },
+            }
+        ]
+        fic_ops.create_or_update.side_effect = HttpResponseError(message="Request failed")
+
+    with pytest.raises(ValidationError) as exc:
+        instances._repair_federated_cred_issuer(
+            mi_resource_id_container=mi_resource_id_container,
+            issuer_url=issuer_url,
+            subject=subject,
+        )
+
+    message = str(exc.value)
+    assert uami_name in message
+    assert resource_group_name in message
+    assert subscription_id in message
+    assert "--resource-group 'rg(prod)'" in message
+    if operation == "list":
+        assert "Permission denied" in message
+        assert "az identity federated-credential list" in message
+        fic_ops.create_or_update.assert_not_called()
+    else:
+        assert "Request failed" in message
+        assert credential_name in message
+        assert "az identity federated-credential update" in message
+        assert f"--issuer '{issuer_url}'" in message
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -33,6 +33,7 @@ from azext_edge.edge.providers.orchestration.resources.instances import (
     SERVICE_ACCOUNT_SCHEMA,
     SERVICE_ACCOUNT_SECRETSYNC,
     SERVICE_ACCOUNT_WASM,
+    SPC_RESOURCE_TYPE,
     get_fc_name,
     get_spc_name,
     parse_feature_kvp_nargs,
@@ -909,6 +910,132 @@ def test_secretsync_enable(
             assert ra_put_request["properties"]["roleDefinitionId"] == role_ids[i]
             assert ra_put_request["properties"]["principalId"] == principal_id
             assert ra_put_request["properties"]["principalType"] == "ServicePrincipal"
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "repair",
+        "exact",
+        "unrelated",
+        "fallback",
+        "exact_preferred",
+    ],
+)
+def test_secretsync_enable_repairs_existing_fic(
+    mocker,
+    mocked_resolve_oidc_issuer: Mock,
+    scenario: str,
+):
+    instances = Instances.__new__(Instances)
+    instances.resource_client = mocker.Mock()
+    instances.msi_mgmt_client = mocker.Mock()
+    instances.ssc_mgmt_client = mocker.Mock()
+    instances.show = mocker.Mock()
+    instances.get_resource_map = mocker.Mock()
+    instances.get_associated_cl = mocker.Mock()
+    instances._ensure_oidc_issuer = mocker.Mock()
+    instances.federate_msi = mocker.Mock()
+    instances.update = mocker.Mock()
+
+    resource_group_name = generate_random_string()
+    instance_name = generate_random_string()
+    namespace = generate_random_string()
+    uami_name = generate_random_string()
+    uami_resource_id = generate_resource_id(
+        resource_group_name=resource_group_name,
+        resource_provider="Microsoft.ManagedIdentity",
+        resource_path=f"/userAssignedIdentities/{uami_name}",
+    )
+    keyvault_resource_id = generate_resource_id(
+        resource_group_name=resource_group_name,
+        resource_provider="Microsoft.KeyVault",
+        resource_path=f"/keyvaults/{generate_random_string()}",
+    )
+    instance = {
+        "name": instance_name,
+        "extendedLocation": {"name": generate_resource_id(resource_group_name=resource_group_name)},
+    }
+    instances.show.return_value = instance
+    instances.get_associated_cl.return_value = {"properties": {"namespace": namespace}}
+    resource_map = instances.get_resource_map.return_value
+    resource_map.connected_cluster.resource = {"name": generate_random_string()}
+    resource_map.connected_cluster.get_cl_resources_by_type.return_value = {SPC_RESOURCE_TYPE: [{}]}
+
+    arm_issuer = "https://issuer.example/cluster/"
+    discovery_issuer = arm_issuer[:-1]
+    instances._ensure_oidc_issuer.return_value = arm_issuer
+    mocked_resolve_oidc_issuer.side_effect = None
+    mocked_resolve_oidc_issuer.return_value = arm_issuer if scenario == "fallback" else discovery_issuer
+
+    subject = f"system:serviceaccount:{namespace}:{SERVICE_ACCOUNT_SECRETSYNC}"
+    audiences = ["api://AzureADTokenExchange"]
+    slash_cred = {
+        "name": "slash-cred",
+        "properties": {
+            "issuer": arm_issuer,
+            "subject": subject,
+            "audiences": audiences,
+        },
+    }
+    exact_cred = {
+        "name": "exact-cred",
+        "properties": {
+            "issuer": discovery_issuer,
+            "subject": subject,
+            "audiences": audiences,
+        },
+    }
+    if scenario == "exact":
+        existing_creds = [exact_cred]
+    elif scenario == "unrelated":
+        slash_cred["properties"]["subject"] = f"{subject}-other"
+        existing_creds = [slash_cred]
+    elif scenario == "exact_preferred":
+        existing_creds = [slash_cred, exact_cred]
+    else:
+        existing_creds = [slash_cred]
+    instances.msi_mgmt_client.federated_identity_credentials.list.return_value = existing_creds
+
+    status = mocker.patch(
+        "azext_edge.edge.providers.orchestration.resources.instances.console.status"
+    ).return_value.__enter__.return_value
+
+    result = instances.enable_secretsync(
+        name=instance_name,
+        resource_group_name=resource_group_name,
+        mi_user_assigned=uami_resource_id,
+        keyvault_resource_id=keyvault_resource_id,
+        skip_role_assignments=True,
+    )
+
+    assert result is None
+    mocked_resolve_oidc_issuer.assert_called_once_with(arm_issuer=arm_issuer)
+    status.stop.assert_called_once()
+    instances.federate_msi.assert_not_called()
+    instances.ssc_mgmt_client.azure_key_vault_secret_provider_classes.begin_create_or_update.assert_not_called()
+    instances.update.assert_not_called()
+
+    fic_ops = instances.msi_mgmt_client.federated_identity_credentials
+    if scenario == "fallback":
+        fic_ops.list.assert_not_called()
+        fic_ops.create_or_update.assert_not_called()
+    elif scenario == "repair":
+        fic_ops.create_or_update.assert_called_once_with(
+            resource_group_name=resource_group_name,
+            resource_name=uami_name,
+            federated_identity_credential_resource_name=slash_cred["name"],
+            parameters={
+                "properties": {
+                    "subject": subject,
+                    "audiences": audiences,
+                    "issuer": discovery_issuer,
+                }
+            },
+        )
+    else:
+        fic_ops.list.assert_called_once()
+        fic_ops.create_or_update.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_oidc_issuer_unit.py
@@ -28,7 +28,7 @@ def test_resolve_oidc_issuer_uses_exact_public_discovery(mocked_responses: respo
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, True)
     warning.assert_not_called()
 
 
@@ -43,7 +43,7 @@ def test_resolve_oidc_issuer_corrects_one_trailing_slash(mocked_responses: respo
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == discovery_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (discovery_issuer, True)
     assert [call.request.url for call in mocked_responses.calls] == [
         f"{discovery_issuer}{OIDC_DISCOVERY_PATH}",
     ]
@@ -60,7 +60,7 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_for_malformed_discovery(mocked_res
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     warning.assert_called_once()
 
 
@@ -78,7 +78,7 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_for_deeply_nested_discovery(mocked
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     warning.assert_called_once()
 
 
@@ -97,7 +97,7 @@ def test_resolve_oidc_issuer_rejects_more_than_one_trailing_slash(mocked_respons
         )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     warning.assert_called_once()
 
 
@@ -109,7 +109,7 @@ def test_resolve_oidc_issuer_rejects_non_https_issuer(mocker):
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     request_get.assert_not_called()
     warning.assert_called_once()
 
@@ -122,7 +122,7 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_for_malformed_issuer_url(mocker):
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     request_get.assert_not_called()
     warning.assert_called_once()
 
@@ -136,7 +136,7 @@ def test_resolve_oidc_issuer_keeps_arm_issuer_when_discovery_is_unreachable(mock
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     warning.assert_called_once()
 
 
@@ -153,7 +153,7 @@ def test_resolve_oidc_issuer_rejects_oversized_discovery(mocked_responses: respo
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     warning.assert_called_once()
 
 
@@ -175,6 +175,6 @@ def test_resolve_oidc_issuer_ignores_redirects(mocked_responses: responses, mock
     )
     warning = mocker.patch("azext_edge.edge.providers.orchestration.resources.instances.logger.warning")
 
-    assert resolve_oidc_issuer(arm_issuer) == arm_issuer
+    assert resolve_oidc_issuer(arm_issuer) == (arm_issuer, False)
     assert len(mocked_responses.calls) == 1
     warning.assert_called_once()

--- a/azext_edge/tests/edge/orchestration/test_clone_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_clone_unit.py
@@ -196,7 +196,7 @@ def mocked_clone_resolve_oidc_issuer(mocker):
     yield mocker.patch(
         "azext_edge.edge.providers.orchestration.clone.resolve_oidc_issuer",
         autospec=True,
-        side_effect=lambda arm_issuer, **_: arm_issuer,
+        side_effect=lambda arm_issuer, **_: (arm_issuer, False),
     )
 
 
@@ -1309,6 +1309,8 @@ def test_clone_resolves_oidc_issuer(
     mocked_clone_resolve_oidc_issuer,
 ):
     arm_issuer = "https://localhost/issuer/"
+    resolved_issuer = arm_issuer[:-1]
+    subject = "system:serviceaccount:namespace:aio-ssc-sa"
     restore = mocker.Mock()
     restore.user_assigned_mis = [
         "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity"
@@ -1316,18 +1318,31 @@ def test_clone_resolves_oidc_issuer(
     restore.connected_cluster.resource = {}
     restore.instances._ensure_oidc_issuer.return_value = arm_issuer
     restore.namespace = "namespace"
+    restore.cluster_name = "cluster"
+    mocked_clone_resolve_oidc_issuer.side_effect = None
+    mocked_clone_resolve_oidc_issuer.return_value = resolved_issuer, True
 
     msi_client = mocker.patch(
         "azext_edge.edge.providers.orchestration.clone.get_msi_mgmt_client",
         autospec=True,
     ).return_value
-    msi_client.federated_identity_credentials.list.return_value = []
+    msi_client.federated_identity_credentials.list.return_value = [
+        {
+            "properties": {
+                "issuer": arm_issuer,
+                "subject": subject,
+            }
+        }
+    ]
 
     InstanceRestore._handle_federation(restore)
 
     mocked_clone_resolve_oidc_issuer.assert_called_once_with(
         arm_issuer=arm_issuer,
     )
+    create_call = msi_client.federated_identity_credentials.create_or_update.call_args
+    assert create_call.kwargs["parameters"]["properties"]["issuer"] == resolved_issuer
+    assert create_call.kwargs["parameters"]["properties"]["subject"] == subject
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

#899 ensures newly created SecretSync FICs use the canonical issuer from OIDC discovery.

Existing installations may still have a FIC created from the ARM issuer whose value differs from the discovery issuer by one trailing slash. Rerunning `az iot ops secretsync enable` did not repair it because the command returned when it found existing SecretSync resources, before resolving the issuer or checking the FIC.



## Fix

**For the affected case:**

 ARM issuer:       https://issuer/       (old FIC copied this)
 Discovery issuer: https://issuer        (canonical token issuer)
 Existing FIC:     same SecretSync subject, issuer=https://issuer/

---
Resolve the discovery issuer before the existing-resource early return and repair an existing slash-equivalent FIC in place.

- Attempt repair only when discovery verifies an issuer that differs from ARM.
- Match the SecretSync FIC by service-account subject.
- Keep the existing subject and audiences, replace only the issuer.
- Do not create a new FIC when no matching existing credential is found.
- Keep the existing early return so SecretSync resources are not recreated.

## Some clarifications...

**Q: What happens when the existing FIC has a trailing-slash mismatch?**  
A: The same FIC resource is updated with the discovery issuer. Its name, subject, and audiences remain unchanged.

**Q: What happens when the existing FIC is already correct?**  
A: It is found as an exact match and no update is made.

**Q: Does this change first-time SecretSync enablement?**  
A: No. New enablement continues through the existing creation path and creates the FIC using the resolved discovery issuer.

**Q: What happens when discovery cannot verify the issuer?**  
A: The ARM value is retained and no repair is attempted. This avoids rewriting an existing FIC toward an unverified value.

**Q: Can this create a duplicate FIC?**  
A: No. The repair path only updates a matching existing credential by name and does nothing when no match is found.

## E2E details:
[yuelin-pr907-fic-e2e-rg](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/a386d5ea-ea90-441a-8263-d816368c84a1/resourceGroups/yuelin-pr907-fic-e2e-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/yuelin-pr907-fic-e2e-mi/federatedcredentials)