### PR TITLE
fix(upgrade): correct Desired State when the CLI is behind the cluster

### DIFF
--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -1215,7 +1215,7 @@ class ExtensionUpgradeState:
                     "Cannot validate upgrade path."
                 )
             if self._has_delta_in_train():
-                self._validate_version_upgrade()
+                self._validate_version_upgrade(target_version=reconcile_version)
             return reconcile_version
 
         return None
@@ -1365,7 +1365,7 @@ class ExtensionUpgradeState:
         """
         return self.provisioning_state.lower() != PROVISIONING_STATE_SUCCESS.lower()
 
-    def _validate_version_upgrade(self):
+    def _validate_version_upgrade(self, target_version: Optional[str] = None):
         # Skip validation for CREATE/DELETE operations
         if self.operation_type in [ExtensionOperation.CREATE, ExtensionOperation.DELETE]:
             return
@@ -1373,12 +1373,14 @@ class ExtensionUpgradeState:
         if self.force:
             return
 
+        target_version = target_version or self.desired_version[0]
+
         # Validate required fields are present
         if not self.current_version[0]:
             raise ValidationError(
                 f"Unable to determine installed version for {self.moniker} extension. Cannot validate upgrade path."
             )
-        if not self.desired_version[0]:
+        if not target_version:
             raise ValidationError(
                 f"Unable to determine target version for {self.moniker} extension. Cannot validate upgrade path."
             )
@@ -1394,7 +1396,7 @@ class ExtensionUpgradeState:
             )
 
         parsed_current = self.semver.parse(self.current_version[0])
-        parsed_desired = self.semver.parse(self.desired_version[0])
+        parsed_desired = self.semver.parse(target_version)
 
         current_is_preview = self.current_version[1].lower() != "stable"
         desired_is_preview = self.desired_version[1].lower() != "stable"
@@ -1403,7 +1405,7 @@ class ExtensionUpgradeState:
         if parsed_desired < parsed_current:
             raise ValidationError(
                 f"Installed {self.moniker} extension version is {self.current_version[0]}.\n"
-                f"The desired {self.desired_version[0]} version is a downgrade which is not supported."
+                f"The desired {target_version} version is a downgrade which is not supported."
             )
 
         if self.moniker != EXTENSION_MONIKER_OPS:
@@ -1413,14 +1415,14 @@ class ExtensionUpgradeState:
         if parsed_desired.major != parsed_current.major:
             raise ValidationError(
                 f"Installed {self.moniker} extension version is {self.current_version[0]}.\n"
-                f"The desired {self.desired_version[0]} version is incompatible (different major version)."
+                f"The desired {target_version} version is incompatible (different major version)."
             )
 
         minor_diff = parsed_desired.minor - parsed_current.minor
         if minor_diff > 2:
             raise ValidationError(
                 f"Installed {self.moniker} extension version is {self.current_version[0]}.\n"
-                f"The desired {self.desired_version[0]} version is incompatible (more than 2 minor versions ahead)."
+                f"The desired {target_version} version is incompatible (more than 2 minor versions ahead)."
             )
 
         min_v2_semver_broker_upgrade = self.semver.parse(MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE)
@@ -1428,7 +1430,7 @@ class ExtensionUpgradeState:
         if parsed_current < min_v2_semver_broker_upgrade and parsed_desired >= min_v2_semver:
             raise ValidationError(
                 f"Installed {self.moniker} extension version is {self.current_version[0]}.\n"
-                f"The desired {self.desired_version[0]} version is incompatible "
+                f"The desired {target_version} version is incompatible "
                 f"(min compatible upgrade version {min_v2_semver_broker_upgrade}).\n"
                 f"Please first upgrade to at least {min_v2_semver_broker_upgrade}/AIO2506. "
                 "See https://aka.ms/aio-versions for version details."

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -90,10 +90,9 @@ def upgrade_ops_instance(
     stale_monikers = upgrade_state.get_stale_cli_extensions()
     if stale_monikers:
         logger.warning(
-            "The version of %s built into this azure-iot-ops CLI extension is older than the "
-            "version deployed on the cluster, so this CLI has no newer version to offer. "
-            "Nothing will be downgraded: a lower version is only applied when explicitly "
-            "requested together with --force. "
+            "This azure-iot-ops CLI extension has no newer version to offer for: %s. "
+            "The version deployed on the cluster is newer than the version built into this CLI. "
+            "No deployed extension version will be changed. "
             "Run 'az extension update --name azure-iot-ops' to pick up newer versions.",
             ", ".join(stale_monikers),
         )
@@ -495,12 +494,12 @@ def format_extension_row(ext: "ExtensionUpgradeState") -> Tuple[str, str, str]:
         patch = ext.get_patch()
         props = patch.get("properties", {})
 
-        desired = "[cyan]{}[/cyan]".format(
-            format_version_with_train(
-                props.get("version", ext.current_version[0]),
-                props.get("releaseTrain", ext.current_version[1]),
-            )
+        desired_state = format_version_with_train(
+            props.get("version", ext.current_version[0]),
+            props.get("releaseTrain", ext.current_version[1]),
         )
+        desired_style = "cyan" if ("version" in props or "releaseTrain" in props) else "dim"
+        desired = f"[{desired_style}]{desired_state}[/{desired_style}]"
 
         if not patch or "properties" not in patch:
             return current, desired, "[dim]No changes[/dim]"
@@ -1214,6 +1213,8 @@ class ExtensionUpgradeState:
                     f"Unable to determine installed version for {self.moniker} extension. "
                     "Cannot validate upgrade path."
                 )
+            # A failed extension can report a version with no release train; guarding on the delta
+            # avoids rejecting it for a missing train the patch never sends.
             if self._has_delta_in_train():
                 self._validate_version_upgrade(target_version=reconcile_version)
             return reconcile_version

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -87,6 +87,17 @@ def upgrade_ops_instance(
 
     upgrade_state = upgrade_manager.analyze_cluster(**kwargs)
 
+    stale_monikers = upgrade_state.get_stale_cli_extensions()
+    if stale_monikers:
+        logger.warning(
+            "The version of %s built into this azure-iot-ops CLI extension is older than the "
+            "version deployed on the cluster, so this CLI has no newer version to offer. "
+            "Nothing will be downgraded: a lower version is only applied when explicitly "
+            "requested together with --force. "
+            "Run 'az extension update --name azure-iot-ops' to pick up newer versions.",
+            ", ".join(stale_monikers),
+        )
+
     if not upgrade_state.has_upgrades():
         logger.warning("Nothing to upgrade :)")
         return
@@ -480,17 +491,27 @@ def format_extension_row(ext: "ExtensionUpgradeState") -> Tuple[str, str, str]:
 
         # UPDATE operation
         current = format_version_with_train(ext.current_version[0], ext.current_version[1]) + status_indicator
-        desired = f"[cyan]{format_version_with_train(ext.desired_version[0], ext.desired_version[1])}[/cyan]"
 
         patch = ext.get_patch()
+        props = patch.get("properties", {})
+
+        desired = "[cyan]{}[/cyan]".format(
+            format_version_with_train(
+                props.get("version", ext.current_version[0]),
+                props.get("releaseTrain", ext.current_version[1]),
+            )
+        )
+
         if not patch or "properties" not in patch:
             return current, desired, "[dim]No changes[/dim]"
 
-        props = patch.get("properties", {})
         action_lines = []
 
         if "version" in props:
-            action_lines.append(f"[cyan]•[/cyan] Update version to [bold]{props['version']}[/bold]")
+            if props["version"] == ext.current_version[0]:
+                action_lines.append(f"[cyan]•[/cyan] Reconcile at version [bold]{props['version']}[/bold]")
+            else:
+                action_lines.append(f"[cyan]•[/cyan] Update version to [bold]{props['version']}[/bold]")
 
         if "releaseTrain" in props:
             action_lines.append(f"[cyan]•[/cyan] Change release train to [bold]{props['releaseTrain']}[/bold]")
@@ -780,6 +801,9 @@ class ClusterUpgradeState:
             or bool(self.connector_template_needed)
             or bool(self.secretsync_migration_needed)
         )
+
+    def get_stale_cli_extensions(self) -> List[str]:
+        return [ext_state.moniker for ext_state in self.extension_upgrades if ext_state.is_cli_behind_cluster()]
 
     def _check_instance_upgrade(self) -> bool:
         """Check if instance needs updates.
@@ -1089,6 +1113,23 @@ class ExtensionUpgradeState:
             return "N/A"
         return self.extension.get("properties", {}).get("provisioningState", "Unknown")
 
+    def is_cli_behind_cluster(self) -> bool:
+        if self.operation_type != ExtensionOperation.UPDATE:
+            return False
+
+        # An explicit --ops-version, not the built-in default, decides what gets sent.
+        if self.override.version:
+            return False
+
+        built_in_version = self.desired_version_map.get("version")
+        if not built_in_version or not self.current_version[0]:
+            return False
+
+        try:
+            return self.semver.parse(built_in_version) < self.semver.parse(self.current_version[0])
+        except ValueError:
+            return False
+
     def can_upgrade(self) -> bool:
         if self.operation_type in [ExtensionOperation.CREATE, ExtensionOperation.DELETE]:
             return True
@@ -1118,9 +1159,10 @@ class ExtensionUpgradeState:
             "properties": {},
         }
 
-        if self._has_delta_in_version() or self._has_non_success_state():
-            self._validate_version_upgrade()
-            payload["properties"]["version"] = self.desired_version[0]
+        target_version = self._validate_and_resolve_version()
+        if target_version:
+            payload["properties"]["version"] = target_version
+
         if self._has_delta_in_train():
             payload["properties"]["releaseTrain"] = self.desired_version[1]
         if self._has_delta_in_config():
@@ -1155,10 +1197,33 @@ class ExtensionUpgradeState:
         Raises:
             ValidationError: If the upgrade is not valid (e.g., downgrade, incompatible versions).
         """
-        # Always validate if there's an override version (user explicitly requested upgrade)
-        # or if there's a version delta or non-success state
-        if self._has_delta_in_version() or self._has_non_success_state():
+        if self.operation_type != ExtensionOperation.UPDATE:
+            return
+
+        self._validate_and_resolve_version()
+
+    def _validate_and_resolve_version(self) -> Optional[str]:
+        if self._has_delta_in_version():
             self._validate_version_upgrade()
+            return self.desired_version[0]
+
+        if self._has_non_success_state():
+            reconcile_version = self._get_reconcile_version()
+            if not reconcile_version:
+                raise ValidationError(
+                    f"Unable to determine installed version for {self.moniker} extension. "
+                    "Cannot validate upgrade path."
+                )
+            if self._has_delta_in_train():
+                self._validate_version_upgrade()
+            return reconcile_version
+
+        return None
+
+    def _get_reconcile_version(self) -> Optional[str]:
+        if self.current_version[0]:
+            return self.current_version[0]
+        return self.desired_version[0] if self.force else None
 
     def _should_migrate_mqtt_config(self) -> bool:
         if not self.extension:

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -92,7 +92,7 @@ def upgrade_ops_instance(
         logger.warning(
             "This azure-iot-ops CLI extension has no newer version to offer for: %s. "
             "The version deployed on the cluster is newer than the version built into this CLI. "
-            "No deployed extension version will be changed. "
+            "No deployed version of the listed extensions will be changed. "
             "Run 'az extension update --name azure-iot-ops' to pick up newer versions.",
             ", ".join(stale_monikers),
         )
@@ -1213,8 +1213,9 @@ class ExtensionUpgradeState:
                     f"Unable to determine installed version for {self.moniker} extension. "
                     "Cannot validate upgrade path."
                 )
-            # A failed extension can report a version with no release train; guarding on the delta
-            # avoids rejecting it for a missing train the patch never sends.
+            # A failed extension can have a version but no releaseTrain. Calling _validate_version_upgrade()
+            # unconditionally then raises "Unable to determine release train" even though the patch only
+            # reapplies the current version and sends no train.
             if self._has_delta_in_train():
                 self._validate_version_upgrade(target_version=reconcile_version)
             return reconcile_version

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -1127,7 +1127,7 @@ class ExtensionUpgradeState:
 
         try:
             return self.semver.parse(built_in_version) < self.semver.parse(self.current_version[0])
-        except ValueError:
+        except (ValueError, TypeError):
             return False
 
     def can_upgrade(self) -> bool:

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -947,7 +947,7 @@ def assert_upgrade_headers(headers: Dict[str, str]):
 
 def assert_no_upgrades_performed(upgrade_result, logger_mock):
     assert upgrade_result is None
-    logger_mock.warning.assert_called_once_with(DEFAULT_LOG_WARNING_MESSAGE)
+    logger_mock.warning.assert_called_with(DEFAULT_LOG_WARNING_MESSAGE)
 
 
 def assert_retry_count(mock_response, expected_count: int = DEFAULT_RETRY_COUNT):
@@ -1284,6 +1284,12 @@ def assert_operation_order(target_scenario: UpgradeScenario, upgrade_result: Lis
         (
             UpgradeScenario("Failed state: Re-apply current version").with_failed_extension(EXTENSION_TYPE_OPS),
             {EXTENSION_TYPE_OPS: build_extension_props(EXTENSION_TYPE_OPS, version=BUILT_IN_VALUE)},
+        ),
+        (
+            UpgradeScenario("Failed state: Re-apply current version with a stale CLI").set_extension(
+                ext_type=EXTENSION_TYPE_OPS, ext_vers="9.9.9", provisioning_state=PROVISIONING_STATE_FAILED
+            ),
+            {EXTENSION_TYPE_OPS: build_extension_props(EXTENSION_TYPE_OPS, version="9.9.9")},
         ),
         (
             UpgradeScenario("Failed state: With version upgrade")
@@ -2800,3 +2806,344 @@ def test_opcua_connector_version_matches_template_tag():
         f"tag stamped by the instance template ({template_tag}); update the constant during the "
         "release bump so create and upgrade stamp the same tag."
     )
+
+
+def build_ext_upgrade_state(
+    ext_type: str = EXTENSION_TYPE_CM,
+    current_version: Optional[str] = "1.4.73",
+    current_train: Optional[str] = "stable",
+    built_in_version: Optional[str] = "1.3.105",
+    built_in_train: Optional[str] = "stable",
+    provisioning_state: str = PROVISIONING_STATE_SUCCESS,
+    version_override: Optional[str] = None,
+    train_override: Optional[str] = None,
+    desired_config: Optional[Dict[str, str]] = None,
+    force: bool = False,
+    operation_type=None,
+):
+    """Build an ExtensionUpgradeState directly, bypassing cluster discovery."""
+    from azext_edge.edge.providers.orchestration.upgrade2 import ConfigOverride, ExtensionUpgradeState
+
+    props: Dict[str, str] = {"extensionType": ext_type, "provisioningState": provisioning_state}
+    if current_version:
+        props["version"] = current_version
+    if current_train:
+        props["releaseTrain"] = current_train
+
+    return ExtensionUpgradeState(
+        extension={"name": generate_random_string(), "properties": props},
+        desired_version_map={"version": built_in_version, "train": built_in_train},
+        desired_config=desired_config,
+        override=ConfigOverride(version=version_override, train=train_override),
+        force=force,
+        operation_type=operation_type,
+    )
+
+
+def test_desired_state_ignores_built_in_target_when_no_version_is_sent():
+    """Only configuration is sent, so Desired State must report the version that stays deployed."""
+    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
+
+    ext = build_ext_upgrade_state(desired_config={"a": "b"})
+    current, desired, action = format_extension_row(ext)
+
+    assert "version" not in ext.get_patch()["properties"]
+    assert "1.4.73" in current
+    assert "1.4.73" in desired
+    assert "1.3.105" not in desired
+    assert "Set a: [bold]b[/bold]" in action
+
+
+def test_desired_state_version_only_patch_keeps_current_train():
+    """A user supplied version suppresses the train delta, so the train must not come from the map."""
+    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
+
+    ext = build_ext_upgrade_state(built_in_version="1.5.0", built_in_train="preview", version_override="1.6.0")
+    _, desired, _ = format_extension_row(ext)
+
+    assert "releaseTrain" not in ext.get_patch()["properties"]
+    assert "1.6.0" in desired
+    assert "stable" in desired
+    assert "preview" not in desired
+
+
+def test_desired_state_train_only_patch_keeps_current_version():
+    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
+
+    ext = build_ext_upgrade_state(built_in_version="1.3.105", train_override="preview")
+    _, desired, action = format_extension_row(ext)
+
+    assert "version" not in ext.get_patch()["properties"]
+    assert "1.4.73" in desired
+    assert "1.3.105" not in desired
+    assert "preview" in desired
+    assert "Update version to" not in action
+
+
+@pytest.mark.parametrize(
+    "built_in_version,provisioning_state,expected_action,rejected_action",
+    [
+        pytest.param(
+            "1.3.105",
+            PROVISIONING_STATE_FAILED,
+            "Reconcile at version [bold]1.4.73[/bold]",
+            "Update version to",
+            id="same-version retry reads as reconcile",
+        ),
+        pytest.param(
+            "1.5.0",
+            PROVISIONING_STATE_SUCCESS,
+            "Update version to [bold]1.5.0[/bold]",
+            "Reconcile at version",
+            id="real upgrade still reads as update",
+        ),
+    ],
+)
+def test_action_distinguishes_reconcile_from_update(
+    built_in_version, provisioning_state, expected_action, rejected_action
+):
+    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
+
+    ext = build_ext_upgrade_state(built_in_version=built_in_version, provisioning_state=provisioning_state)
+    _, desired, action = format_extension_row(ext)
+
+    assert expected_action in action
+    assert rejected_action not in action
+    assert "1.3.105" not in desired
+
+
+def test_failed_non_ops_extension_no_longer_renders_unknown():
+    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
+
+    ext = build_ext_upgrade_state(ext_type=EXTENSION_TYPE_CM, provisioning_state=PROVISIONING_STATE_FAILED)
+
+    assert ext.can_upgrade() is True
+    current, desired, action = format_extension_row(ext)
+
+    assert "Unknown" not in current + desired + action
+    assert "Check configuration" not in action
+    assert ext.get_patch()["properties"]["version"] == "1.4.73"
+
+
+@pytest.mark.parametrize(
+    "built_in_version,provisioning_state,force,expected_version",
+    [
+        pytest.param("1.5.0", PROVISIONING_STATE_SUCCESS, False, "1.5.0", id="real upgrade"),
+        pytest.param("1.5.0", PROVISIONING_STATE_FAILED, False, "1.5.0", id="real upgrade over a failed state"),
+        pytest.param(
+            "1.3.105",
+            PROVISIONING_STATE_FAILED,
+            False,
+            "1.4.73",
+            id="stale CLI repairs a failed extension",
+        ),
+        pytest.param("1.4.73", PROVISIONING_STATE_FAILED, False, "1.4.73", id="same-version retry"),
+        pytest.param("1.3.105", PROVISIONING_STATE_FAILED, True, "1.4.73", id="force alone never downgrades"),
+        pytest.param("1.3.105", PROVISIONING_STATE_SUCCESS, True, None, id="force alone sends nothing"),
+    ],
+)
+def test_get_patch_version_selection(built_in_version, provisioning_state, force, expected_version):
+    ext = build_ext_upgrade_state(built_in_version=built_in_version, provisioning_state=provisioning_state, force=force)
+
+    ext.validate_upgrade()
+    assert ext.get_patch().get("properties", {}).get("version") == expected_version
+
+
+def test_failed_extension_without_installed_version_is_rejected():
+    ext = build_ext_upgrade_state(current_version=None, provisioning_state=PROVISIONING_STATE_FAILED)
+
+    with pytest.raises(ValidationError, match="Unable to determine installed version"):
+        ext.validate_upgrade()
+    with pytest.raises(ValidationError, match="Unable to determine installed version"):
+        ext.get_patch()
+
+
+def test_failed_extension_without_installed_version_is_bypassed_by_force():
+    ext = build_ext_upgrade_state(current_version=None, provisioning_state=PROVISIONING_STATE_FAILED, force=True)
+
+    ext.validate_upgrade()
+    assert ext.get_patch()["properties"]["version"] == "1.3.105"
+
+
+def test_failed_extension_never_emits_a_null_version():
+    """Extensions absent from the built-in map must raise rather than patch "version": None."""
+    ext = build_ext_upgrade_state(
+        current_version=None,
+        built_in_version=None,
+        provisioning_state=PROVISIONING_STATE_FAILED,
+        force=True,
+    )
+
+    with pytest.raises(ValidationError, match="Unable to determine installed version"):
+        ext.validate_upgrade()
+    with pytest.raises(ValidationError, match="Unable to determine installed version"):
+        ext.get_patch()
+
+
+@pytest.mark.parametrize("op_type_name", ["CREATE", "DELETE"])
+def test_validate_upgrade_skips_non_update_operations(op_type_name):
+    from azext_edge.edge.providers.orchestration.upgrade2 import ExtensionOperation
+
+    ext = build_ext_upgrade_state(
+        current_version=None,
+        provisioning_state=PROVISIONING_STATE_FAILED,
+        operation_type=getattr(ExtensionOperation, op_type_name),
+    )
+
+    ext.validate_upgrade()
+    assert not ext.get_patch()
+
+
+@pytest.mark.parametrize(
+    "built_in_train,train_override",
+    [
+        pytest.param("preview", None, id="train delta from built-in target"),
+        pytest.param("stable", "preview", id="train delta from --ops-train override"),
+    ],
+)
+def test_reconcile_cannot_bypass_release_train_guard(built_in_train, train_override):
+    """Both routes are covered: an --ops-train override short circuits before the version compare."""
+    ext = build_ext_upgrade_state(
+        ext_type=EXTENSION_TYPE_OPS,
+        built_in_version="1.4.73",
+        built_in_train=built_in_train,
+        train_override=train_override,
+        provisioning_state=PROVISIONING_STATE_FAILED,
+    )
+
+    with pytest.raises(ValidationError, match="non-stable release trains are not supported"):
+        ext.validate_upgrade()
+    with pytest.raises(ValidationError, match="non-stable release trains are not supported"):
+        ext.get_patch()
+
+
+@pytest.mark.parametrize("provisioning_state", [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED])
+def test_explicit_downgrade_still_blocked(provisioning_state):
+    ext = build_ext_upgrade_state(version_override="1.0.0", provisioning_state=provisioning_state)
+
+    with pytest.raises(ValidationError, match="downgrade which is not supported"):
+        ext.validate_upgrade()
+    with pytest.raises(ValidationError, match="downgrade which is not supported"):
+        ext.get_patch()
+
+
+@pytest.mark.parametrize("provisioning_state", [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED])
+def test_explicit_downgrade_allowed_with_force(provisioning_state):
+    ext = build_ext_upgrade_state(version_override="1.0.0", provisioning_state=provisioning_state, force=True)
+
+    ext.validate_upgrade()
+    assert ext.get_patch()["properties"]["version"] == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    "built_in_version,current_version,version_override,operation_type_name,expected",
+    [
+        ("1.3.105", "1.4.73", None, None, True),
+        ("1.5.0", "1.4.73", None, None, False),
+        ("1.4.73", "1.4.73", None, None, False),
+        # An explicit version override decides what is sent, so a stale built-in must not warn.
+        ("1.4.73", "1.4.73", "1.0.0", None, False),
+        ("1.4.73", "1.4.90", "1.5.0", None, False),
+        ("1.3.105", "1.4.73", "1.4.73", None, False),
+        (None, "1.4.73", None, None, False),
+        ("1.3.105", None, None, None, False),
+        ("1.3.105", "not-a-version", None, None, False),
+        ("1.3.105", "1.4.73", None, "DELETE", False),
+        ("1.3.105", "1.4.73", None, "CREATE", False),
+    ],
+)
+def test_is_cli_behind_cluster(built_in_version, current_version, version_override, operation_type_name, expected):
+    from azext_edge.edge.providers.orchestration.upgrade2 import ExtensionOperation
+
+    ext = build_ext_upgrade_state(
+        built_in_version=built_in_version,
+        current_version=current_version,
+        version_override=version_override,
+        operation_type=getattr(ExtensionOperation, operation_type_name) if operation_type_name else None,
+    )
+    assert ext.is_cli_behind_cluster() is expected
+
+
+def test_stale_cli_warning_precedes_no_op_return(
+    mocked_cmd: Mock,
+    mocked_responses: responses,
+    mocked_logger: Mock,
+    mocked_sleep: Mock,
+    spy_upgrade_displays: Dict[str, Mock],
+    mocked_confirm: Mock,
+    mocked_upgrade_manager: Mock,
+):
+    from azext_edge.edge.commands_edge import upgrade_instance
+
+    resource_group_name = generate_random_string()
+    instance_name = generate_random_string()
+
+    target_scenario = UpgradeScenario("Stale CLI: deployed version ahead of built-in target").set_extension(
+        ext_type=EXTENSION_TYPE_CM, ext_vers="9.9.9"
+    )
+    target_scenario.set_instance_mock(
+        mocked_responses=mocked_responses, instance_name=instance_name, resource_group_name=resource_group_name
+    )
+
+    assert (
+        upgrade_instance(
+            cmd=mocked_cmd,
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            no_progress=True,
+            confirm_yes=True,
+        )
+        is None
+    )
+
+    warning_calls = mocked_logger.warning.call_args_list
+    assert len(warning_calls) == 2
+    advisory = warning_calls[0].args[0]
+    assert "older than the version deployed on the cluster" in advisory
+    assert "--force" in advisory
+    assert "Unless a version is explicitly requested" not in advisory
+    assert warning_calls[0].args[1] == EXTENSION_TYPE_TO_MONIKER_MAP[EXTENSION_TYPE_CM]
+    assert warning_calls[1].args[0] == DEFAULT_LOG_WARNING_MESSAGE
+
+
+@pytest.mark.parametrize("ext_type", [EXTENSION_TYPE_OPS, EXTENSION_TYPE_CM])
+def test_validate_upgrade_and_get_patch_cannot_diverge(ext_type):
+    """validate_upgrade is the early gate for get_patch, so the two must agree on every input."""
+    from itertools import product
+
+    versions = [None, "1.0.0", "1.3.105", "1.4.73", "1.5.0"]
+    trains = [None, "stable", "preview"]
+
+    def outcome(call) -> Optional[str]:
+        try:
+            call()
+            return None
+        except ValidationError as e:
+            return str(e)
+
+    compared = 0
+    for current_version, current_train, built_in_version, built_in_train, version_override, force, state in product(
+        versions,
+        trains,
+        versions,
+        trains,
+        [None, "1.4.73"],
+        [False, True],
+        [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED],
+    ):
+        kwargs = {
+            "ext_type": ext_type,
+            "current_version": current_version,
+            "current_train": current_train,
+            "built_in_version": built_in_version,
+            "built_in_train": built_in_train,
+            "version_override": version_override,
+            "force": force,
+            "provisioning_state": state,
+        }
+        from_validate = outcome(build_ext_upgrade_state(**kwargs).validate_upgrade)
+        from_patch = outcome(build_ext_upgrade_state(**kwargs).get_patch)
+        assert from_validate == from_patch, f"validate_upgrade and get_patch disagree for {kwargs}"
+        compared += 1
+
+    assert compared == 1800

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -2851,6 +2851,8 @@ def test_desired_state_ignores_built_in_target_when_no_version_is_sent():
     assert "1.4.73" in current
     assert "1.4.73" in desired
     assert "1.3.105" not in desired
+    assert "[dim]" in desired
+    assert "cyan" not in desired
     assert "Set a: [bold]b[/bold]" in action
 
 
@@ -3113,9 +3115,9 @@ def test_stale_cli_warning_precedes_no_op_return(
     warning_calls = mocked_logger.warning.call_args_list
     assert len(warning_calls) == 2
     advisory = warning_calls[0].args[0]
-    assert "older than the version deployed on the cluster" in advisory
-    assert "--force" in advisory
-    assert "Unless a version is explicitly requested" not in advisory
+    assert "newer than the version built into this CLI" in advisory
+    assert "No deployed extension version will be changed" in advisory
+    assert "--force" not in advisory
     assert warning_calls[0].args[1] == EXTENSION_TYPE_TO_MONIKER_MAP[EXTENSION_TYPE_CM]
     assert warning_calls[1].args[0] == DEFAULT_LOG_WARNING_MESSAGE
 
@@ -3135,8 +3137,8 @@ def test_stale_cli_warning_precedes_no_op_return(
         ),
     ],
 )
-def test_validate_upgrade_and_get_patch_cannot_diverge(ext_type, kwargs):
-    """validate_upgrade is the early gate for get_patch, so the two must agree."""
+def test_validate_upgrade_and_get_patch_have_same_validation_outcome(ext_type, kwargs):
+    """Both entry points resolve the target through the same helper, so their validation must agree."""
 
     def outcome(call) -> Optional[str]:
         try:

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -3017,6 +3017,21 @@ def test_reconcile_cannot_bypass_release_train_guard(built_in_train, train_overr
         ext.get_patch()
 
 
+def test_reconcile_train_delta_validates_the_version_the_patch_sends():
+    # A train override re-runs the guard, it must compare the reconcile version, not the stale built-in.
+    ext = build_ext_upgrade_state(
+        ext_type=EXTENSION_TYPE_OPS,
+        current_version="1.4.73",
+        built_in_version="1.3.105",
+        train_override="stable",
+        provisioning_state=PROVISIONING_STATE_FAILED,
+    )
+
+    ext.validate_upgrade()
+
+    assert ext.get_patch()["properties"]["version"] == "1.4.73"
+
+
 @pytest.mark.parametrize("provisioning_state", [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED])
 def test_explicit_downgrade_still_blocked(provisioning_state):
     ext = build_ext_upgrade_state(version_override="1.0.0", provisioning_state=provisioning_state)

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -3116,7 +3116,7 @@ def test_stale_cli_warning_precedes_no_op_return(
     assert len(warning_calls) == 2
     advisory = warning_calls[0].args[0]
     assert "newer than the version built into this CLI" in advisory
-    assert "No deployed extension version will be changed" in advisory
+    assert "No deployed version of the listed extensions will be changed" in advisory
     assert "--force" not in advisory
     assert warning_calls[0].args[1] == EXTENSION_TYPE_TO_MONIKER_MAP[EXTENSION_TYPE_CM]
     assert warning_calls[1].args[0] == DEFAULT_LOG_WARNING_MESSAGE

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -2867,19 +2867,6 @@ def test_desired_state_version_only_patch_keeps_current_train():
     assert "preview" not in desired
 
 
-def test_desired_state_train_only_patch_keeps_current_version():
-    from azext_edge.edge.providers.orchestration.upgrade2 import format_extension_row
-
-    ext = build_ext_upgrade_state(built_in_version="1.3.105", train_override="preview")
-    _, desired, action = format_extension_row(ext)
-
-    assert "version" not in ext.get_patch()["properties"]
-    assert "1.4.73" in desired
-    assert "1.3.105" not in desired
-    assert "preview" in desired
-    assert "Update version to" not in action
-
-
 @pytest.mark.parametrize(
     "built_in_version,provisioning_state,expected_action,rejected_action",
     [
@@ -2947,15 +2934,6 @@ def test_get_patch_version_selection(built_in_version, provisioning_state, force
 
     ext.validate_upgrade()
     assert ext.get_patch().get("properties", {}).get("version") == expected_version
-
-
-def test_failed_extension_without_installed_version_is_rejected():
-    ext = build_ext_upgrade_state(current_version=None, provisioning_state=PROVISIONING_STATE_FAILED)
-
-    with pytest.raises(ValidationError, match="Unable to determine installed version"):
-        ext.validate_upgrade()
-    with pytest.raises(ValidationError, match="Unable to determine installed version"):
-        ext.get_patch()
 
 
 def test_failed_extension_without_installed_version_is_bypassed_by_force():
@@ -3032,6 +3010,21 @@ def test_reconcile_train_delta_validates_the_version_the_patch_sends():
     assert ext.get_patch()["properties"]["version"] == "1.4.73"
 
 
+def test_reconcile_repairs_a_failed_extension_on_a_preview_train():
+    ext = build_ext_upgrade_state(
+        ext_type=EXTENSION_TYPE_OPS,
+        current_version="1.4.73",
+        current_train="preview",
+        built_in_version="1.3.105",
+        built_in_train="preview",
+        provisioning_state=PROVISIONING_STATE_FAILED,
+    )
+
+    ext.validate_upgrade()
+
+    assert ext.get_patch()["properties"]["version"] == "1.4.73"
+
+
 @pytest.mark.parametrize("provisioning_state", [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED])
 def test_explicit_downgrade_still_blocked(provisioning_state):
     ext = build_ext_upgrade_state(version_override="1.0.0", provisioning_state=provisioning_state)
@@ -3079,6 +3072,12 @@ def test_is_cli_behind_cluster(built_in_version, current_version, version_overri
     assert ext.is_cli_behind_cluster() is expected
 
 
+@pytest.mark.parametrize("bad_version", [1.4, 14073, ["1.4.73"]])
+def test_stale_cli_check_is_best_effort_on_a_malformed_version(bad_version):
+    ext = build_ext_upgrade_state(current_version=bad_version)
+    assert ext.is_cli_behind_cluster() is False
+
+
 def test_stale_cli_warning_precedes_no_op_return(
     mocked_cmd: Mock,
     mocked_responses: responses,
@@ -3122,12 +3121,22 @@ def test_stale_cli_warning_precedes_no_op_return(
 
 
 @pytest.mark.parametrize("ext_type", [EXTENSION_TYPE_OPS, EXTENSION_TYPE_CM])
-def test_validate_upgrade_and_get_patch_cannot_diverge(ext_type):
-    """validate_upgrade is the early gate for get_patch, so the two must agree on every input."""
-    from itertools import product
-
-    versions = [None, "1.0.0", "1.3.105", "1.4.73", "1.5.0"]
-    trains = [None, "stable", "preview"]
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"version_override": "1.0.0"}, id="downgrade"),
+        pytest.param({"built_in_version": "1.5.0"}, id="upgrade"),
+        pytest.param({"provisioning_state": PROVISIONING_STATE_FAILED}, id="reconcile"),
+        pytest.param(
+            {"provisioning_state": PROVISIONING_STATE_FAILED, "built_in_train": "preview"}, id="train-guard"
+        ),
+        pytest.param(
+            {"provisioning_state": PROVISIONING_STATE_FAILED, "current_version": None}, id="no-installed-version"
+        ),
+    ],
+)
+def test_validate_upgrade_and_get_patch_cannot_diverge(ext_type, kwargs):
+    """validate_upgrade is the early gate for get_patch, so the two must agree."""
 
     def outcome(call) -> Optional[str]:
         try:
@@ -3136,29 +3145,6 @@ def test_validate_upgrade_and_get_patch_cannot_diverge(ext_type):
         except ValidationError as e:
             return str(e)
 
-    compared = 0
-    for current_version, current_train, built_in_version, built_in_train, version_override, force, state in product(
-        versions,
-        trains,
-        versions,
-        trains,
-        [None, "1.4.73"],
-        [False, True],
-        [PROVISIONING_STATE_SUCCESS, PROVISIONING_STATE_FAILED],
-    ):
-        kwargs = {
-            "ext_type": ext_type,
-            "current_version": current_version,
-            "current_train": current_train,
-            "built_in_version": built_in_version,
-            "built_in_train": built_in_train,
-            "version_override": version_override,
-            "force": force,
-            "provisioning_state": state,
-        }
-        from_validate = outcome(build_ext_upgrade_state(**kwargs).validate_upgrade)
-        from_patch = outcome(build_ext_upgrade_state(**kwargs).get_patch)
-        assert from_validate == from_patch, f"validate_upgrade and get_patch disagree for {kwargs}"
-        compared += 1
-
-    assert compared == 1800
+    assert outcome(build_ext_upgrade_state(ext_type=ext_type, **kwargs).validate_upgrade) == outcome(
+        build_ext_upgrade_state(ext_type=ext_type, **kwargs).get_patch
+    )


### PR DESCRIPTION
## Problem

When the installed `azure-iot-ops` extension is older than the AIO build deployed on the cluster, the upgrade table rendered a Desired State lower than Current State:

│ iotOperations │ 1.3.137 [stable] │ 1.3.105 [stable] │ • ... │

The customer read this as an imminent downgrade and stopped.

No downgrade was attempted. Absent a version override, `_has_delta_in_version()` requires `desired > current`, so it is false on a stale CLI and the patch carries `configurationSettings` only. The table was describing the CLI's built-in constant instead of the values the patch actually sends.

## Changes

**1. Desired State is a per-field overlay of the patch.** A version-only patch no longer blanks the train, and a train-only patch no longer misreports the version. A same-version retry now reads `Reconcile at version X` instead of `Update version to X`. When the patch sends neither `version` nor `releaseTrain`, the Desired cell is dim rather than cyan, so the change signal is reserved for a version that is actually moving.

**2. A stale CLI is called out**, before the `has_upgrades()` early return so it is still visible on a no-op run. The warning states the outcome — no deployed extension version will be changed — and points at `az extension update`. It does not name `--force` or the version overrides: those are hidden, and each CLI release pins and tests AIO alongside its dependencies as a set.

**3. A failed extension is repaired at its installed version.** `validate_upgrade()` and `get_patch()` shared one condition (`_has_delta_in_version() or _has_non_success_state()`) and unconditionally resolved the built-in target, so on a stale CLI the repair aborted with a downgrade error naming a version the patch would never have sent. The branches are now separated at both sites, and an extension with no resolvable version raises instead of emitting `"version": null`.

The reconcile branch is only reachable when `_has_delta_in_version()` is false — no override *and* `desired <= current` — so it can only ever send a version **≥** what the old code sent. The change cannot skip or downgrade a legitimate upgrade. The explicit downgrade guard and `--force` are unchanged.

This clears the **stale CLI cause** of the `Unknown / Unknown / Check configuration` row for `certManager` / `secretStore`, which came from the same raise. It does not clear that row in general: `validate_upgrade()` runs only for the ops extension, so the other extensions first reach this logic when `format_extension_row()` calls `get_patch()` inside a broad handler, and a failed extension reporting no installed version still renders `Unknown / Unknown`. That path is pre-existing and unchanged here, as is the apply loop's exception handling.

**4. The train guard validates the version the patch sends.** Found by the automated review on this PR. In the reconcile branch an `--ops-train` override re-runs `_validate_version_upgrade()`, which compared the stale built-in version rather than the reconcile version being sent — so `--ops-train stable` on a failed extension with a cluster ahead of the CLI raised the same spurious downgrade error this PR exists to remove. `_validate_version_upgrade()` now takes an optional `target_version`; the reconcile call site passes the resolved version and every other call site is unchanged by the default. The release-train checks are retained, so `--ops-train preview` on a stable cluster is still blocked — now reporting the real reason instead of a downgrade that was never proposed.

## Implementation notes

- **`is_cli_behind_cluster()` respects `--ops-version`.** Without it, `--ops-version 1.5.0` printed *"this CLI has no newer version to offer"* directly above `Update version to 1.5.0`. An explicit version always takes the version-delta path, so it can never reach the reconcile case the warning describes.

- **One shared helper rather than a guard duplicated at both sites.** `validate_upgrade()` and `get_patch()` previously shared a single condition that resolved the built-in target at both, which is where the bug came from. Both now call `_validate_and_resolve_version()`, and `test_validate_upgrade_and_get_patch_have_same_validation_outcome` pins that they cannot disagree.

- **The train guard in the reconcile branch is conditional.** A failed extension can report a version with no release train; validating unconditionally would reject it on a missing train even though the patch only reapplies the installed version and sends no train.

## Validation

Live A/B on a cluster (AIO `1.4.73`) with two extension trees differing in exactly one file:

| scenario | before | after |
|---|---|---|
| stale CLI, config-only upgrade | `1.4.73 -> 1.3.105` (defect) | `1.4.73 -> 1.4.73` + advisory |
| **applied** run, then ARM read-back | - | `version=1.4.73`, `Succeeded`, config written - **no downgrade** |
| genuinely `Failed` extension | hard-fails; repair impossible | `Reconcile at version x.x.x` |
| explicit downgrade / `--force` / repeat run | - | unchanged |
