### PR TITLE
fix(lro): surface terminal operation error details

### DIFF
--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -27,6 +27,8 @@ AZURE_CLI_CREDENTIAL = AzureCliCredential()
 
 POLL_RETRIES = 240
 POLL_WAIT_SEC = 15
+_LRO_FAILURE_STATUSES = frozenset({"failed", "canceled", "cancelled"})
+_INVALID_STATUS_MESSAGE = "Operation returned an invalid status"
 
 logger = get_logger(__name__)
 
@@ -297,6 +299,8 @@ def get_keyvault_client(subscription_id: str, keyvault_scope: Optional[str] = No
 
 
 def wait_for_terminal_state(poller: "LROPoller", wait_sec: int = POLL_WAIT_SEC, **_) -> JSON:
+    from azure.core.exceptions import HttpResponseError
+
     # resource client does not handle sigint well
     counter = 0
     while counter < POLL_RETRIES:
@@ -304,7 +308,86 @@ def wait_for_terminal_state(poller: "LROPoller", wait_sec: int = POLL_WAIT_SEC, 
             break
         sleep(wait_sec)
         counter = counter + 1
-    return poller.result()
+    try:
+        return poller.result()
+    except HttpResponseError as e:
+        message = _get_lro_failure_message(e)
+        if message:
+            e.message = message
+            e.args = (message,)
+        raise
+
+
+def _get_lro_failure_message(exception: "HttpResponseError") -> Optional[str]:
+    """Format terminal LRO failures that Azure SDK reports as an invalid 2xx status."""
+    response = exception.response
+    status_code = exception.status_code
+    if (
+        response is None
+        or not isinstance(status_code, int)
+        or not 200 <= status_code <= 299
+        or exception.error
+        or not exception.message.startswith(_INVALID_STATUS_MESSAGE)
+    ):
+        return None
+
+    try:
+        payload = response.json()
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+    if not isinstance(payload, MutableMapping):
+        return None
+
+    operation_status = str(payload.get("status", ""))
+    if operation_status.lower() not in _LRO_FAILURE_STATUSES:
+        return None
+
+    lines = [f"Long-running operation failed with status '{operation_status}'."]
+    error = payload.get("error")
+    if isinstance(error, MutableMapping):
+        code = error.get("code")
+        message = error.get("message")
+        has_error_details = False
+        if code:
+            lines.append(f"Code: {code}")
+            has_error_details = True
+        if message:
+            lines.append(f"Message: {message}")
+            has_error_details = True
+
+        details = error.get("details")
+        if details:
+            detail_items = details if isinstance(details, list) else [details]
+            formatted_details = [_format_lro_error_detail(detail) for detail in detail_items]
+            lines.append("Details:")
+            lines.extend(f"  - {detail}" for detail in formatted_details)
+            has_error_details = True
+        if not has_error_details:
+            lines.append("The service returned no error details.")
+    elif error:
+        lines.append(f"Error: {error}")
+    else:
+        lines.append("The service returned no error details.")
+
+    headers = getattr(response, "headers", None)
+    if hasattr(headers, "get"):
+        request_id = headers.get("x-ms-request-id") or headers.get("x-ms-correlation-request-id")
+        if request_id:
+            lines.append(f"Request ID: {request_id}")
+
+    return "\n".join(lines)
+
+
+def _format_lro_error_detail(detail: Any) -> str:
+    if not isinstance(detail, MutableMapping):
+        return str(detail)
+
+    code = detail.get("code")
+    message = detail.get("message")
+    if code and message:
+        return f"{code}: {message}"
+    return str(code or message or dict(detail))
 
 
 def wait_for_terminal_states(

--- a/azext_edge/tests/utility/test_az_client_unit.py
+++ b/azext_edge/tests/utility/test_az_client_unit.py
@@ -5,6 +5,8 @@
 # ----------------------------------------------------------------------------------------------
 
 import pytest
+from azure.core.exceptions import HttpResponseError
+
 from ..generators import generate_random_string
 
 AZ_CLIENT_PATH = "azext_edge.edge.util.az_client"
@@ -26,6 +28,147 @@ def test_wait_for_terminal_state(mocker, done):
     result = wait_for_terminal_state(poller)
     assert result == poller.result.return_value
     assert sleep_patch.call_count == (0 if done else poll_num)
+
+
+def _get_http_response_error(mocker, payload, status_code=200, text=""):
+    response = mocker.Mock()
+    response.status_code = status_code
+    response.reason = "OK"
+    response.headers = {}
+    response.json.return_value = payload
+    response.text.return_value = text
+    return HttpResponseError(response=response)
+
+
+def test_wait_for_terminal_state_formats_failed_lro(mocker):
+    error = _get_http_response_error(
+        mocker,
+        {
+            "status": "Failed",
+            "error": {
+                "code": "ResourceOperationFailure",
+                "message": "The resource operation failed.",
+                "details": [
+                    {"code": "ReconcileFailed", "message": "A child resource could not be removed."},
+                    "Retry the operation.",
+                ],
+            },
+        },
+    )
+    error.response.headers = {"x-ms-request-id": "request-id"}
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError) as exc_info:
+        wait_for_terminal_state(poller)
+
+    assert exc_info.value is error
+    assert error.message == (
+        "Long-running operation failed with status 'Failed'.\n"
+        "Code: ResourceOperationFailure\n"
+        "Message: The resource operation failed.\n"
+        "Details:\n"
+        "  - ReconcileFailed: A child resource could not be removed.\n"
+        "  - Retry the operation.\n"
+        "Request ID: request-id"
+    )
+    assert str(error) == error.message
+
+
+@pytest.mark.parametrize("service_error", [None, {}])
+def test_wait_for_terminal_state_formats_canceled_lro_without_error(mocker, service_error):
+    error = _get_http_response_error(mocker, {"status": "Canceled", "error": service_error})
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError):
+        wait_for_terminal_state(poller)
+
+    assert error.message == (
+        "Long-running operation failed with status 'Canceled'.\n"
+        "The service returned no error details."
+    )
+
+
+def test_wait_for_terminal_state_formats_nonstandard_lro_error(mocker):
+    error = _get_http_response_error(mocker, {"status": "Failed", "error": "Reconciliation failed."})
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError):
+        wait_for_terminal_state(poller)
+
+    assert error.message == (
+        "Long-running operation failed with status 'Failed'.\n"
+        "Error: Reconciliation failed."
+    )
+
+
+@pytest.mark.parametrize(
+    "payload,status_code",
+    [
+        ({"status": "Succeeded"}, 200),
+        ({"status": "Failed"}, 500),
+        (["Failed"], 200),
+    ],
+)
+def test_wait_for_terminal_state_preserves_nonmatching_error(mocker, payload, status_code):
+    error = _get_http_response_error(mocker, payload, status_code=status_code)
+    original_message = error.message
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError):
+        wait_for_terminal_state(poller)
+
+    assert error.message == original_message
+
+
+def test_wait_for_terminal_state_preserves_standard_arm_error(mocker):
+    error = _get_http_response_error(
+        mocker,
+        {"status": "Failed"},
+        text='{"error":{"code":"Conflict","message":"A dependency exists."}}',
+    )
+    original_message = error.message
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError):
+        wait_for_terminal_state(poller)
+
+    assert error.message == original_message
+
+
+def test_wait_for_terminal_state_preserves_unreadable_response(mocker):
+    error = _get_http_response_error(mocker, {"status": "Failed"})
+    error.response.json.side_effect = ValueError("Invalid JSON")
+    original_message = error.message
+    poller = mocker.Mock()
+    poller.done.return_value = True
+    poller.result.side_effect = error
+
+    from azext_edge.edge.util.az_client import wait_for_terminal_state
+
+    with pytest.raises(HttpResponseError):
+        wait_for_terminal_state(poller)
+
+    assert error.message == original_message
 
 
 def test_get_tenant_id(mocker):


### PR DESCRIPTION
Fix useless message: `ERROR: Operation returned an invalid status 'OK'`
- format failed or canceled terminal LRO payloads returned with HTTP 2xx
- preserve the original `HttpResponseError` type and standard ARM 4xx/5xx errors
- include service error code, message, details, and request ID when available

