### PR TITLE
fix: apply custom instance name to OPC UA connector template resource

### DIFF
--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -275,6 +275,7 @@ class InitTargets:
         dataflow_profile = template.get_resource_by_key("dataflowProfile")
         dataflow_endpoint = template.get_resource_by_key("dataflowEndpoint")
         artifact_registry_endpoint = template.get_resource_by_key("artifactRegistryEndpoint")
+        opcua_connector_template = template.get_resource_by_key("opcUaConnectorTemplate")
 
         instance["properties"] = get_default_instance_config(
             description=self.instance_description,
@@ -289,6 +290,9 @@ class InitTargets:
             dataflow_profile["name"] = f"{self.instance_name}/{DEFAULT_DATAFLOW_PROFILE}"
             dataflow_endpoint["name"] = f"{self.instance_name}/{DEFAULT_DATAFLOW_ENDPOINT}"
             artifact_registry_endpoint["name"] = f"{self.instance_name}/{DEFAULT_ARTIFACT_REGISTRY}"
+            opcua_connector_template["name"] = (
+                f"[format('{self.instance_name}/{{0}}', variables('opcUaConnectorTemplateName'))]"
+            )
 
             template.content["outputs"]["aio"]["value"]["name"] = self.instance_name
 

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -27,6 +27,7 @@ from ..orchestration.common import (
     TRUST_SETTING_KEYS,
 )
 from ..orchestration.resources.brokers import Brokers
+from ..orchestration.resources.connector_templates import ConnectorTemplates
 from ..orchestration.resources.instances import parse_feature_kvp_nargs
 from .template import (
     TEMPLATE_BLUEPRINT_ENABLEMENT,
@@ -291,7 +292,7 @@ class InitTargets:
             dataflow_endpoint["name"] = f"{self.instance_name}/{DEFAULT_DATAFLOW_ENDPOINT}"
             artifact_registry_endpoint["name"] = f"{self.instance_name}/{DEFAULT_ARTIFACT_REGISTRY}"
             opcua_connector_template["name"] = (
-                f"[format('{self.instance_name}/{{0}}', variables('opcUaConnectorTemplateName'))]"
+                f"{self.instance_name}/{ConnectorTemplates.default_opcua_template_name(self.instance_name)}"
             )
 
             template.content["outputs"]["aio"]["value"]["name"] = self.instance_name

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -1656,3 +1656,6 @@ def assert_instance_deployment_body(body_str: str, target_scenario: dict, phase:
         assert resources["dataflowProfile"]["name"] == f"{instance_name_lowered}/{DEFAULT_DATAFLOW_PROFILE}"
         assert resources["dataflowEndpoint"]["name"] == f"{instance_name_lowered}/{DEFAULT_DATAFLOW_ENDPOINT}"
         assert resources["artifactRegistryEndpoint"]["name"] == f"{instance_name_lowered}/{DEFAULT_ARTIFACT_REGISTRY}"
+        assert resources["opcUaConnectorTemplate"]["name"] == (
+            f"[format('{instance_name_lowered}/{{0}}', variables('opcUaConnectorTemplateName'))]"
+        )

--- a/azext_edge/tests/edge/orchestration/test_work_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_work_unit.py
@@ -55,6 +55,7 @@ from azext_edge.edge.providers.orchestration.rp_namespace import (
     RP_NAMESPACE_OPTIONAL_SET,
     RP_NAMESPACE_SET,
 )
+from azext_edge.edge.providers.orchestration.resources.connector_templates import ConnectorTemplates
 from azext_edge.edge.providers.orchestration.targets import (
     InstancePhase,
     get_default_cl_name,
@@ -1656,6 +1657,5 @@ def assert_instance_deployment_body(body_str: str, target_scenario: dict, phase:
         assert resources["dataflowProfile"]["name"] == f"{instance_name_lowered}/{DEFAULT_DATAFLOW_PROFILE}"
         assert resources["dataflowEndpoint"]["name"] == f"{instance_name_lowered}/{DEFAULT_DATAFLOW_ENDPOINT}"
         assert resources["artifactRegistryEndpoint"]["name"] == f"{instance_name_lowered}/{DEFAULT_ARTIFACT_REGISTRY}"
-        assert resources["opcUaConnectorTemplate"]["name"] == (
-            f"[format('{instance_name_lowered}/{{0}}', variables('opcUaConnectorTemplateName'))]"
-        )
+        expected_opcua_template = ConnectorTemplates.default_opcua_template_name(instance_name_lowered)
+        assert resources["opcUaConnectorTemplate"]["name"] == f"{instance_name_lowered}/{expected_opcua_template}"

--- a/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
@@ -18,6 +18,7 @@ AKRI_PREFIXES = [
     "aio-akri",
     "aiomedia",
     "aioonvif",
+    "azureiotoperationsconnectorforopcua",
     "media-connector-template",
     "onvif-connector-template",
     "rest-connector-template",

--- a/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_akri_int.py
@@ -18,12 +18,17 @@ AKRI_PREFIXES = [
     "aio-akri",
     "aiomedia",
     "aioonvif",
-    "azureiotoperationsconnectorforopcua",
     "media-connector-template",
     "onvif-connector-template",
     "rest-connector-template",
     "sse-connector-template"
 ]
+# The default OPC UA connector template (and its connector) is captured by the akri bundle via the
+# akri CRD APIs (AkriConnectorTemplate/AkriConnector), not by the akri name label. So it shows up as
+# an accepted "extra" in the bundle contents but must be excluded from the label-coverage check,
+# which asserts label presence for label-collected resources only.
+OPCUA_CONNECTOR_PREFIX = "azureiotoperationsconnectorforopcua"
+AKRI_BUNDLE_PREFIXES = AKRI_PREFIXES + [OPCUA_CONNECTOR_PREFIX]
 AKRI_WORKLOAD_TYPES = [
     "deployment",
     "pod",
@@ -56,7 +61,7 @@ def test_create_bundle_akri(cluster_connection, tracked_files):
     check_workload_resource_files(
         file_objs=file_map,
         pre_bundle_items=pre_bundle_workload_items,
-        prefixes=AKRI_PREFIXES,
+        prefixes=AKRI_BUNDLE_PREFIXES,
         bundle_path=bundle_path,
         expected_label=AKRI_LABEL,
     )


### PR DESCRIPTION
- Fixes az iot ops create -n <instance> failing with ParentResourceNotFound — the opcUaConnectorTemplate resource wasn't renamed to the custom instance, so its parent pointed at the default aio-<hash> instance.
- Rewrites the connector template's parent to the custom instance name (preserving the deploy-time name variable) and adds a unit-test assertion.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
