### PR TITLE
fix(delete): try to stop OPC UA connector reconciliation before instance removal

### DIFF
--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -430,8 +430,8 @@ MIN_INSTANCE_VERSION_V2 = "1.2.36"
 MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE = "1.1.59"
 MIN_INSTANCE_VERSION_FOR_CM_MIGRATE = "1.2.83"
 # Target version at/above which `az iot ops upgrade` backfills the default OPC UA
-# akriConnectorTemplates resource. The requirement landed in 2608 (1.4.72)
-MIN_INSTANCE_VERSION_FOR_OPCUA_CONNECTOR_TEMPLATE = "1.4.72"
+# akriConnectorTemplates resource. Version 1.4.72 has a known issue fixed in 1.4.73.
+MIN_INSTANCE_VERSION_FOR_OPCUA_CONNECTOR_TEMPLATE = "1.4.73"
 
 # Default OPC UA connector template values, mirroring the product Bicep. OPC UA is
 # supervisor-managed: the supervisor adopts the template by name prefix and the connector image

--- a/azext_edge/edge/providers/orchestration/deletion2.py
+++ b/azext_edge/edge/providers/orchestration/deletion2.py
@@ -367,19 +367,26 @@ class DeletionManager:
                 resource_group_name=self.resource_group_name,
                 instance_name=instance_name,
             )
+            discovered_templates = []
             for template in templates:
                 template_name = template.get("name", "")
                 template_id = template.get("id") or (
                     f"{self._instance_resource.resource_id}/akriConnectorTemplates/{template_name}"
                 )
-                self._connector_templates.append(IoTOperationsResource(
+                discovered_templates.append(IoTOperationsResource(
                     resource_id=template_id,
                     display_name=template_name,
                     api_version=DEFAULT_IOTOPS_MGMT_API_VERSION.value,
                 ))
+            self._connector_templates.extend(discovered_templates)
         except HttpResponseError as e:
-            if e.status_code != 404:
-                raise
+            if e.status_code == 404:
+                logger.debug(f"Connector templates not found for instance: {instance_name}")
+            else:
+                logger.warning(
+                    f"Could not discover connector templates for instance '{instance_name}': {e}. "
+                    "Continuing with instance deletion."
+                )
 
     def _collect_spc_from_instance(self) -> None:
         """Extract the default SPC resource ID from instance properties."""
@@ -685,7 +692,17 @@ class DeletionManager:
                 if e.status_code == 404:
                     logger.debug(f"Connector template already deleted: {resource.resource_id}")
                 else:
-                    raise
+                    display.update_step(
+                        _STEP_CONNECTOR_TEMPLATES,
+                        resource.display_name,
+                        StepState.FAILED,
+                        "failed",
+                    )
+                    logger.warning(
+                        f"Could not delete connector template '{resource.display_name}': {e}. "
+                        "Continuing with instance deletion."
+                    )
+                    return
             display.update_step(
                 _STEP_CONNECTOR_TEMPLATES,
                 resource.display_name,

--- a/azext_edge/edge/providers/orchestration/deletion2.py
+++ b/azext_edge/edge/providers/orchestration/deletion2.py
@@ -46,6 +46,7 @@ from .common import (
 from .resource_map import IoTOperationsResource
 from .resources import ConnectedClusters, Instances
 from .resources.clusters import ClusterExtensions
+from .resources.connector_templates import ConnectorTemplates
 from .resources.custom_locations import CustomLocations
 
 logger = get_logger(__name__)
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from azure.core.polling import LROPoller
 
 # Step labels used as WorkflowDisplay categories and render_summary section headers.
+_STEP_CONNECTOR_TEMPLATES = "Connector Templates"
 _STEP_INSTANCE = "Instance"
 _STEP_AIO_EXT = "Ops Extension"
 _STEP_CL_RESOURCES = "CL Resources"
@@ -138,6 +140,7 @@ class DeletionManager:
         # Discovered state — populated during discovery phase.
         self._instance: Optional[dict] = None
         self._instance_resource: Optional[IoTOperationsResource] = None
+        self._connector_templates: List[IoTOperationsResource] = []
         self._cl_id: Optional[str] = None
         self._cl_name: Optional[str] = None
         self._cluster_resource: Optional[dict] = None
@@ -148,6 +151,7 @@ class DeletionManager:
         self._sync_rules: List[IoTOperationsResource] = []
         self._cl_resource: Optional[IoTOperationsResource] = None
         self._cluster_extensions_client: Optional[ClusterExtensions] = None
+        self._connector_templates_client: Optional[ConnectorTemplates] = None
         self._aio_typed_ext_ids: Set[str] = set()
 
     def do_work(self, confirm_yes: Optional[bool] = None, force: Optional[bool] = None) -> None:
@@ -253,7 +257,8 @@ class DeletionManager:
         # SPC from instance properties.
         self._collect_spc_from_instance()
 
-        # Extensions, sync rules, ARG sweep — shared discovery.
+        # Connector templates, extensions, sync rules, ARG sweep — shared discovery.
+        self._discover_connector_templates()
         self._discover_extensions()
         self._discover_sync_rules()
         self._run_arg_sweep()
@@ -311,6 +316,7 @@ class DeletionManager:
         # SPC from instance properties (if instance found).
         if self._instance:
             self._collect_spc_from_instance()
+            self._discover_connector_templates()
 
         # Sync rules and ARG sweep — remaining shared discovery.
         self._discover_sync_rules()
@@ -348,6 +354,32 @@ class DeletionManager:
     # ------------------------------------------------------------------
     # Shared Discovery Helpers
     # ------------------------------------------------------------------
+
+    def _discover_connector_templates(self) -> None:
+        """Discover connector templates so their controllers stop before instance deletion."""
+        if not self._instance_resource:
+            return
+
+        instance_name = self._instance_resource.display_name
+        self._connector_templates_client = ConnectorTemplates(self.cmd)
+        try:
+            templates = self._connector_templates_client.ops.list_by_instance_resource(
+                resource_group_name=self.resource_group_name,
+                instance_name=instance_name,
+            )
+            for template in templates:
+                template_name = template.get("name", "")
+                template_id = template.get("id") or (
+                    f"{self._instance_resource.resource_id}/akriConnectorTemplates/{template_name}"
+                )
+                self._connector_templates.append(IoTOperationsResource(
+                    resource_id=template_id,
+                    display_name=template_name,
+                    api_version=DEFAULT_IOTOPS_MGMT_API_VERSION.value,
+                ))
+        except HttpResponseError as e:
+            if e.status_code != 404:
+                raise
 
     def _collect_spc_from_instance(self) -> None:
         """Extract the default SPC resource ID from instance properties."""
@@ -492,6 +524,7 @@ class DeletionManager:
 
     def _has_work(self) -> bool:
         return any([
+            self._connector_templates,
             self._instance_resource,
             self._aio_extension,
             self._cl_resources,
@@ -514,6 +547,11 @@ class DeletionManager:
     def _display_summary(self) -> None:
         """Render a pre-deletion confirmation summary to stderr."""
         sections: Dict[str, list] = OrderedDict()
+
+        if self._connector_templates:
+            sections[_STEP_CONNECTOR_TEMPLATES] = [
+                (template.display_name, "found") for template in self._connector_templates
+            ]
 
         if self._instance_resource:
             sections[_STEP_INSTANCE] = [(self._instance_resource.display_name, "found")]
@@ -550,6 +588,10 @@ class DeletionManager:
         """Execute deletion in strict step order with WorkflowDisplay progress."""
         categories: Dict[str, List[str]] = OrderedDict()
 
+        if self._connector_templates:
+            categories[_STEP_CONNECTOR_TEMPLATES] = [
+                template.display_name for template in self._connector_templates
+            ]
         if self._instance_resource:
             categories[_STEP_INSTANCE] = [self._instance_resource.display_name]
         if self._cl_resources:
@@ -571,6 +613,11 @@ class DeletionManager:
             no_progress=not self._render_progress,
         ) as display:
             try:
+                # Connector templates first, so their controllers cannot recreate children
+                # while the instance cascade deletion is in progress.
+                for template in self._connector_templates:
+                    self._execute_connector_template_single(display, template)
+
                 # Instance (cascade).
                 if self._instance_resource:
                     self._execute_step_single(
@@ -617,6 +664,34 @@ class DeletionManager:
                     f"Correlation Id for failed deletion: {self.headers['x-ms-correlation-request-id']}"
                 )
                 raise
+
+    def _execute_connector_template_single(
+        self, display: WorkflowDisplay, resource: IoTOperationsResource
+    ) -> None:
+        """Delete a connector template and wait for its controller to stop."""
+        if not self._connector_templates_client or not self._instance_resource:
+            raise RuntimeError("Connector template client is not initialized.")
+
+        with display.step_scope(_STEP_CONNECTOR_TEMPLATES, resource.display_name):
+            try:
+                poller = self._connector_templates_client.ops.begin_delete(
+                    resource_group_name=self.resource_group_name,
+                    instance_name=self._instance_resource.display_name,
+                    akri_connector_template_name=resource.display_name,
+                    headers=self.headers,
+                )
+                wait_for_terminal_state(poller)
+            except HttpResponseError as e:
+                if e.status_code == 404:
+                    logger.debug(f"Connector template already deleted: {resource.resource_id}")
+                else:
+                    raise
+            display.update_step(
+                _STEP_CONNECTOR_TEMPLATES,
+                resource.display_name,
+                StepState.COMPLETE,
+                "removed",
+            )
 
     def _execute_step_single(
         self, display: WorkflowDisplay, category: str, resource: IoTOperationsResource

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -1475,7 +1475,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.4.72"},
+            "VERSIONS": {"iotOperations": "1.4.73"},
             "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",

--- a/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
@@ -124,6 +124,14 @@ def _build_connector_templates_list_endpoint(rg: str, instance_name: str) -> str
     )
 
 
+def _build_connector_template_endpoint(rg: str, instance_name: str, template_name: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.IoTOperations/instances/{instance_name}"
+        f"/akriConnectorTemplates/{template_name}?api-version={IOTOPS_API_VERSION}"
+    )
+
+
 def _build_extension_delete_endpoint(rg: str, cluster_name: str, ext_name: str) -> str:
     return (
         f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
@@ -158,6 +166,7 @@ def _register_instance_discovery(
     spc_id: str = "",
     connectivity: str = "Connected",
     connector_templates: Optional[List[dict]] = None,
+    connector_templates_status: int = 200,
 ) -> None:
     """Register GET mocks for the instance-name discovery path: instance → CL → cluster."""
     rsps.assert_all_requests_are_fired = False
@@ -182,6 +191,7 @@ def _register_instance_discovery(
         rsps,
         templates=connector_templates,
         instance_name=name,
+        status=connector_templates_status,
     )
 
 
@@ -250,13 +260,18 @@ def _register_connector_templates(
     rsps: responses.RequestsMock,
     templates: Optional[List[dict]] = None,
     instance_name: str = "myinst",
+    status: int = 200,
 ) -> None:
     """Register connector template list GET mock."""
     rsps.add(
         method=responses.GET,
         url=_build_connector_templates_list_endpoint(_RG, instance_name),
-        json={"value": templates or []},
-        status=200,
+        json=(
+            {"value": templates or []}
+            if status == 200
+            else {"error": {"code": "TemplateListError", "message": "Template list failed"}}
+        ),
+        status=status,
     )
 
 
@@ -1332,6 +1347,88 @@ class TestDeletionOrder:
         assert sync_idx < cl_idx, "Sync rules must be before CL"
         assert cl_idx < aio_ext_idx, "CL must be before AIO extension"
         assert aio_ext_idx < dep_ext_idx, "AIO extension must be before dep extensions"
+
+    def test_connector_template_list_failure_continues_to_instance(
+        self,
+        mocker,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Template list failure warns and does not block instance deletion."""
+        _register_instance_discovery(mocked_responses, connector_templates_status=403)
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        _register_delete_handler(mocked_responses)
+        mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        assert not manager._connector_templates
+        warning_messages = [str(call.args[0]) for call in mock_logger.warning.call_args_list]
+        assert any("discover connector templates" in message.lower() for message in warning_messages)
+        instance_deletes = [
+            call for call in mocked_responses.calls
+            if call.request.method == "DELETE"
+            and call.request.url == _build_instance_endpoint("myinst", _RG)
+        ]
+        assert len(instance_deletes) == 1
+
+    def test_connector_template_delete_failure_continues_to_instance(
+        self,
+        mocker,
+        mocked_cmd,
+        mocked_responses,
+        mocked_should_continue_prompt,
+    ):
+        """Template DELETE failure warns and does not block instance deletion."""
+        connector_template = _build_connector_template()
+        _register_instance_discovery(
+            mocked_responses,
+            connector_templates=[connector_template],
+        )
+        _register_extensions(mocked_responses)
+        _register_sync_rules(mocked_responses)
+        _register_arg_sweep(mocked_responses)
+        for _ in range(4):
+            mocked_responses.add(
+                method=responses.DELETE,
+                url=_build_connector_template_endpoint(_RG, "myinst", "opcua-template"),
+                status=500,
+                json={
+                    "error": {
+                        "code": "InternalServerError",
+                        "message": "Template delete failed",
+                    }
+                },
+            )
+        _register_delete_handler(mocked_responses)
+        mock_logger = mocker.patch("azext_edge.edge.providers.orchestration.deletion2.logger")
+
+        manager = DeletionManager(
+            cmd=mocked_cmd, instance_name="myinst", resource_group_name=_RG, no_progress=True
+        )
+        manager.do_work(confirm_yes=True)
+
+        template_delete_statuses = [
+            call.response.status_code for call in mocked_responses.calls
+            if call.request.method == "DELETE"
+            and "/akriConnectorTemplates/opcua-template" in call.request.url
+        ]
+        assert template_delete_statuses
+        assert all(status == 500 for status in template_delete_statuses)
+        warning_messages = [str(call.args[0]) for call in mock_logger.warning.call_args_list]
+        assert any("delete connector template" in message.lower() for message in warning_messages)
+        instance_deletes = [
+            call for call in mocked_responses.calls
+            if call.request.method == "DELETE"
+            and call.request.url == _build_instance_endpoint("myinst", _RG)
+        ]
+        assert len(instance_deletes) == 1
 
     def test_cl_delete_failure_continues_to_aio_extension(
         self,

--- a/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_deletion2_unit.py
@@ -116,6 +116,14 @@ def _build_extensions_list_endpoint(rg: str, cluster_name: str) -> str:
     )
 
 
+def _build_connector_templates_list_endpoint(rg: str, instance_name: str) -> str:
+    return (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+        f"/providers/Microsoft.IoTOperations/instances/{instance_name}"
+        f"/akriConnectorTemplates?api-version={IOTOPS_API_VERSION}"
+    )
+
+
 def _build_extension_delete_endpoint(rg: str, cluster_name: str, ext_name: str) -> str:
     return (
         f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
@@ -149,6 +157,7 @@ def _register_instance_discovery(
     version: str = "1.2.0",
     spc_id: str = "",
     connectivity: str = "Connected",
+    connector_templates: Optional[List[dict]] = None,
 ) -> None:
     """Register GET mocks for the instance-name discovery path: instance → CL → cluster."""
     rsps.assert_all_requests_are_fired = False
@@ -168,6 +177,11 @@ def _register_instance_discovery(
         url=_build_cluster_endpoint(_RG, "mycluster"),
         json={"id": _CLUSTER_ID, "properties": {"connectivityStatus": connectivity}},
         status=200,
+    )
+    _register_connector_templates(
+        rsps,
+        templates=connector_templates,
+        instance_name=name,
     )
 
 
@@ -212,13 +226,36 @@ def _register_cl_list(
 
 
 def _register_instances_list(
-    rsps: responses.RequestsMock, instances: Optional[List[dict]] = None,
+    rsps: responses.RequestsMock,
+    instances: Optional[List[dict]] = None,
+    connector_templates: Optional[List[dict]] = None,
 ) -> None:
     """Register instances list GET mock."""
+    instance_list = instances or []
     rsps.add(
         method=responses.GET,
         url=_build_instances_list_endpoint(_RG),
-        json={"value": instances or []},
+        json={"value": instance_list},
+        status=200,
+    )
+    for instance in instance_list:
+        _register_connector_templates(
+            rsps,
+            templates=connector_templates,
+            instance_name=instance["name"],
+        )
+
+
+def _register_connector_templates(
+    rsps: responses.RequestsMock,
+    templates: Optional[List[dict]] = None,
+    instance_name: str = "myinst",
+) -> None:
+    """Register connector template list GET mock."""
+    rsps.add(
+        method=responses.GET,
+        url=_build_connector_templates_list_endpoint(_RG, instance_name),
+        json={"value": templates or []},
         status=200,
     )
 
@@ -249,12 +286,14 @@ def _register_arg_sweep(
 
 
 def _register_delete_handler(rsps: responses.RequestsMock) -> None:
-    """Register a catch-all DELETE handler returning 200 (success).
+    """Register a catch-all DELETE handler returning a valid success response.
 
     Uses add_callback so it persists across multiple DELETE calls.
     For error simulation, register a specific DELETE mock BEFORE this handler.
     """
     def _handle_delete(request):
+        if "/akriConnectorTemplates/" in request.url:
+            return (204, {}, "")
         return (200, {"content-type": "application/json"}, json.dumps({}))
 
     rsps.add_callback(method=responses.DELETE, url=_DELETE_ENDPOINT_RE, callback=_handle_delete)
@@ -375,6 +414,19 @@ def _build_extension(
     }
 
 
+def _build_connector_template(name: str = "opcua-template", rg: str = "rg1", instance: str = "myinst") -> dict:
+    template_id = generate_resource_id(
+        resource_group_name=rg,
+        resource_provider="Microsoft.IoTOperations",
+        resource_path=f"/instances/{instance}/akriConnectorTemplates/{name}",
+    )
+    return {
+        "id": template_id,
+        "name": name,
+        "properties": {"provisioningState": "Succeeded"},
+    }
+
+
 def _build_sync_rule(name: str = "aio-sync", rg: str = "rg1", cl_name: str = "mycl") -> dict:
     rule_id = generate_resource_id(
         resource_group_name=rg,
@@ -416,7 +468,7 @@ class TestDeleteOpsResourcesEntryPoint:
         # Verify instance GET was made.
         instance_gets = [
             c for c in mocked_responses.calls
-            if c.request.method == "GET" and "instances/myinstance" in c.request.url
+            if c.request.method == "GET" and c.request.url == _build_instance_endpoint("myinstance", _RG)
         ]
         assert len(instance_gets) == 1
 
@@ -516,6 +568,7 @@ class TestInstanceNamePath:
         )
         # Extensions, sync rules, and ARG are still attempted after CL resolution failure.
         # Note: _discover_extensions() returns early (cluster_name is None).
+        _register_connector_templates(mocked_responses)
         _register_sync_rules(mocked_responses)
         _register_arg_sweep(mocked_responses)
         _register_delete_handler(mocked_responses)
@@ -1224,8 +1277,13 @@ class TestDeletionOrder:
         mocked_responses,
         mocked_should_continue_prompt,
     ):
-        """Full 6-step ordering: instance → CL resources → sync rules → CL → AIO ext → dep ext."""
-        _register_instance_discovery(mocked_responses, spc_id=_SPC_ID)
+        """Full ordering: templates → instance → CL resources → sync rules → CL → extensions."""
+        connector_template = _build_connector_template()
+        _register_instance_discovery(
+            mocked_responses,
+            spc_id=_SPC_ID,
+            connector_templates=[connector_template],
+        )
 
         # Extensions: AIO + CM dep.
         aio_ext = _build_extension(name="aio-ext", extension_type=EXTENSION_TYPE_OPS, version="1.2.0")
@@ -1253,7 +1311,11 @@ class TestDeletionOrder:
         def find_idx(substring: str) -> int:
             return next(i for i, url in enumerate(delete_urls) if substring in url.lower())
 
-        instance_idx = find_idx("instances/myinst")
+        template_idx = find_idx("akriconnectortemplates/opcua-template")
+        instance_idx = next(
+            i for i, url in enumerate(delete_urls)
+            if "/instances/myinst?" in url.lower()
+        )
         spc_idx = find_idx("azurekeyvaultsecretproviderclasses")
         sync_idx = find_idx("resourcesyncrules")
         cl_idx = next(
@@ -1264,6 +1326,7 @@ class TestDeletionOrder:
         dep_ext_idx = find_idx("/extensions/cm-ext")
 
         # Verify strict step ordering.
+        assert template_idx < instance_idx, "Connector templates must be before the instance"
         assert instance_idx < spc_idx, "Instance must be before CL resources"
         assert spc_idx < sync_idx, "CL resources must be before sync rules"
         assert sync_idx < cl_idx, "Sync rules must be before CL"

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -155,7 +155,7 @@ EXTENSION_CONFIGS = {
         (EXTENSION_TYPE_SSC, "1.5.2", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.4.72", "integration"),
+        (EXTENSION_TYPE_OPS, "1.4.73", "integration"),
     ],
 }
 


### PR DESCRIPTION
Delete connector templates before cascading instance deletion to prevent runtime connector controllers from recreating child resources during teardown.

Template discovery and deletion are best-effort so failures do not block the existing instance cascade deletion and subsequent cleanup.

The backend team confirmed that 1.4.72 has a known issue fixed in 1.4.73. This PR pins IoT Operations and the OPC UA connector-template upgrade gate to 1.4.73; do not use 1.4.72.

https://github.com/Azure/azure-iot-ops-cli-extension/actions/runs/32050729727/job/95449706791