### PR TITLE
build: update IoT Operations to 1.4.73

### DIFF
--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -430,8 +430,8 @@ MIN_INSTANCE_VERSION_V2 = "1.2.36"
 MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE = "1.1.59"
 MIN_INSTANCE_VERSION_FOR_CM_MIGRATE = "1.2.83"
 # Target version at/above which `az iot ops upgrade` backfills the default OPC UA
-# akriConnectorTemplates resource. The requirement landed in 2608 (1.4.72)
-MIN_INSTANCE_VERSION_FOR_OPCUA_CONNECTOR_TEMPLATE = "1.4.72"
+# akriConnectorTemplates resource. Version 1.4.72 has a known issue fixed in 1.4.73.
+MIN_INSTANCE_VERSION_FOR_OPCUA_CONNECTOR_TEMPLATE = "1.4.73"
 
 # Default OPC UA connector template values, mirroring the product Bicep. OPC UA is
 # supervisor-managed: the supervisor adopts the template by name prefix and the connector image

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -430,7 +430,7 @@ MIN_INSTANCE_VERSION_V2 = "1.2.36"
 MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE = "1.1.59"
 MIN_INSTANCE_VERSION_FOR_CM_MIGRATE = "1.2.83"
 # Target version at/above which `az iot ops upgrade` backfills the default OPC UA
-# akriConnectorTemplates resource. Version 1.4.72 has a known issue fixed in 1.4.73.
+# akriConnectorTemplates resource.
 MIN_INSTANCE_VERSION_FOR_OPCUA_CONNECTOR_TEMPLATE = "1.4.73"
 
 # Default OPC UA connector template values, mirroring the product Bicep. OPC UA is

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -1475,7 +1475,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.4.72"},
+            "VERSIONS": {"iotOperations": "1.4.73"},
             "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -155,7 +155,7 @@ EXTENSION_CONFIGS = {
         (EXTENSION_TYPE_SSC, "1.5.2", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.4.72", "integration"),
+        (EXTENSION_TYPE_OPS, "1.4.73", "integration"),
     ],
 }
 


### PR DESCRIPTION
Avoid the known issue in 1.4.72 and align the OPC UA template upgrade gate with the fixed backend release.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
