### PR TITLE
ci: update GitHub Actions for Node.js 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  # Enable weekly version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(actions-deps)"
+
   # Enable daily version updates for pip
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/azdev_linter.yml
+++ b/.github/workflows/azdev_linter.yml
@@ -17,18 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout source (for linter_exclusions)
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # download built wheel (from ./release_build.yml)
       - name: Download Wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: azure-iot-ops-cli-ext
           path: ../drop
 
       # Install python
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/azdev_linter.yml
+++ b/.github/workflows/azdev_linter.yml
@@ -17,18 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout source (for linter_exclusions)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # download built wheel (from ./release_build.yml)
       - name: Download Wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: azure-iot-ops-cli-ext
           path: ../drop
 
       # Install python
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,9 +8,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
             python-version: "3.13"
       - name: Build Wheel
@@ -18,7 +18,7 @@ jobs:
           pip install -r dev_requirements.txt
           python -m build
       - name: Upload Wheel Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: dist/*.whl
           name: azure-iot-ops-cli-ext

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,9 +8,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
             python-version: "3.13"
       - name: Build Wheel
@@ -18,7 +18,7 @@ jobs:
           pip install -r dev_requirements.txt
           python -m build
       - name: Upload Wheel Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: dist/*.whl
           name: azure-iot-ops-cli-ext

--- a/.github/workflows/cluster_cleanup.yml
+++ b/.github/workflows/cluster_cleanup.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Az CLI login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/container_int_test.yml
+++ b/.github/workflows/container_int_test.yml
@@ -55,11 +55,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Setup python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
       - name: "Checkout extension source for build"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: "Build and install local IoT Ops extension from source"
         run: |
           pip install -r dev_requirements.txt

--- a/.github/workflows/container_int_test.yml
+++ b/.github/workflows/container_int_test.yml
@@ -55,11 +55,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Setup python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: "Checkout extension source for build"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Build and install local IoT Ops extension from source"
         run: |
           pip install -r dev_requirements.txt
@@ -71,7 +71,7 @@ jobs:
         with:
           version: ${{ env.K3S_VERSION }}
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -83,7 +83,7 @@ jobs:
           resource-group: ${{ env.RESOURCE_GROUP }}
           custom-locations-oid: ${{ env.CUSTOM_LOCATIONS_OID }}
       - name: "Az CLI login refresh"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -156,7 +156,7 @@ jobs:
             --network host \
             $(docker build . -q)
       - name: "Az CLI login refresh"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ensure_docker_build.yml
+++ b/.github/workflows/ensure_docker_build.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: docker build --no-cache .

--- a/.github/workflows/ensure_docker_build.yml
+++ b/.github/workflows/ensure_docker_build.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - run: docker build --no-cache .

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -129,7 +129,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: "Checkout for config"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github
@@ -147,9 +147,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout Source"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Setup python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: "Setup test suite"
@@ -160,7 +160,7 @@ jobs:
         run: tox r --skip-pkg-install
       - name: "Upload coverage report"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-unit
           path: ./.coverage
@@ -197,11 +197,11 @@ jobs:
           echo "CLUSTER_NAME=${{ env.CLUSTER_NAME }}" >> $GITHUB_OUTPUT
           echo "INSTANCE_NAME=${{ env.INSTANCE_NAME }}" >> $GITHUB_OUTPUT
       - name: "Setup python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: "Checkout extension source for build"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Build and install local IoT Ops extension from source"
         run: |
           pip install -r dev_requirements.txt
@@ -221,7 +221,7 @@ jobs:
             tox r -vv -e "${{ matrix.scenario.tox_env }}" --notest
           fi
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -234,7 +234,7 @@ jobs:
           custom-locations-oid: ${{ env.CUSTOM_LOCATIONS_OID }}
           enable-workload-identity: ${{ matrix.scenario.needs_trust && 'true' || 'false' }}
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -284,7 +284,7 @@ jobs:
           tox r -e report
       - name: "Upload coverage artifacts"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ matrix.scenario.name }}
           path: ./.coverage
@@ -374,9 +374,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Download all coverage artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage-*
           path: ./coverage_parts
@@ -387,7 +387,7 @@ jobs:
           coverage report
           coverage html --directory ./htmlcov --title "AIO CLI Combined Coverage Report"
       - name: "Upload combined coverage artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: combined-coverage
           path: ./htmlcov

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -129,7 +129,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: "Checkout for config"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             .github
@@ -147,9 +147,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout Source"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: "Setup python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: "Setup test suite"
@@ -160,7 +160,7 @@ jobs:
         run: tox r --skip-pkg-install
       - name: "Upload coverage report"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-unit
           path: ./.coverage
@@ -197,11 +197,11 @@ jobs:
           echo "CLUSTER_NAME=${{ env.CLUSTER_NAME }}" >> $GITHUB_OUTPUT
           echo "INSTANCE_NAME=${{ env.INSTANCE_NAME }}" >> $GITHUB_OUTPUT
       - name: "Setup python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: "Checkout extension source for build"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: "Build and install local IoT Ops extension from source"
         run: |
           pip install -r dev_requirements.txt
@@ -284,7 +284,7 @@ jobs:
           tox r -e report
       - name: "Upload coverage artifacts"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.scenario.name }}
           path: ./.coverage
@@ -374,9 +374,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: "Download all coverage artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
           path: ./coverage_parts
@@ -387,7 +387,7 @@ jobs:
           coverage report
           coverage html --directory ./htmlcov --title "AIO CLI Combined Coverage Report"
       - name: "Upload combined coverage artifact"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: combined-coverage
           path: ./htmlcov

--- a/.github/workflows/publish_test_container_image.yml
+++ b/.github/workflows/publish_test_container_image.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: "Az CLI login"
         uses: azure/login@v3
         with:

--- a/.github/workflows/publish_test_container_image.yml
+++ b/.github/workflows/publish_test_container_image.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -10,12 +10,12 @@ jobs:
       id-token: write
     steps:
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -47,12 +47,12 @@ jobs:
           chmod +x $RUNNER_TEMP/sbom-tool
           $RUNNER_TEMP/sbom-tool generate -b ./dist -bc . -pn "Azure IoT Operations CLI Extension" -pv "${{ env.version }}" -ps Microsoft
       - name: Upload Wheel Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ${{ env.wheel }}
           name: azure-iot-ops-cli-ext
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: dist/_manifest/
           name: SBOM

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -10,10 +10,10 @@ jobs:
       id-token: write
     steps:
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: "Az CLI login"
         uses: azure/login@v3
         with:
@@ -47,12 +47,12 @@ jobs:
           chmod +x $RUNNER_TEMP/sbom-tool
           $RUNNER_TEMP/sbom-tool generate -b ./dist -bc . -pn "Azure IoT Operations CLI Extension" -pv "${{ env.version }}" -ps Microsoft
       - name: Upload Wheel Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{ env.wheel }}
           name: azure-iot-ops-cli-ext
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: dist/_manifest/
           name: SBOM

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -26,16 +26,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
       # Install dotnet, used by MSDO
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 6.0.x
 
       # Run analyzers
+    # The v1 tag still targets Node.js 20; pin the current Node.js 24 implementation.
     - name: Run Microsoft Security DevOps Analysis
-      uses: microsoft/security-devops-action@v1
+      uses: microsoft/security-devops-action@241d09d34a00dc03aad8b1e8cf988a6f66ecd3f5
       id: msdo
       env:
         # file path to analyze
@@ -50,7 +51,7 @@ jobs:
 
       # Upload alerts file as a workflow artifact
     - name: Upload alerts artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:  
         name: alerts
         path: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -26,14 +26,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
       # Install dotnet, used by MSDO
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: |
-          5.0.x
-          6.0.x
+        dotnet-version: 6.0.x
 
       # Run analyzers
     - name: Run Microsoft Security DevOps Analysis
@@ -46,13 +44,13 @@ jobs:
 
       # Upload alerts to the Security tab
     - name: Upload alerts to Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}
 
       # Upload alerts file as a workflow artifact
     - name: Upload alerts artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:  
         name: alerts
         path: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/stage_release.yml
+++ b/.github/workflows/stage_release.yml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Download Wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: azure-iot-ops-cli-ext
           path: ./release
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install and determine version
@@ -28,7 +28,7 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
           echo "tag=v$version" >> $GITHUB_ENV
       - name: Download SBOM
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: SBOM
           path: ./release/SBOM

--- a/.github/workflows/stage_release.yml
+++ b/.github/workflows/stage_release.yml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Download Wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: azure-iot-ops-cli-ext
           path: ./release
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install and determine version
@@ -28,7 +28,7 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
           echo "tag=v$version" >> $GITHUB_ENV
       - name: Download SBOM
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: SBOM
           path: ./release/SBOM

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,10 +36,10 @@ jobs:
           - "3.10"
     steps:
       - name: Setup python ${{ matrix.py }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.py }}
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Setup test suite
         run: |
           python -m pip install tox
@@ -49,7 +49,7 @@ jobs:
       - name: Upload coverage report
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.py == '3.13' }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ./htmlcov
           name: code_coverage

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,10 +36,10 @@ jobs:
           - "3.10"
     steps:
       - name: Setup python ${{ matrix.py }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup test suite
         run: |
           python -m pip install tox
@@ -49,7 +49,7 @@ jobs:
       - name: Upload coverage report
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.py == '3.13' }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ./htmlcov
           name: code_coverage

--- a/.github/workflows/update_private_index.yml
+++ b/.github/workflows/update_private_index.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Download wheel
         id: wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: azure-iot-ops-cli-ext
           path: ./
@@ -34,7 +34,7 @@ jobs:
           curl -so azcopy.tar.gz -L 'https://aka.ms/downloadazcopy-v10-linux'
           tar -zxvf azcopy.tar.gz --strip 1
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/update_private_index.yml
+++ b/.github/workflows/update_private_index.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Download wheel
         id: wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: azure-iot-ops-cli-ext
           path: ./

--- a/.github/workflows/upload_wheel.yml
+++ b/.github/workflows/upload_wheel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Download wheel
         id: wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: azure-iot-ops-cli-ext
           path: ./

--- a/.github/workflows/upload_wheel.yml
+++ b/.github/workflows/upload_wheel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Download wheel
         id: wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: azure-iot-ops-cli-ext
           path: ./
@@ -36,7 +36,7 @@ jobs:
           curl -so azcopy.tar.gz -L 'https://aka.ms/downloadazcopy-v10-linux'
           tar -zxvf azcopy.tar.gz --strip 1
       - name: "Az CLI login"
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -171,7 +171,7 @@ First, create a local cluster and store the kubeconfig in an environment variabl
 Next, login to azure and connect your local cluster to ARC using inputs named `resource-group` and `cluster-name` (as well as your custom locations OID and a reference to your kubeconfig environment variable):
 ```yaml
 - name: "Azure login"
-  uses: azure/login@v2
+  uses: azure/login@v3
   with:
     client-id: ${{ secrets.AZURE_CLIENT_ID }}
     tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
- update GitHub-maintained actions to their latest stable Node.js 24-compatible major versions across CI, integration, release, maintenance, CodeQL, and security workflows
- update Azure Login to v3 and pin the current Node.js 24 Microsoft Security DevOps implementation because its `v1` tag still targets Node.js 20
- pin the remaining floating checkout reference, remove the unsupported .NET 5 setup, and update the integration-test documentation
- enable weekly Dependabot updates for GitHub Actions
