### PR TITLE
ci: enable subprocess coverage for integration tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,13 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = azext_edge/edge
+# parallel writes a uniquely-suffixed data file per process so that the pytest
+# process and every `az` subprocess spawned by integration tests can be measured
+# without clobbering each other. Combined later via `coverage combine`.
+parallel = True
+# Measure by importable package name (not path) so the installed extension used
+# by `az iot ops ...` subprocesses is measured wherever it lives on disk.
+source_pkgs = azext_edge.edge
 omit =
     # ignore all tests
     azext_edge/tests/*
@@ -12,3 +18,11 @@ omit =
     azext_edge/edge/command_map.py
     # skip params and command map
     azext_edge/edge/providers/rpsaas/adr/params.py
+
+[paths]
+# Map the various on-disk locations of the extension (repo source, tox target,
+# `az extension add` cliextensions dir) back to the repo source so data from the
+# pytest process and the `az` subprocesses combines into a single set of files.
+source =
+    azext_edge/edge
+    */azext_edge/edge

--- a/scripts/coverage/sitecustomize.py
+++ b/scripts/coverage/sitecustomize.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""
+sitecustomize hook to enable coverage.py measurement inside subprocesses.
+
+Integration tests invoke the CLI as child ``az iot ops ...`` processes (see
+``azext_edge/tests/helpers.py::run`` -> ``subprocess.run``). coverage.py only
+traces the process it starts in, so those child processes would otherwise be
+invisible to coverage, which is why integration coverage reads as ~0%.
+
+When this directory is on ``PYTHONPATH`` and ``COVERAGE_PROCESS_START`` points at
+the coverage config, Python imports this module at interpreter startup and
+``coverage.process_startup()`` arms measurement for the child process. It is a
+no-op when ``COVERAGE_PROCESS_START`` is unset and when coverage is unavailable,
+so it is safe for every process that inherits ``PYTHONPATH``.
+"""
+
+try:
+    import coverage
+
+    coverage.process_startup()
+except Exception:  # pragma: no cover - never break a subprocess if coverage is missing
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,11 @@ passenv =
 setenv =
     # You can temporarily add variables here to modify your tests
     # azext_edge_skip_init=true
-    PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops
+    # scripts/coverage is appended so `az` subprocesses import sitecustomize.py and
+    # arm coverage via coverage.process_startup() (see COVERAGE_PROCESS_START below).
+    PYTHONPATH={envsitepackagesdir}/azure-cli-extensions/azure-iot-ops{:}{toxinidir}{/}scripts{/}coverage
+    # enable coverage.py measurement inside the `az iot ops ...` subprocesses the int tests spawn
+    COVERAGE_PROCESS_START={toxinidir}{/}.coveragerc
     init: SCENARIO="init_scenario_test"
     e2e: SCENARIO="e2e"
     rpsaas: SCENARIO="rpsaas and not long_running"
@@ -110,6 +114,9 @@ deps = coverage
 allowlist_externals = coverage
 skip_install = true
 commands =
+    # combine per-process (parallel) data files, incl. those written by `az` subprocesses,
+    # into a single .coverage. Leading '-' ignores the "no data to combine" case.
+    - coverage combine --append
     coverage report
     coverage html
     coverage json


### PR DESCRIPTION
## Summary
Integration tests invoke the CLI as child `az iot ops ...` processes (via `helpers.run` -> `subprocess.run`). coverage.py only traces the process it starts in, so handler execution in those child processes was invisible — ops integration coverage read as ~0%.

This enables coverage.py subprocess measurement so those child processes are traced and combined into the report.

## Changes
- **`.coveragerc`**: add `parallel = True` (per-process data files), switch to `source_pkgs = azext_edge.edge`, and add a `[paths]` mapping so the installed-extension path and repo source combine into one dataset.
- **`scripts/coverage/sitecustomize.py`** (new): startup hook that calls `coverage.process_startup()` to arm measurement inside each `az` subprocess. No-op when `COVERAGE_PROCESS_START` is unset or coverage is unavailable.
- **`tox.ini`**: append `scripts/coverage` to `PYTHONPATH` and set `COVERAGE_PROCESS_START` in the integration env so subprocesses self-arm; add `coverage combine --append` to the `report` env to merge per-process data files.

## Validation
- Verified against a live cluster: a real `az iot ops check` run produced per-process data files that combined into non-zero coverage for check-provider modules that previously reported 0% (e.g. `providers/check/common.py` 89%, `base/node.py` 79%, `base/check_manager.py` 73%, `summary.py` 31%).
- `flake8 scripts/coverage/sitecustomize.py --config=setup.cfg` passes.