### PR TITLE
feat(live-data): add az iot ops live-data command group

### DIFF
--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -2526,9 +2526,10 @@ def load_iotops_help():
         type: command
         short-summary: Disable Live Data for an IoT Operations instance.
         long-summary: |
-            Removes this instance's observability endpoint entry from the Device Registry
-            namespace first (the per-instance disable signal), then tears down the dedicated
-            dataflow profile, the EG dataflow endpoint, and the observability topic space.
+            Tears down the dedicated dataflow profile, the EG dataflow endpoint, and the
+            observability topic space, then removes this instance's observability endpoint
+            entry from the Device Registry namespace last so an interrupted disable can be
+            safely re-run.
 
             Namespace-scoped role assignments are preserved; topic-space-scoped role
             assignments are removed together with the topic space.

--- a/azext_edge/edge/_help.py
+++ b/azext_edge/edge/_help.py
@@ -2473,6 +2473,93 @@ def load_iotops_help():
     """
 
     helps[
+        "iot ops live-data"
+    ] = """
+        type: group
+        short-summary: Live Data infrastructure configuration for an IoT Operations instance.
+    """
+
+    helps[
+        "iot ops live-data enable"
+    ] = """
+        type: command
+        short-summary: Enable Live Data for an IoT Operations instance.
+        long-summary: |
+            Provisions and configures the shared, instance-level infrastructure required for
+            Live Data across three domains:
+            - Event Grid Namespace: an observability topic space.
+            - IoT Operations Instance: a dedicated dataflow profile and an EG MQTT dataflow endpoint.
+            - Device Registry Namespace: the outbound identity and the per-instance observability
+              endpoint entry (keyed by the instance's custom location).
+
+            The command is idempotent. Re-running converges to the desired state without
+            overwriting unrelated entries. Enablement for an instance is expressed by the presence
+            of its observability endpoint entry.
+
+            By default, role assignments (Event Grid TopicSpaces Publisher for the instance identity
+            and Subscriber for the ADR namespace identity) are created at the Event Grid namespace
+            scope. Use --ra-scope topic-space for least-privilege assignments scoped to the topic
+            space, or --skip-ra to skip role assignment creation.
+
+        examples:
+        - name: Enable Live Data using a system-assigned managed identity and default roles.
+          text: >
+            az iot ops live-data enable --instance myinstance -g myresourcegroup
+            --eg-resource-id $EG_NAMESPACE_RESOURCE_ID
+        - name: Enable Live Data using a user-assigned managed identity for outbound auth.
+          text: >
+            az iot ops live-data enable --instance myinstance -g myresourcegroup
+            --eg-resource-id $EG_NAMESPACE_RESOURCE_ID --mi-user-assigned $UA_MI_RESOURCE_ID
+        - name: Enable Live Data with least-privilege, topic-space-scoped role assignments.
+          text: >
+            az iot ops live-data enable --instance myinstance -g myresourcegroup
+            --eg-resource-id $EG_NAMESPACE_RESOURCE_ID --ra-scope topic-space
+        - name: Enable Live Data and skip role assignments.
+          text: >
+            az iot ops live-data enable --instance myinstance -g myresourcegroup
+            --eg-resource-id $EG_NAMESPACE_RESOURCE_ID --skip-ra
+    """
+
+    helps[
+        "iot ops live-data disable"
+    ] = """
+        type: command
+        short-summary: Disable Live Data for an IoT Operations instance.
+        long-summary: |
+            Removes this instance's observability endpoint entry from the Device Registry
+            namespace first (the per-instance disable signal), then tears down the dedicated
+            dataflow profile, the EG dataflow endpoint, and the observability topic space.
+
+            Namespace-scoped role assignments are preserved; topic-space-scoped role
+            assignments are removed together with the topic space.
+
+        examples:
+        - name: Disable Live Data for an instance.
+          text: >
+            az iot ops live-data disable --instance myinstance -g myresourcegroup
+        - name: Disable Live Data without a confirmation prompt.
+          text: >
+            az iot ops live-data disable --instance myinstance -g myresourcegroup --yes
+    """
+
+    helps[
+        "iot ops live-data show"
+    ] = """
+        type: command
+        short-summary: Show Live Data configuration for an IoT Operations instance.
+        long-summary: |
+            Reports the Live Data configuration and resource status across the Device Registry
+            namespace, Event Grid, and IoT Operations dataflow resources. The top-level enabled
+            flag is true only when this instance's observability endpoint entry and all supporting
+            resources are present.
+
+        examples:
+        - name: Show Live Data configuration for an instance.
+          text: >
+            az iot ops live-data show --instance myinstance -g myresourcegroup
+    """
+
+    helps[
         "iot ops schema"
     ] = """
         type: group

--- a/azext_edge/edge/command_map.py
+++ b/azext_edge/edge/command_map.py
@@ -17,6 +17,7 @@ registry_endpoint_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge
 edge_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_edge#{}")
 secretsync_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_secretsync#{}")
 mgmt_actions_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_mgmt_actions#{}")
+live_data_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_live_data#{}")
 asset_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_assets#{}")
 aep_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_asset_endpoint_profiles#{}")
 namespace_resource_ops = CliCommandType(operations_tmpl="azext_edge.edge.commands_namespaces#{}")
@@ -76,6 +77,15 @@ def load_iotops_commands(self, _):
         cmd_group.command("disable", "mgmt_actions_disable")
         cmd_group.show_command("show", "mgmt_actions_show")
         cmd_group.command("execute", "mgmt_actions_execute")
+
+    with self.command_group(
+        "iot ops live-data",
+        command_type=live_data_resource_ops,
+        is_preview=True,
+    ) as cmd_group:
+        cmd_group.command("enable", "live_data_enable")
+        cmd_group.command("disable", "live_data_disable")
+        cmd_group.show_command("show", "live_data_show")
 
     with self.command_group(
         "iot ops support",

--- a/azext_edge/edge/commands_live_data.py
+++ b/azext_edge/edge/commands_live_data.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import Dict, List, Optional
+
+from .providers.orchestration.live_data import LiveData
+
+
+def live_data_enable(
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    eg_resource_id: str,
+    mi_user_assigned: Optional[str] = None,
+    ra_scope: Optional[str] = None,
+    adr_role_ids: Optional[List[str]] = None,
+    ops_role_ids: Optional[List[str]] = None,
+    skip_role_assignments: Optional[bool] = None,
+    no_progress: Optional[bool] = None,
+    **kwargs,
+) -> Dict:
+    return LiveData(cmd).enable(
+        name=instance_name,
+        resource_group_name=resource_group_name,
+        eg_resource_id=eg_resource_id,
+        mi_user_assigned=mi_user_assigned,
+        ra_scope=ra_scope,
+        adr_role_ids=adr_role_ids,
+        ops_role_ids=ops_role_ids,
+        skip_role_assignments=skip_role_assignments,
+        no_progress=no_progress,
+        **kwargs,
+    )
+
+
+def live_data_show(
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    no_progress: Optional[bool] = None,
+    **kwargs,
+) -> Dict:
+    return LiveData(cmd).show(
+        name=instance_name,
+        resource_group_name=resource_group_name,
+        no_progress=no_progress,
+        **kwargs,
+    )
+
+
+def live_data_disable(
+    cmd,
+    instance_name: str,
+    resource_group_name: str,
+    confirm_yes: Optional[bool] = None,
+    no_progress: Optional[bool] = None,
+    **kwargs,
+) -> None:
+    return LiveData(cmd).disable(
+        name=instance_name,
+        resource_group_name=resource_group_name,
+        confirm_yes=confirm_yes,
+        no_progress=no_progress,
+        **kwargs,
+    )

--- a/azext_edge/edge/params.py
+++ b/azext_edge/edge/params.py
@@ -40,6 +40,7 @@ from .providers.orchestration.common import (
     KafkaCompressionType,
     KafkaPartitionStrategyType,
     ListenerProtocol,
+    LiveDataRoleScope,
     MqMemoryProfile,
     MqServiceType,
     MqttRetainType,
@@ -1709,6 +1710,51 @@ def load_iotops_arguments(self, _):
             options_list=["--show-schema"],
             help="Resolve and display the action's request schema. No action is executed.",
             action="store_true",
+        )
+
+    with self.argument_context("iot ops live-data") as context:
+        context.argument(
+            "instance_name",
+            options_list=["--instance", "-i", "-n"],
+            help="IoT Operations instance name.",
+        )
+
+    with self.argument_context("iot ops live-data enable") as context:
+        context.argument(
+            "eg_resource_id",
+            options_list=["--eg-resource-id"],
+            help="Event Grid Namespace ARM resource Id.",
+        )
+        context.argument(
+            "mi_user_assigned",
+            options_list=["--mi-user-assigned"],
+            help="User-assigned managed identity resource Id for the EG dataflow endpoint and ADR "
+            "namespace outbound identity. Default: system-assigned managed identity.",
+        )
+        context.argument(
+            "ra_scope",
+            options_list=["--ra-scope"],
+            arg_type=get_enum_type(LiveDataRoleScope),
+            help="Scope for Event Grid role assignments. 'namespace' (default) assigns at the EG "
+            "namespace and is preserved on disable; 'topic-space' assigns at the topic-space "
+            "resource (least privilege) and is removed with the topic space on disable.",
+            arg_group="Role Assignment",
+        )
+        context.argument(
+            "adr_role_ids",
+            options_list=["--adr-role-ids"],
+            nargs="+",
+            help="Custom role Ids for the ADR namespace identity (Subscriber) against the EG namespace. "
+            "Default: 'Event Grid TopicSpaces Subscriber'.",
+            arg_group="Role Assignment",
+        )
+        context.argument(
+            "ops_role_ids",
+            options_list=["--ops-role-ids"],
+            nargs="+",
+            help="Custom role Ids for the AIO instance identity (Publisher) against the EG namespace. "
+            "Default: 'Event Grid TopicSpaces Publisher'.",
+            arg_group="Role Assignment",
         )
 
     with self.argument_context("iot ops schema") as context:

--- a/azext_edge/edge/providers/adr/namespaces.py
+++ b/azext_edge/edge/providers/adr/namespaces.py
@@ -53,8 +53,9 @@ class Namespaces(Queryable):
             "location": location,
             "identity": {"type": "SystemAssigned"},
             "properties": {},
-            "tags": tags,
         }
+        if tags:
+            namespace_body["tags"] = tags
         with console.status(f"Creating {namespace_name}..."):
             poller = self.ops.begin_create_or_replace(
                 resource_group_name,

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -461,3 +461,16 @@ MGMT_ACTIONS_ADR_ENDPOINT_TYPE = "Microsoft.EventGrid/Namespaces"
 MGMT_ACTIONS_GRAPH_ARTIFACT = "azureiotoperations/graph-dataflow-map:1.0.0"
 MGMT_ACTIONS_GRAPH_RULES_VERSION = "1.0.0"
 MIN_EG_CLIENT_SESSIONS_PER_AUTH_NAME = 4
+
+# Live Data
+LIVE_DATA_ADR_API_VERSION = "2026-11-02-preview"
+LIVE_DATA_PROFILE_NAME = "live-data-profile"
+LIVE_DATA_ENDPOINT_NAME = "live-data-endpoint"
+LIVE_DATA_TOPICSPACE_PREFIX = "live-data-ts"
+LIVE_DATA_TOPIC_TEMPLATE = "aio/observabilitySessions/{scope_id}/#"
+LIVE_DATA_ADR_ENDPOINT_TYPE = "Microsoft.EventGrid/namespaces"
+
+
+class LiveDataRoleScope(Enum):
+    NAMESPACE = "namespace"
+    TOPIC_SPACE = "topic-space"

--- a/azext_edge/edge/providers/orchestration/eg_provider_base.py
+++ b/azext_edge/edge/providers/orchestration/eg_provider_base.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License file in the project root for license information.
 # ----------------------------------------------------------------------------------------------
 
-from typing import Callable, Dict, NamedTuple, Optional
+from typing import Any, Callable, Dict, NamedTuple, Optional
 
 from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
 from azure.core.exceptions import ResourceNotFoundError
@@ -58,6 +58,10 @@ class EventGridProviderBase(Queryable):
     are responsible for constructing the ``eventgrid_mgmt_client``, ``iotops_mgmt_client``,
     ``resource_client``, and ``permission_manager`` attributes these helpers rely on.
     """
+
+    # Constructed by subclasses in __init__; declared here so shared helpers can reference them.
+    iotops_mgmt_client: Any
+    permission_manager: Any
 
     def _validate_eg_namespace(
         self,

--- a/azext_edge/edge/providers/orchestration/eg_provider_base.py
+++ b/azext_edge/edge/providers/orchestration/eg_provider_base.py
@@ -1,0 +1,398 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import Callable, Dict, NamedTuple, Optional
+
+from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
+from azure.core.exceptions import ResourceNotFoundError
+from knack.log import get_logger
+
+from ...util.az_client import get_eventgrid_mgmt_client, wait_for_terminal_state
+from ...util.cloud_config import CloudConfig
+from ...util.id_tools import parse_resource_id as parse_resource_id_dict
+from ...util.queryable import Queryable
+from .common import (
+    CUSTOM_LOCATIONS_API_VERSION,
+    EXTENSION_TYPE_OPS,
+    MANAGED_IDENTITY_API_VERSION,
+    MQTT_ENDPOINT_TYPE,
+)
+from .connected_cluster import ConnectedCluster
+from .permissions import PermissionManager
+
+logger = get_logger(__name__)
+
+
+class EgNamespaceContext(NamedTuple):
+    """Validated Event Grid namespace context, produced by _validate_eg_namespace().
+
+    Set once during validation, then shared read-only across all subsequent setup
+    methods. Immutable NamedTuple ensures thread safety if concurrency is added later.
+    """
+
+    resource_id: str
+    subscription_id: str
+    resource_group_name: str
+    namespace_name: str
+    mqtt_hostname: str
+
+
+def graceful_delete(begin_delete_fn: Callable, resource_desc: str, **kwargs) -> None:
+    """Execute a begin_delete LRO, catching ResourceNotFoundError for idempotent teardown."""
+    try:
+        poller = begin_delete_fn()
+        wait_for_terminal_state(poller, **kwargs)
+        logger.info("Deleted %s.", resource_desc)
+    except ResourceNotFoundError:
+        logger.info("%s already deleted — skipping.", resource_desc.capitalize())
+
+
+class EventGridProviderBase(Queryable):
+    """Shared base for providers that integrate an AIO instance with an Event Grid MQTT broker.
+
+    Concentrates the Event Grid namespace validation, MQTT dataflow endpoint setup, and
+    identity resolution reused by the management-actions and live-data providers. Subclasses
+    are responsible for constructing the ``eventgrid_mgmt_client``, ``iotops_mgmt_client``,
+    ``resource_client``, and ``permission_manager`` attributes these helpers rely on.
+    """
+
+    def _validate_eg_namespace(
+        self,
+        eg_resource_id: str,
+        min_client_sessions: Optional[int] = None,
+    ) -> EgNamespaceContext:
+        """Parse, fetch, and validate an Event Grid namespace for MQTT integration.
+
+        Validates that the resource ID is a well-formed Microsoft.EventGrid/namespaces ID,
+        the namespace exists, and MQTT broker (topic spaces) is enabled. When the namespace
+        resides in a different subscription, a cross-subscription EG client is created and
+        stored as self.eventgrid_mgmt_client for use by subsequent EG setup methods. When
+        ``min_client_sessions`` is provided, the namespace must allow at least that many
+        concurrent client sessions per authentication name.
+        """
+        parsed = parse_resource_id_dict(eg_resource_id)
+
+        eg_namespace = parsed.get("namespace", "")
+        eg_type = parsed.get("type", "")
+        if eg_namespace.lower() != "microsoft.eventgrid" or eg_type.lower() != "namespaces":
+            raise InvalidArgumentValueError(
+                f"--eg-resource-id must reference a Microsoft.EventGrid/namespaces resource.\n"
+                f"Got: {eg_namespace}/{eg_type}\n"
+                f"Expected format: /subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}"
+                f"/providers/Microsoft.EventGrid/namespaces/{{namespaceName}}"
+            )
+
+        eg_subscription_id = parsed.get("subscription", "")
+        eg_resource_group = parsed.get("resource_group", "")
+        eg_name = parsed.get("name", "")
+
+        if not all([eg_subscription_id, eg_resource_group, eg_name]):
+            raise InvalidArgumentValueError(
+                f"Malformed resource Id '{eg_resource_id}'. Could not extract subscription, "
+                f"resource group, or namespace name."
+            )
+
+        if eg_subscription_id.lower() != self.default_subscription_id.lower():
+            logger.info(
+                "Event Grid namespace is in subscription '%s' (instance subscription: '%s'). "
+                "Creating cross-subscription client.",
+                eg_subscription_id,
+                self.default_subscription_id,
+            )
+            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
+                **self._get_client_kwargs(subscription_id=eg_subscription_id)
+            )
+
+        try:
+            namespace_resource = self.eventgrid_mgmt_client.namespaces.get(
+                resource_group_name=eg_resource_group,
+                namespace_name=eg_name,
+            )
+        except ResourceNotFoundError:
+            raise InvalidArgumentValueError(
+                f"Event Grid namespace '{eg_name}' not found in resource group '{eg_resource_group}' "
+                f"(subscription: {eg_subscription_id}).\n"
+                f"Verify the --eg-resource-id value and ensure the namespace exists."
+            )
+
+        topic_spaces_config = namespace_resource.get("properties", {}).get("topicSpacesConfiguration", {})
+        topic_spaces_state = topic_spaces_config.get("state", "")
+        if topic_spaces_state != "Enabled":
+            state_detail = (
+                f"Current state: '{topic_spaces_state}'."
+                if topic_spaces_state
+                else "MQTT broker has not been configured."
+            )
+            raise ValidationError(
+                f"Event Grid namespace '{eg_name}' does not have MQTT broker (topic spaces) enabled.\n"
+                f"{state_detail} "
+                f"Enable topic spaces on the namespace before enabling this feature."
+            )
+
+        mqtt_hostname = topic_spaces_config.get("hostname", "")
+        if not mqtt_hostname:
+            raise ValidationError(
+                f"Event Grid namespace '{eg_name}' has topic spaces enabled but no MQTT hostname. "
+                f"This may indicate the namespace is still provisioning."
+            )
+
+        if min_client_sessions is not None:
+            max_client_sessions = topic_spaces_config.get("maximumClientSessionsPerAuthenticationName", 0)
+            if max_client_sessions < min_client_sessions:
+                raise ValidationError(
+                    f"Event Grid namespace '{eg_name}' has maximumClientSessionsPerAuthenticationName "
+                    f"set to {max_client_sessions}. This feature requires at least "
+                    f"{min_client_sessions} concurrent client sessions per authentication name "
+                    f"to support reliable dataflow connectivity."
+                )
+
+        return EgNamespaceContext(
+            resource_id=eg_resource_id,
+            subscription_id=eg_subscription_id,
+            resource_group_name=eg_resource_group,
+            namespace_name=eg_name,
+            mqtt_hostname=mqtt_hostname,
+        )
+
+    def _discover_eg_context(self, endpoint_entry: Optional[Dict]) -> Optional[EgNamespaceContext]:
+        """Extract EG namespace context from an ADR endpoint entry.
+
+        Parses the resourceId from the endpoint, validates required fields, and creates a
+        cross-subscription EG client when the namespace is in a different subscription.
+        Returns None if the endpoint is missing or has incomplete EG reference data.
+        """
+        if not endpoint_entry:
+            return None
+
+        eg_resource_id = endpoint_entry.get("resourceId", "")
+        if not eg_resource_id:
+            return None
+
+        parsed_eg = parse_resource_id_dict(eg_resource_id)
+        eg_namespace_name = parsed_eg.get("name", "")
+        eg_resource_group = parsed_eg.get("resource_group", "")
+        eg_subscription_id = parsed_eg.get("subscription", "")
+        mqtt_hostname = endpoint_entry.get("address", "")
+
+        if not (eg_namespace_name and eg_resource_group and eg_subscription_id):
+            return None
+
+        eg_ctx = EgNamespaceContext(
+            resource_id=eg_resource_id,
+            subscription_id=eg_subscription_id,
+            resource_group_name=eg_resource_group,
+            namespace_name=eg_namespace_name,
+            mqtt_hostname=mqtt_hostname,
+        )
+
+        if eg_subscription_id.lower() != self.default_subscription_id.lower():
+            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
+                **self._get_client_kwargs(subscription_id=eg_subscription_id)
+            )
+
+        return eg_ctx
+
+    def _build_eg_endpoint_auth(self, mi_resource: Optional[Dict] = None) -> Dict:
+        """Build the authentication block for the EG MQTT dataflow endpoint."""
+        eg_audience = CloudConfig(self.cmd).eventgrid_audience
+        if mi_resource:
+            return {
+                "method": "UserAssignedManagedIdentity",
+                "userAssignedManagedIdentitySettings": {
+                    "clientId": mi_resource["properties"]["clientId"],
+                    "tenantId": mi_resource["properties"]["tenantId"],
+                    "scope": f"{eg_audience}/.default",
+                },
+            }
+        return {
+            "method": "SystemAssignedManagedIdentity",
+            "systemAssignedManagedIdentitySettings": {
+                "audience": eg_audience,
+            },
+        }
+
+    def _setup_eg_dataflow_endpoint(
+        self,
+        eg_ctx: EgNamespaceContext,
+        instance_name: str,
+        resource_group_name: str,
+        extended_location: Dict,
+        endpoint_name: str,
+        mi_resource: Optional[Dict] = None,
+        **kwargs,
+    ) -> Dict:
+        """Create or update the EG MQTT dataflow endpoint on the AIO instance.
+
+        Uses GET-then-PUT to report accurate status. The endpoint connects to the EG
+        namespace's MQTT broker using managed identity authentication. Defaults to
+        SystemAssigned MI; when mi_resource is provided, a UserAssigned MI is configured
+        instead. When the endpoint already exists, compares host, authentication, and
+        clientIdPrefix against the desired state and updates via PUT if any differ.
+        """
+        desired_authentication = self._build_eg_endpoint_auth(mi_resource)
+
+        try:
+            existing = self.iotops_mgmt_client.dataflow_endpoint.get(
+                resource_group_name=resource_group_name,
+                instance_name=instance_name,
+                dataflow_endpoint_name=endpoint_name,
+            )
+            existing_mqtt = existing.get("properties", {}).get("mqttSettings", {})
+            existing_host = existing_mqtt.get("host", "")
+            existing_auth = existing_mqtt.get("authentication", {})
+            existing_client_id_prefix = existing_mqtt.get("clientIdPrefix", "")
+
+            host_matches = existing_host == eg_ctx.mqtt_hostname
+            auth_matches = existing_auth == desired_authentication
+            client_id_prefix_matches = existing_client_id_prefix == instance_name
+            if host_matches and auth_matches and client_id_prefix_matches:
+                logger.info(
+                    "Dataflow endpoint '%s' already exists on instance '%s' with matching configuration.",
+                    endpoint_name,
+                    instance_name,
+                )
+                return {"name": endpoint_name, "authentication": existing_auth, "exists": True}
+
+            logger.info(
+                "Dataflow endpoint '%s' exists but configuration differs "
+                "(host_match=%s, auth_match=%s, client_id_prefix_match=%s). Updating.",
+                endpoint_name,
+                host_matches,
+                auth_matches,
+                client_id_prefix_matches,
+            )
+        except ResourceNotFoundError:
+            existing = None
+
+        resource = {
+            "extendedLocation": extended_location,
+            "properties": {
+                "endpointType": MQTT_ENDPOINT_TYPE,
+                "mqttSettings": {
+                    "host": eg_ctx.mqtt_hostname,
+                    "clientIdPrefix": instance_name,
+                    "authentication": desired_authentication,
+                    "tls": {
+                        "mode": "Enabled",
+                    },
+                },
+            },
+        }
+
+        poller = self.iotops_mgmt_client.dataflow_endpoint.begin_create_or_update(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_endpoint_name=endpoint_name,
+            resource=resource,
+        )
+        wait_for_terminal_state(poller, **kwargs)
+
+        if existing:
+            logger.info("Updated dataflow endpoint '%s' on instance '%s'.", endpoint_name, instance_name)
+            return {
+                "name": endpoint_name,
+                "authentication": desired_authentication,
+                "exists": True,
+                "updated": True,
+            }
+
+        logger.info("Created dataflow endpoint '%s' on instance '%s'.", endpoint_name, instance_name)
+        return {"name": endpoint_name, "authentication": desired_authentication, "exists": False}
+
+    def _resolve_user_assigned_mi(self, mi_resource_id: str) -> Dict:
+        """Fetch a user-assigned managed identity resource to extract clientId and tenantId.
+
+        Uses the base Queryable resource_client for same-subscription lookups. When the
+        UAMI is in a different subscription, creates a cross-subscription client.
+        """
+        parsed = parse_resource_id_dict(mi_resource_id)
+        mi_subscription = parsed.get("subscription", self.default_subscription_id)
+
+        if mi_subscription.lower() != self.default_subscription_id.lower():
+            from ...util.az_client import get_resource_client
+
+            client = get_resource_client(**self._get_client_kwargs(subscription_id=mi_subscription))
+        else:
+            client = self.resource_client
+
+        try:
+            return client.resources.get_by_id(
+                resource_id=mi_resource_id,
+                api_version=MANAGED_IDENTITY_API_VERSION,
+            )
+        except ResourceNotFoundError:
+            raise InvalidArgumentValueError(
+                f"User-assigned managed identity '{mi_resource_id}' not found.\n"
+                f"Verify the --mi-user-assigned value and ensure the identity exists."
+            )
+
+    def _resolve_ops_extension_identity(self, instance: Dict, mi_resource: Optional[Dict] = None) -> str:
+        """Resolve the principal ID of the identity used for Event Grid role assignments.
+
+        When a UAMI is provided, its principalId is used directly. Otherwise, resolves the
+        AIO extension's system MI by traversing: instance → custom location → connected
+        cluster → extensions.
+        """
+        if mi_resource:
+            principal_id = mi_resource.get("properties", {}).get("principalId")
+            if not principal_id:
+                raise ValidationError(
+                    "User-assigned managed identity is missing 'principalId'.\n"
+                    "Verify the identity resource has been fully provisioned."
+                )
+            return principal_id
+
+        cl_id = instance.get("extendedLocation", {}).get("name")
+        if not cl_id:
+            raise ValidationError(
+                "Instance is missing 'extendedLocation.name' (custom location ID).\n"
+                "The instance may not be fully provisioned."
+            )
+
+        custom_location = self.resource_client.resources.get_by_id(
+            resource_id=cl_id,
+            api_version=CUSTOM_LOCATIONS_API_VERSION,
+        )
+
+        host_resource_id = custom_location.get("properties", {}).get("hostResourceId")
+        if not host_resource_id:
+            raise ValidationError(
+                f"Custom location '{cl_id}' is missing 'hostResourceId'.\n"
+                "Unable to resolve the connected cluster for extension identity."
+            )
+
+        cluster_parts = parse_resource_id_dict(host_resource_id)
+        connected_cluster = ConnectedCluster(
+            cmd=self.cmd,
+            subscription_id=cluster_parts.get("subscription", self.default_subscription_id),
+            cluster_name=cluster_parts["name"],
+            resource_group_name=cluster_parts["resource_group"],
+        )
+
+        ext_map = connected_cluster.get_extensions_by_type(EXTENSION_TYPE_OPS)
+        ops_ext = ext_map.get(EXTENSION_TYPE_OPS)
+        if not ops_ext:
+            raise ValidationError(
+                "IoT Operations extension not found on the connected cluster.\n"
+                "Cannot resolve the extension identity for EG role assignments.\n"
+                "Ensure 'az iot ops create' has been run successfully."
+            )
+
+        principal_id = ops_ext.get("identity", {}).get("principalId")
+        if not principal_id:
+            raise ValidationError(
+                "IoT Operations extension is missing 'identity.principalId'.\n"
+                "Cannot assign EG roles without the extension identity.\n"
+                "Please re-deploy via 'az iot ops create'."
+            )
+
+        return principal_id
+
+    def _permission_manager(self, eg_ctx: EgNamespaceContext) -> PermissionManager:
+        """Return a PermissionManager scoped to the EG namespace's subscription."""
+        if eg_ctx.subscription_id.lower() != self.default_subscription_id.lower():
+            return PermissionManager(subscription_id=eg_ctx.subscription_id)
+        return self.permission_manager

--- a/azext_edge/edge/providers/orchestration/live_data.py
+++ b/azext_edge/edge/providers/orchestration/live_data.py
@@ -63,13 +63,18 @@ def _build_adr_observability_put_payload(adr_namespace: Dict, custom_location_id
     outboundIdentity, management, and messaging from the original namespace.
     """
     properties = adr_namespace.get("properties", {})
-    existing_endpoints = properties.get("observability", {}).get("endpoints", {})
+    observability = properties.get("observability", {})
+    existing_endpoints = observability.get("endpoints", {})
     updated_endpoints = {k: v for k, v in existing_endpoints.items() if k != custom_location_id}
+
+    # Preserve any sibling keys under observability since this is a full PUT.
+    updated_observability = dict(observability)
+    updated_observability["endpoints"] = updated_endpoints
 
     payload: Dict = {
         "location": adr_namespace.get("location", ""),
         "properties": {
-            "observability": {"endpoints": updated_endpoints},
+            "observability": updated_observability,
         },
     }
     if adr_namespace.get("identity"):
@@ -856,6 +861,8 @@ class LiveData(EventGridProviderBase):
         current_endpoint = existing_endpoints.get(custom_location_id)
         endpoint_already_configured = current_endpoint == desired_endpoint
 
+        outbound_identity_already_configured = properties.get("outboundIdentity") == outbound_identity
+
         current_identity = adr_namespace.get("identity", {})
         current_identity_type = (current_identity.get("type") or "").lower()
         sami_already_enabled = current_identity_type == "systemassigned"
@@ -867,7 +874,7 @@ class LiveData(EventGridProviderBase):
         if needs_identity_enable:
             base_payload["identity"] = {"type": "SystemAssigned"}
 
-        if endpoint_already_configured and (not needs_identity_enable):
+        if endpoint_already_configured and outbound_identity_already_configured and (not needs_identity_enable):
             principal_id = self._resolve_outbound_principal(mi_resource, current_identity)
             logger.info(
                 "ADR namespace '%s' already has outbound identity and observability endpoint configured.",

--- a/azext_edge/edge/providers/orchestration/live_data.py
+++ b/azext_edge/edge/providers/orchestration/live_data.py
@@ -1,0 +1,1043 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from azure.cli.core.azclierror import ValidationError
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from knack.log import get_logger
+from rich.console import Console
+
+from ...util.az_client import (
+    get_eventgrid_mgmt_client,
+    get_iotops_mgmt_client,
+    get_registry_mgmt_client,
+    wait_for_terminal_state,
+)
+from ...util.cloud_config import CloudConfig
+from ...util.common import should_continue_prompt, url_safe_hash_phrase
+from ...util.id_tools import parse_resource_id as parse_resource_id_dict
+from ...util.workflow_display import StepState, WorkflowDisplay, render_summary
+from .common import (
+    EG_TOPICSPACES_PUBLISHER_ROLE_ID,
+    EG_TOPICSPACES_SUBSCRIBER_ROLE_ID,
+    LIVE_DATA_ADR_API_VERSION,
+    LIVE_DATA_ADR_ENDPOINT_TYPE,
+    LIVE_DATA_ENDPOINT_NAME,
+    LIVE_DATA_PROFILE_NAME,
+    LIVE_DATA_TOPIC_TEMPLATE,
+    LIVE_DATA_TOPICSPACE_PREFIX,
+    LiveDataRoleScope,
+)
+from .eg_provider_base import EgNamespaceContext, EventGridProviderBase, graceful_delete
+from .permissions import ROLE_DEF_FORMAT_STR, PermissionManager, PrincipalType
+
+if TYPE_CHECKING:
+    from ...vendor.clients.deviceregistrymgmt import (
+        MicrosoftDeviceRegistryManagementService,
+    )
+    from ...vendor.clients.eventgridmgmt import EventGridManagementClient
+
+logger = get_logger(__name__)
+console = Console()
+
+
+def get_live_data_topic_space_name(instance_resource_id: str) -> str:
+    """Build the deterministic topic space name: live-data-ts-{hash8}.
+
+    hash8 = first 8 chars of a URL-safe hash of the instance ARM resource ID, so the
+    shared Event Grid namespace can host topic spaces for multiple instances.
+    """
+    hash8 = url_safe_hash_phrase(instance_resource_id)[:8]
+    return f"{LIVE_DATA_TOPICSPACE_PREFIX}-{hash8}"
+
+
+def _build_adr_observability_put_payload(adr_namespace: Dict, custom_location_id: str) -> Dict:
+    """Build an ADR namespace PUT payload with one observability endpoint entry removed.
+
+    ARM PATCH deep-merges dicts (omitting a key preserves it) and the ADR API rejects
+    null endpoint values, so a full PUT replaces the resource. Preserves identity, tags,
+    outboundIdentity, management, and messaging from the original namespace.
+    """
+    properties = adr_namespace.get("properties", {})
+    existing_endpoints = properties.get("observability", {}).get("endpoints", {})
+    updated_endpoints = {k: v for k, v in existing_endpoints.items() if k != custom_location_id}
+
+    payload: Dict = {
+        "location": adr_namespace.get("location", ""),
+        "properties": {
+            "observability": {"endpoints": updated_endpoints},
+        },
+    }
+    if adr_namespace.get("identity"):
+        payload["identity"] = adr_namespace["identity"]
+    if adr_namespace.get("tags"):
+        payload["tags"] = adr_namespace["tags"]
+    outbound_identity = properties.get("outboundIdentity")
+    if outbound_identity:
+        payload["properties"]["outboundIdentity"] = outbound_identity
+    management = properties.get("management")
+    if management:
+        payload["properties"]["management"] = management
+    messaging = properties.get("messaging")
+    if messaging:
+        payload["properties"]["messaging"] = messaging
+    return payload
+
+
+class LiveData(EventGridProviderBase):
+    """Provider for Live Data enable/show/disable operations."""
+
+    def __init__(self, cmd, subscription_id: Optional[str] = None):
+        super().__init__(cmd=cmd, subscription_id=subscription_id)
+        self.iotops_mgmt_client = get_iotops_mgmt_client(**self._get_client_kwargs())
+        # Live Data requires ADR observability fields from the preview API version.
+        self.registry_mgmt_client: "MicrosoftDeviceRegistryManagementService" = get_registry_mgmt_client(
+            api_version=LIVE_DATA_ADR_API_VERSION,
+            **self._get_client_kwargs(),
+        )
+        # May be replaced with a cross-subscription client by _validate_eg_namespace.
+        self.eventgrid_mgmt_client: "EventGridManagementClient" = get_eventgrid_mgmt_client(
+            **self._get_client_kwargs()
+        )
+        self.permission_manager = PermissionManager(self.default_subscription_id)
+
+    def enable(
+        self,
+        name: str,
+        resource_group_name: str,
+        eg_resource_id: str,
+        mi_user_assigned: Optional[str] = None,
+        ra_scope: Optional[str] = None,
+        adr_role_ids: Optional[List[str]] = None,
+        ops_role_ids: Optional[List[str]] = None,
+        skip_role_assignments: Optional[bool] = None,
+        no_progress: Optional[bool] = None,
+        **kwargs,
+    ) -> Dict:
+        """Enable Live Data infrastructure for an IoT Operations instance.
+
+        Converges Event Grid, AIO, and ADR namespace resources plus role assignments.
+        All steps are idempotent — re-running adds to shared resources without
+        overwriting unrelated entries.
+        """
+        if not CloudConfig(self.cmd).supports_eventgrid_mqtt:
+            raise ValidationError(
+                "Live Data is not available in this cloud environment. This feature relies on "
+                "Event Grid Namespaces with MQTT, which is not supported in the active cloud."
+            )
+
+        resolved_scope = LiveDataRoleScope(ra_scope) if ra_scope else LiveDataRoleScope.NAMESPACE
+
+        analyzing_cats = {"Analyzing": ["Instance resolution", "EG namespace validation", "UAMI resolution"]}
+        with WorkflowDisplay(
+            "Live Data Enablement", analyzing_cats, no_progress=no_progress,
+        ) as display:
+            with display.step_scope("Analyzing", "Instance resolution"):
+                instance = self.iotops_mgmt_client.instance.get(
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                )
+                instance_resource_id: str = instance["id"]
+                extended_location: Dict = instance["extendedLocation"]
+                custom_location_id: str = extended_location["name"]
+                display.update_step("Analyzing", "Instance resolution", StepState.COMPLETE, "done")
+
+            with display.step_scope("Analyzing", "EG namespace validation"):
+                eg_ctx = self._validate_eg_namespace(eg_resource_id)
+                display.update_step("Analyzing", "EG namespace validation", StepState.COMPLETE, "done")
+
+            with display.step_scope("Analyzing", "UAMI resolution"):
+                mi_resource = self._resolve_user_assigned_mi(mi_user_assigned) if mi_user_assigned else None
+                if mi_resource:
+                    display.update_step("Analyzing", "UAMI resolution", StepState.COMPLETE, "done")
+                else:
+                    display.update_step("Analyzing", "UAMI resolution", StepState.SKIPPED, "not needed")
+
+        adr_ns_ref = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId", "")
+        adr_ns_display = parse_resource_id_dict(adr_ns_ref).get("name", "") if adr_ns_ref else ""
+
+        cat_eg = f"Event Grid Namespace ({eg_ctx.namespace_name})"
+        cat_aio = f"IoT Operations Instance ({name})"
+        cat_adr = f"Device Registry Namespace ({adr_ns_display})" if adr_ns_display else "Device Registry Namespace"
+        cat_roles = "Role Assignments"
+
+        config_cats: Dict[str, List[str]] = {
+            cat_eg: ["Topic space"],
+            cat_aio: ["Dataflow profile", "EG dataflow endpoint"],
+            cat_adr: ["Outbound identity", "Observability endpoint"],
+        }
+        if not skip_role_assignments:
+            config_cats[cat_roles] = ["Publisher (instance)", "Subscriber (namespace)"]
+
+        with WorkflowDisplay(
+            "Live Data Enablement", config_cats, transient=False, no_progress=no_progress,
+        ) as display:
+            with display.step_scope(cat_eg, "Topic space"):
+                topic_space_result = self._setup_topic_space(
+                    eg_ctx=eg_ctx,
+                    instance_name=name,
+                    instance_resource_id=instance_resource_id,
+                    **kwargs,
+                )
+                detail = "exists" if topic_space_result.get("exists") else "created"
+                state = StepState.SKIPPED if topic_space_result.get("exists") else StepState.COMPLETE
+                display.update_step(cat_eg, "Topic space", state, detail)
+
+            with display.step_scope(cat_aio, "Dataflow profile"):
+                profile_result = self._setup_dataflow_profile(
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                    extended_location=extended_location,
+                    **kwargs,
+                )
+                detail = "exists" if profile_result.get("exists") else "created"
+                state = StepState.SKIPPED if profile_result.get("exists") else StepState.COMPLETE
+                display.update_step(cat_aio, "Dataflow profile", state, detail)
+
+            with display.step_scope(cat_aio, "EG dataflow endpoint"):
+                endpoint_result = self._setup_eg_dataflow_endpoint(
+                    eg_ctx=eg_ctx,
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                    extended_location=extended_location,
+                    endpoint_name=LIVE_DATA_ENDPOINT_NAME,
+                    mi_resource=mi_resource,
+                    **kwargs,
+                )
+                if endpoint_result.get("updated"):
+                    display.update_step(cat_aio, "EG dataflow endpoint", StepState.COMPLETE, "updated")
+                elif endpoint_result.get("exists"):
+                    display.update_step(cat_aio, "EG dataflow endpoint", StepState.SKIPPED, "exists")
+                else:
+                    display.update_step(cat_aio, "EG dataflow endpoint", StepState.COMPLETE, "created")
+
+            # ADR namespace + role assignments are interdependent (staged identity flow).
+            display.update_step(cat_adr, "Outbound identity", StepState.ACTIVE)
+            display.update_step(cat_adr, "Observability endpoint", StepState.ACTIVE)
+            try:
+                adr_result = self._setup_adr_observability(
+                    instance=instance,
+                    eg_ctx=eg_ctx,
+                    custom_location_id=custom_location_id,
+                    mi_resource=mi_resource,
+                    ra_scope=resolved_scope,
+                    topic_space_name=topic_space_result["name"],
+                    adr_role_ids=adr_role_ids,
+                    skip_role_assignments=bool(skip_role_assignments),
+                    **kwargs,
+                )
+                identity_detail = "exists" if adr_result.get("identity_exists") else "enabled"
+                identity_state = StepState.SKIPPED if adr_result.get("identity_exists") else StepState.COMPLETE
+                display.update_step(cat_adr, "Outbound identity", identity_state, identity_detail)
+                endpoint_detail = "exists" if adr_result.get("endpoint_exists") else "created"
+                endpoint_state = StepState.SKIPPED if adr_result.get("endpoint_exists") else StepState.COMPLETE
+                display.update_step(cat_adr, "Observability endpoint", endpoint_state, endpoint_detail)
+            except Exception as exc:
+                display.update_step(cat_adr, "Outbound identity", StepState.FAILED, str(exc)[:40])
+                display.update_step(cat_adr, "Observability endpoint", StepState.FAILED, str(exc)[:40])
+                raise
+
+            role_assignments_result = None
+            if not skip_role_assignments:
+                display.update_step(cat_roles, "Publisher (instance)", StepState.ACTIVE)
+                display.update_step(cat_roles, "Subscriber (namespace)", StepState.ACTIVE)
+                try:
+                    publisher_principal_id = self._resolve_ops_extension_identity(
+                        instance=instance,
+                        mi_resource=mi_resource,
+                    )
+                    role_assignments_result = self._setup_role_assignments(
+                        eg_ctx=eg_ctx,
+                        ra_scope=resolved_scope,
+                        topic_space_name=topic_space_result["name"],
+                        publisher_principal_id=publisher_principal_id,
+                        subscriber_principal_id=adr_result["identity"]["principalId"],
+                        adr_role_ids=adr_role_ids,
+                        ops_role_ids=ops_role_ids,
+                    )
+                    display.update_step(cat_roles, "Publisher (instance)", StepState.COMPLETE, "done")
+                    display.update_step(cat_roles, "Subscriber (namespace)", StepState.COMPLETE, "done")
+                except Exception as exc:
+                    display.update_step(cat_roles, "Publisher (instance)", StepState.FAILED, str(exc)[:40])
+                    display.update_step(cat_roles, "Subscriber (namespace)", StepState.FAILED, str(exc)[:40])
+                    raise
+
+        for sub_result in [topic_space_result, profile_result, endpoint_result]:
+            sub_result.pop("exists", None)
+            sub_result.pop("updated", None)
+
+        result: Dict = {
+            "instance": {
+                "dataflowProfile": profile_result,
+                "dataflowEndpoint": endpoint_result,
+            },
+            "eventGrid": {
+                "namespace": {
+                    "name": eg_ctx.namespace_name,
+                    "resourceGroup": eg_ctx.resource_group_name,
+                    "subscriptionId": eg_ctx.subscription_id,
+                    "mqttHostname": eg_ctx.mqtt_hostname,
+                },
+                "topicSpace": topic_space_result,
+            },
+            "deviceRegistryNamespace": {
+                "name": adr_result["name"],
+                "resourceGroup": adr_result["resourceGroup"],
+                "subscriptionId": adr_result["subscriptionId"],
+                "outboundIdentity": adr_result.get("outboundIdentity"),
+                "observabilityEndpoint": adr_result.get("observabilityEndpoint"),
+            },
+            "roleAssignmentScope": resolved_scope.value,
+        }
+        if role_assignments_result is not None:
+            result["roleAssignments"] = role_assignments_result
+
+        return result
+
+    def show(
+        self,
+        name: str,
+        resource_group_name: str,
+        no_progress: Optional[bool] = None,
+        **kwargs,
+    ) -> Dict:
+        """Show Live Data configuration for an IoT Operations instance.
+
+        Live Data state for this instance is derived from the presence of this instance's
+        observability.endpoints[<customLocationId>] entry on the ADR namespace. The
+        namespace-level observability.enabled flag is not managed or interpreted here.
+        """
+        analyzing_cats = {
+            "Analyzing": ["Instance & ADR namespace", "Event Grid resources", "Instance dataflow resources"],
+        }
+
+        adr_section: Optional[Dict] = None
+        eg_section: Optional[Dict] = None
+        obs_endpoint: Optional[Dict] = None
+        obs_endpoint_exists = False
+        eg_all_exist = False
+
+        with WorkflowDisplay(
+            title="Live Data Status",
+            categories=analyzing_cats,
+            transient=True,
+            no_progress=no_progress,
+        ) as display:
+            with display.step_scope("Analyzing", "Instance & ADR namespace"):
+                instance = self.iotops_mgmt_client.instance.get(
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                )
+                instance_resource_id: str = instance["id"]
+                custom_location_id: str = instance.get("extendedLocation", {}).get("name", "")
+
+                adr_namespace_resource_id = (
+                    instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+                )
+
+                if adr_namespace_resource_id:
+                    parsed_adr = parse_resource_id_dict(adr_namespace_resource_id)
+                    adr_subscription_id = parsed_adr.get("subscription", "")
+                    adr_resource_group = parsed_adr.get("resource_group", "")
+                    adr_namespace_name = parsed_adr.get("name", "")
+
+                    if adr_subscription_id and adr_resource_group and adr_namespace_name:
+                        try:
+                            adr_namespace = self.registry_mgmt_client.namespaces.get(
+                                resource_group_name=adr_resource_group,
+                                namespace_name=adr_namespace_name,
+                            )
+                            existing_endpoints = (
+                                adr_namespace.get("properties", {})
+                                .get("observability", {})
+                                .get("endpoints", {})
+                            )
+                            obs_endpoint = existing_endpoints.get(custom_location_id) if custom_location_id else None
+                            obs_endpoint_exists = bool(obs_endpoint)
+
+                            adr_section = {
+                                "name": adr_namespace_name,
+                                "resourceGroup": adr_resource_group,
+                                "subscriptionId": adr_subscription_id,
+                                "outboundIdentity": adr_namespace.get("properties", {}).get("outboundIdentity"),
+                                "observabilityEndpoint": {
+                                    "endpointType": obs_endpoint.get("endpointType", ""),
+                                    "address": obs_endpoint.get("address", ""),
+                                    "scopeId": obs_endpoint.get("scopeId", ""),
+                                } if obs_endpoint else None,
+                            }
+                        except ResourceNotFoundError:
+                            logger.warning("ADR namespace '%s' not found.", adr_namespace_name)
+
+                display.update_step("Analyzing", "Instance & ADR namespace", StepState.COMPLETE, "done")
+
+            with display.step_scope("Analyzing", "Event Grid resources"):
+                eg_ctx = self._discover_eg_context(obs_endpoint)
+                if eg_ctx:
+                    try:
+                        eg_namespace = self.eventgrid_mgmt_client.namespaces.get(
+                            resource_group_name=eg_ctx.resource_group_name,
+                            namespace_name=eg_ctx.namespace_name,
+                        )
+                        mqtt_hostname = (
+                            eg_namespace.get("properties", {})
+                            .get("topicSpacesConfiguration", {})
+                            .get("hostname", "")
+                        )
+                        ts_name = get_live_data_topic_space_name(instance_resource_id)
+                        ts_exists = False
+                        topic_space_section: Dict = {"name": ts_name, "exists": False}
+                        try:
+                            ts_resource = self.eventgrid_mgmt_client.topic_spaces.get(
+                                resource_group_name=eg_ctx.resource_group_name,
+                                namespace_name=eg_ctx.namespace_name,
+                                topic_space_name=ts_name,
+                            )
+                            ts_exists = True
+                            topic_space_section = {
+                                "name": ts_name,
+                                "topicTemplates": ts_resource.get("properties", {}).get("topicTemplates", []),
+                                "exists": True,
+                            }
+                        except ResourceNotFoundError:
+                            pass
+
+                        eg_all_exist = ts_exists
+                        eg_section = {
+                            "namespace": {
+                                "name": eg_ctx.namespace_name,
+                                "resourceGroup": eg_ctx.resource_group_name,
+                                "subscriptionId": eg_ctx.subscription_id,
+                                "mqttHostname": mqtt_hostname,
+                            },
+                            "topicSpace": topic_space_section,
+                        }
+                    except ResourceNotFoundError:
+                        logger.warning("Event Grid namespace '%s' not found.", eg_ctx.namespace_name)
+
+                eg_detail = "done" if eg_section else ("not reachable" if eg_ctx else "skipped")
+                display.update_step("Analyzing", "Event Grid resources", StepState.COMPLETE, eg_detail)
+
+            with display.step_scope("Analyzing", "Instance dataflow resources"):
+                profile_exists = False
+                try:
+                    self.iotops_mgmt_client.dataflow_profile.get(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        dataflow_profile_name=LIVE_DATA_PROFILE_NAME,
+                    )
+                    profile_exists = True
+                except ResourceNotFoundError:
+                    pass
+
+                ep_exists = False
+                try:
+                    self.iotops_mgmt_client.dataflow_endpoint.get(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        dataflow_endpoint_name=LIVE_DATA_ENDPOINT_NAME,
+                    )
+                    ep_exists = True
+                except ResourceNotFoundError:
+                    pass
+
+                aio_all_exist = profile_exists and ep_exists
+                display.update_step("Analyzing", "Instance dataflow resources", StepState.COMPLETE, "done")
+
+        instance_section = {
+            "dataflowProfile": {"name": LIVE_DATA_PROFILE_NAME, "exists": profile_exists},
+            "dataflowEndpoint": {"name": LIVE_DATA_ENDPOINT_NAME, "exists": ep_exists},
+        }
+
+        enabled = obs_endpoint_exists and eg_all_exist and aio_all_exist
+
+        return {
+            "enabled": enabled,
+            "instance": instance_section,
+            "eventGrid": eg_section,
+            "deviceRegistryNamespace": adr_section,
+        }
+
+    def disable(
+        self,
+        name: str,
+        resource_group_name: str,
+        confirm_yes: Optional[bool] = None,
+        no_progress: Optional[bool] = None,
+        **kwargs,
+    ) -> None:
+        """Disable Live Data for an IoT Operations instance.
+
+        Removes this instance's observability endpoint entry first (per-instance disable),
+        then tears down the dedicated dataflow profile, EG dataflow endpoint, and topic
+        space. Namespace-scoped role assignments are preserved; topic-space-scoped roles
+        are removed together with the topic space.
+        """
+        analyzing_cats = {"Analyzing": ["Instance & ADR namespace", "Resource probing"]}
+        with WorkflowDisplay(
+            "Live Data Disablement", analyzing_cats, no_progress=no_progress,
+        ) as display:
+            with display.step_scope("Analyzing", "Instance & ADR namespace"):
+                instance = self.iotops_mgmt_client.instance.get(
+                    instance_name=name,
+                    resource_group_name=resource_group_name,
+                )
+                instance_resource_id: str = instance["id"]
+                custom_location_id: str = instance.get("extendedLocation", {}).get("name", "")
+                ts_name = get_live_data_topic_space_name(instance_resource_id)
+
+                adr_namespace_resource_id = (
+                    instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+                )
+                if not adr_namespace_resource_id:
+                    logger.warning(
+                        "Instance '%s' has no ADR namespace reference. Live Data may not have been enabled.",
+                        name,
+                    )
+                    display.update_step("Analyzing", "Instance & ADR namespace", StepState.SKIPPED, "no ref")
+                    return
+
+                parsed_adr = parse_resource_id_dict(adr_namespace_resource_id)
+                adr_resource_group = parsed_adr.get("resource_group", "")
+                adr_namespace_name = parsed_adr.get("name", "")
+
+                try:
+                    adr_namespace = self.registry_mgmt_client.namespaces.get(
+                        resource_group_name=adr_resource_group,
+                        namespace_name=adr_namespace_name,
+                    )
+                except ResourceNotFoundError:
+                    logger.warning(
+                        "ADR namespace '%s' not found. Live Data may not have been enabled.",
+                        adr_namespace_name,
+                    )
+                    display.update_step("Analyzing", "Instance & ADR namespace", StepState.SKIPPED, "not found")
+                    return
+
+                existing_endpoints = (
+                    adr_namespace.get("properties", {}).get("observability", {}).get("endpoints", {})
+                )
+                obs_endpoint = existing_endpoints.get(custom_location_id)
+                eg_ctx = self._discover_eg_context(obs_endpoint)
+                display.update_step("Analyzing", "Instance & ADR namespace", StepState.COMPLETE, "found")
+
+            with display.step_scope("Analyzing", "Resource probing"):
+                profile_exists = True
+                try:
+                    self.iotops_mgmt_client.dataflow_profile.get(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        dataflow_profile_name=LIVE_DATA_PROFILE_NAME,
+                    )
+                except ResourceNotFoundError:
+                    profile_exists = False
+
+                ep_exists = True
+                try:
+                    self.iotops_mgmt_client.dataflow_endpoint.get(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        dataflow_endpoint_name=LIVE_DATA_ENDPOINT_NAME,
+                    )
+                except ResourceNotFoundError:
+                    ep_exists = False
+
+                ts_exists = False
+                if eg_ctx:
+                    try:
+                        self.eventgrid_mgmt_client.topic_spaces.get(
+                            resource_group_name=eg_ctx.resource_group_name,
+                            namespace_name=eg_ctx.namespace_name,
+                            topic_space_name=ts_name,
+                        )
+                        ts_exists = True
+                    except ResourceNotFoundError:
+                        pass
+                display.update_step("Analyzing", "Resource probing", StepState.COMPLETE, "done")
+
+        has_endpoint_entry = custom_location_id in existing_endpoints
+        if not confirm_yes:
+            self._log_disable_summary(
+                instance_name=name,
+                adr_namespace_name=adr_namespace_name,
+                has_endpoint_entry=has_endpoint_entry,
+                profile_exists=profile_exists,
+                ep_exists=ep_exists,
+                ts_exists=ts_exists,
+                eg_ctx=eg_ctx,
+            )
+
+        if not should_continue_prompt(confirm_yes=confirm_yes):
+            return
+
+        self._execute_disable_teardown(
+            name=name,
+            resource_group_name=resource_group_name,
+            adr_namespace=adr_namespace,
+            adr_resource_group=adr_resource_group,
+            adr_namespace_name=adr_namespace_name,
+            custom_location_id=custom_location_id,
+            existing_endpoints=existing_endpoints,
+            profile_exists=profile_exists,
+            ep_exists=ep_exists,
+            eg_ctx=eg_ctx,
+            ts_name=ts_name,
+            ts_exists=ts_exists,
+            no_progress=no_progress,
+            **kwargs,
+        )
+
+    def _execute_disable_teardown(
+        self,
+        name: str,
+        resource_group_name: str,
+        adr_namespace: Dict,
+        adr_resource_group: str,
+        adr_namespace_name: str,
+        custom_location_id: str,
+        existing_endpoints: Dict,
+        profile_exists: bool,
+        ep_exists: bool,
+        eg_ctx: Optional["EgNamespaceContext"],
+        ts_name: str,
+        ts_exists: bool,
+        no_progress: Optional[bool] = None,
+        **kwargs,
+    ) -> None:
+        """Execute the teardown of disable(): remove endpoint entry first, then resources."""
+        eg_ns_label = f"Event Grid Namespace ({eg_ctx.namespace_name})" if eg_ctx else "Event Grid Namespace"
+        cat_adr = f"Device Registry Namespace ({adr_namespace_name})"
+        cat_aio = f"IoT Operations Instance ({name})"
+
+        teardown_cats: Dict[str, List[str]] = {
+            cat_adr: ["Observability endpoint"],
+            cat_aio: ["Dataflow profile", "EG dataflow endpoint"],
+            eg_ns_label: ["Topic space"],
+        }
+        with WorkflowDisplay(
+            "Live Data Disablement", teardown_cats, transient=False, no_progress=no_progress,
+        ) as display:
+            if profile_exists:
+                with display.step_scope(cat_aio, "Dataflow profile"):
+                    graceful_delete(
+                        lambda: self.iotops_mgmt_client.dataflow_profile.begin_delete(
+                            resource_group_name=resource_group_name,
+                            instance_name=name,
+                            dataflow_profile_name=LIVE_DATA_PROFILE_NAME,
+                        ),
+                        resource_desc=f"dataflow profile '{LIVE_DATA_PROFILE_NAME}'",
+                        **kwargs,
+                    )
+                    display.update_step(cat_aio, "Dataflow profile", StepState.COMPLETE, "removed")
+            else:
+                display.update_step(cat_aio, "Dataflow profile", StepState.SKIPPED, "not found")
+
+            if ep_exists:
+                with display.step_scope(cat_aio, "EG dataflow endpoint"):
+                    graceful_delete(
+                        lambda: self.iotops_mgmt_client.dataflow_endpoint.begin_delete(
+                            resource_group_name=resource_group_name,
+                            instance_name=name,
+                            dataflow_endpoint_name=LIVE_DATA_ENDPOINT_NAME,
+                        ),
+                        resource_desc=f"dataflow endpoint '{LIVE_DATA_ENDPOINT_NAME}'",
+                        **kwargs,
+                    )
+                    display.update_step(cat_aio, "EG dataflow endpoint", StepState.COMPLETE, "removed")
+            else:
+                display.update_step(cat_aio, "EG dataflow endpoint", StepState.SKIPPED, "not found")
+
+            if eg_ctx and ts_exists:
+                with display.step_scope(eg_ns_label, "Topic space"):
+                    graceful_delete(
+                        lambda: self.eventgrid_mgmt_client.topic_spaces.begin_delete(
+                            resource_group_name=eg_ctx.resource_group_name,
+                            namespace_name=eg_ctx.namespace_name,
+                            topic_space_name=ts_name,
+                        ),
+                        resource_desc=f"topic space '{ts_name}'",
+                        **kwargs,
+                    )
+                    display.update_step(eg_ns_label, "Topic space", StepState.COMPLETE, "removed")
+            else:
+                display.update_step(eg_ns_label, "Topic space", StepState.SKIPPED, "not found")
+
+            # Remove the ADR endpoint entry last: it holds the EG resourceId used to discover
+            # the EG namespace, so keeping it until the end keeps an interrupted disable re-run-safe.
+            if custom_location_id in existing_endpoints:
+                with display.step_scope(cat_adr, "Observability endpoint"):
+                    put_payload = _build_adr_observability_put_payload(adr_namespace, custom_location_id)
+                    poller = self.registry_mgmt_client.namespaces.begin_create_or_replace(
+                        resource_group_name=adr_resource_group,
+                        namespace_name=adr_namespace_name,
+                        resource=put_payload,
+                    )
+                    wait_for_terminal_state(poller, **kwargs)
+                    logger.info(
+                        "Removed observability endpoint entry for custom location from ADR namespace '%s'.",
+                        adr_namespace_name,
+                    )
+                    display.update_step(cat_adr, "Observability endpoint", StepState.COMPLETE, "removed")
+            else:
+                display.update_step(cat_adr, "Observability endpoint", StepState.SKIPPED, "not found")
+
+    def _log_disable_summary(
+        self,
+        instance_name: str,
+        adr_namespace_name: str,
+        has_endpoint_entry: bool,
+        profile_exists: bool,
+        ep_exists: bool,
+        ts_exists: bool,
+        eg_ctx: Optional["EgNamespaceContext"],
+    ) -> None:
+        """Render a Rich summary of resources that will be removed by disable()."""
+        aio_items: List[str] = []
+        if profile_exists:
+            aio_items.append("Dataflow profile")
+        if ep_exists:
+            aio_items.append("EG dataflow endpoint")
+
+        adr_items: List[str] = []
+        if has_endpoint_entry:
+            adr_items.append("Observability endpoint")
+
+        eg_items: List[str] = []
+        if ts_exists:
+            eg_items.append("Topic space")
+
+        eg_ns_label = f"Event Grid Namespace ({eg_ctx.namespace_name})" if eg_ctx else "Event Grid Namespace"
+        sections: Dict[str, List[str]] = {
+            f"IoT Operations Instance ({instance_name})": aio_items,
+            f"Device Registry Namespace ({adr_namespace_name})": adr_items,
+            eg_ns_label: eg_items,
+        }
+        total = sum(len(items) for items in sections.values())
+        render_summary(
+            title=f"Resources to remove ({total})",
+            sections=sections,
+            footer="Note: Namespace-scoped role assignments are NOT removed.",
+        )
+
+    def _setup_topic_space(
+        self,
+        eg_ctx: EgNamespaceContext,
+        instance_name: str,
+        instance_resource_id: str,
+        **kwargs,
+    ) -> Dict:
+        """Create or confirm the Live Data topic space on the EG namespace."""
+        topic_space_name = get_live_data_topic_space_name(instance_resource_id)
+        topic_templates = [LIVE_DATA_TOPIC_TEMPLATE.format(scope_id=instance_name)]
+
+        try:
+            self.eventgrid_mgmt_client.topic_spaces.get(
+                resource_group_name=eg_ctx.resource_group_name,
+                namespace_name=eg_ctx.namespace_name,
+                topic_space_name=topic_space_name,
+            )
+            logger.info(
+                "Topic space '%s' already exists on namespace '%s'.", topic_space_name, eg_ctx.namespace_name
+            )
+            return {"name": topic_space_name, "topicTemplates": topic_templates, "exists": True}
+        except ResourceNotFoundError:
+            pass
+
+        topic_space_payload = {
+            "properties": {
+                "description": f"Live Data topic space for IoT Operations instance '{instance_name}'.",
+                "topicTemplates": topic_templates,
+            }
+        }
+        poller = self.eventgrid_mgmt_client.topic_spaces.begin_create_or_update(
+            resource_group_name=eg_ctx.resource_group_name,
+            namespace_name=eg_ctx.namespace_name,
+            topic_space_name=topic_space_name,
+            topic_space_info=topic_space_payload,
+        )
+        wait_for_terminal_state(poller, **kwargs)
+        logger.info("Created topic space '%s' on namespace '%s'.", topic_space_name, eg_ctx.namespace_name)
+        return {"name": topic_space_name, "topicTemplates": topic_templates, "exists": False}
+
+    def _setup_dataflow_profile(
+        self,
+        instance_name: str,
+        resource_group_name: str,
+        extended_location: Dict,
+        **kwargs,
+    ) -> Dict:
+        """Create or confirm the dedicated Live Data dataflow profile (instanceCount=1)."""
+        try:
+            self.iotops_mgmt_client.dataflow_profile.get(
+                resource_group_name=resource_group_name,
+                instance_name=instance_name,
+                dataflow_profile_name=LIVE_DATA_PROFILE_NAME,
+            )
+            logger.info(
+                "Dataflow profile '%s' already exists on instance '%s'.", LIVE_DATA_PROFILE_NAME, instance_name
+            )
+            return {"name": LIVE_DATA_PROFILE_NAME, "exists": True}
+        except ResourceNotFoundError:
+            pass
+
+        resource = {
+            "extendedLocation": extended_location,
+            "properties": {
+                "diagnostics": {"logs": {"level": "info"}},
+                "instanceCount": 1,
+            },
+        }
+        poller = self.iotops_mgmt_client.dataflow_profile.begin_create_or_update(
+            resource_group_name=resource_group_name,
+            instance_name=instance_name,
+            dataflow_profile_name=LIVE_DATA_PROFILE_NAME,
+            resource=resource,
+        )
+        wait_for_terminal_state(poller, **kwargs)
+        logger.info("Created dataflow profile '%s' on instance '%s'.", LIVE_DATA_PROFILE_NAME, instance_name)
+        return {"name": LIVE_DATA_PROFILE_NAME, "exists": False}
+
+    def _setup_adr_observability(
+        self,
+        instance: Dict,
+        eg_ctx: EgNamespaceContext,
+        custom_location_id: str,
+        mi_resource: Optional[Dict],
+        ra_scope: LiveDataRoleScope,
+        topic_space_name: str,
+        adr_role_ids: Optional[List[str]],
+        skip_role_assignments: bool,
+        **kwargs,
+    ) -> Dict:
+        """Configure outboundIdentity and the observability endpoint on the ADR namespace.
+
+        When the outbound identity is a new system-assigned identity, staged enablement is
+        used: the identity is enabled first (no endpoint entry), the Subscriber role is
+        granted to its principal, then the endpoint entry is written. When the identity
+        already exists (or a UAMI is supplied and pre-authorized), a single write is used.
+        """
+        adr_namespace_resource_id = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+        if not adr_namespace_resource_id:
+            raise ValidationError(
+                "Instance does not have an ADR namespace reference (adrNamespaceRef.resourceId). "
+                "This is required for Live Data. Ensure the instance was deployed with an ADR namespace."
+            )
+
+        parsed_adr = parse_resource_id_dict(adr_namespace_resource_id)
+        adr_resource_group = parsed_adr.get("resource_group", "")
+        adr_namespace_name = parsed_adr.get("name", "")
+        adr_subscription_id = parsed_adr.get("subscription", "")
+        if not all([adr_resource_group, adr_namespace_name]):
+            raise ValidationError(
+                f"Malformed ADR namespace resource Id '{adr_namespace_resource_id}'. "
+                f"Could not extract resource group or namespace name."
+            )
+
+        adr_namespace = self.registry_mgmt_client.namespaces.get(
+            resource_group_name=adr_resource_group,
+            namespace_name=adr_namespace_name,
+        )
+        properties = adr_namespace.get("properties", {})
+
+        desired_endpoint = {
+            "endpointType": LIVE_DATA_ADR_ENDPOINT_TYPE,
+            "address": eg_ctx.mqtt_hostname,
+            "scopeId": instance.get("name", ""),
+            "resourceId": eg_ctx.resource_id,
+        }
+        outbound_identity = self._build_outbound_identity(mi_resource)
+
+        existing_endpoints = properties.get("observability", {}).get("endpoints", {})
+        current_endpoint = existing_endpoints.get(custom_location_id)
+        endpoint_already_configured = current_endpoint == desired_endpoint
+
+        current_identity = adr_namespace.get("identity", {})
+        current_identity_type = (current_identity.get("type") or "").lower()
+        sami_already_enabled = current_identity_type == "systemassigned"
+
+        use_sami = mi_resource is None
+        needs_identity_enable = use_sami and not sami_already_enabled
+
+        base_payload: Dict = {"properties": {"outboundIdentity": outbound_identity}}
+        if needs_identity_enable:
+            base_payload["identity"] = {"type": "SystemAssigned"}
+
+        if endpoint_already_configured and (not needs_identity_enable):
+            principal_id = self._resolve_outbound_principal(mi_resource, current_identity)
+            logger.info(
+                "ADR namespace '%s' already has outbound identity and observability endpoint configured.",
+                adr_namespace_name,
+            )
+            return {
+                "name": adr_namespace_name,
+                "resourceGroup": adr_resource_group,
+                "subscriptionId": adr_subscription_id,
+                "outboundIdentity": outbound_identity,
+                "identity": {"principalId": principal_id},
+                "observabilityEndpoint": desired_endpoint,
+                "identity_exists": True,
+                "endpoint_exists": True,
+            }
+
+        # Staged write for a new system-assigned identity: enable identity + outboundIdentity
+        # first (no endpoint), grant Subscriber, then add the endpoint entry.
+        staged = needs_identity_enable and not skip_role_assignments
+        if staged:
+            identity_payload = dict(base_payload)
+            updated_namespace = self._patch_namespace(
+                adr_resource_group, adr_namespace_name, identity_payload, **kwargs
+            )
+            principal_id = updated_namespace.get("identity", {}).get("principalId", "")
+            if not principal_id:
+                raise ValidationError(
+                    f"ADR namespace '{adr_namespace_name}' was updated with a SystemAssigned identity "
+                    f"but no principalId was returned. The operation may still be propagating."
+                )
+            self._assign_subscriber_role(
+                eg_ctx=eg_ctx,
+                ra_scope=ra_scope,
+                topic_space_name=topic_space_name,
+                principal_id=principal_id,
+                adr_role_ids=adr_role_ids,
+            )
+            merged_endpoints = dict(existing_endpoints)
+            merged_endpoints[custom_location_id] = desired_endpoint
+            endpoint_payload = {"properties": {"observability": {"endpoints": merged_endpoints}}}
+            self._patch_namespace(adr_resource_group, adr_namespace_name, endpoint_payload, **kwargs)
+        else:
+            merged_endpoints = dict(existing_endpoints)
+            merged_endpoints[custom_location_id] = desired_endpoint
+            payload = dict(base_payload)
+            payload["properties"]["observability"] = {"endpoints": merged_endpoints}
+            updated_namespace = self._patch_namespace(
+                adr_resource_group, adr_namespace_name, payload, **kwargs
+            )
+            principal_id = self._resolve_outbound_principal(
+                mi_resource, updated_namespace.get("identity", {})
+            )
+
+        return {
+            "name": adr_namespace_name,
+            "resourceGroup": adr_resource_group,
+            "subscriptionId": adr_subscription_id,
+            "outboundIdentity": outbound_identity,
+            "identity": {"principalId": principal_id},
+            "observabilityEndpoint": desired_endpoint,
+            "identity_exists": sami_already_enabled if use_sami else True,
+            "endpoint_exists": endpoint_already_configured,
+        }
+
+    def _patch_namespace(self, resource_group_name: str, namespace_name: str, payload: Dict, **kwargs) -> Dict:
+        poller = self.registry_mgmt_client.namespaces.begin_update(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            properties=payload,
+        )
+        return wait_for_terminal_state(poller, **kwargs)
+
+    def _build_outbound_identity(self, mi_resource: Optional[Dict]) -> Dict:
+        """Build the ADR namespace outboundIdentity block."""
+        if mi_resource:
+            return {"type": "UserAssigned", "userAssignedIdentity": mi_resource["id"]}
+        return {"type": "SystemAssigned"}
+
+    def _resolve_outbound_principal(self, mi_resource: Optional[Dict], identity: Dict) -> str:
+        """Resolve the principal ID of the ADR namespace outbound identity."""
+        if mi_resource:
+            principal_id = mi_resource.get("properties", {}).get("principalId", "")
+        else:
+            principal_id = identity.get("principalId", "")
+        if not principal_id:
+            raise ValidationError(
+                "Could not resolve the outbound identity principal ID for the ADR namespace. "
+                "The identity may still be provisioning."
+            )
+        return principal_id
+
+    def _role_scope(self, eg_ctx: EgNamespaceContext, ra_scope: LiveDataRoleScope, topic_space_name: str) -> str:
+        """Resolve the role-assignment scope resource ID for the selected --ra-scope."""
+        if ra_scope == LiveDataRoleScope.TOPIC_SPACE:
+            return f"{eg_ctx.resource_id}/topicSpaces/{topic_space_name}"
+        return eg_ctx.resource_id
+
+    def _assign_subscriber_role(
+        self,
+        eg_ctx: EgNamespaceContext,
+        ra_scope: LiveDataRoleScope,
+        topic_space_name: str,
+        principal_id: str,
+        adr_role_ids: Optional[List[str]],
+    ) -> None:
+        """Grant the ADR namespace identity the Subscriber role at the selected scope."""
+        role_ids = adr_role_ids or [EG_TOPICSPACES_SUBSCRIBER_ROLE_ID]
+        scope = self._role_scope(eg_ctx, ra_scope, topic_space_name)
+        manager = self._permission_manager(eg_ctx)
+        try:
+            for role_id in role_ids:
+                role_def_id = ROLE_DEF_FORMAT_STR.format(
+                    subscription_id=eg_ctx.subscription_id, role_id=role_id
+                )
+                manager.apply_role_assignment(
+                    scope=scope,
+                    principal_id=principal_id,
+                    role_def_id=role_def_id,
+                    principal_type=PrincipalType.SERVICE_PRINCIPAL.value,
+                )
+        except HttpResponseError as e:
+            raise ValidationError(
+                f"Failed to assign Subscriber role for principal '{principal_id}' "
+                f"on Event Grid namespace '{eg_ctx.namespace_name}'.\n"
+                f"Error: {e.message}\n"
+                f"  Scope: {scope}\n  Principal ID: {principal_id}\n  Role IDs: {', '.join(role_ids)}"
+            )
+
+    def _setup_role_assignments(
+        self,
+        eg_ctx: EgNamespaceContext,
+        ra_scope: LiveDataRoleScope,
+        topic_space_name: str,
+        publisher_principal_id: str,
+        subscriber_principal_id: str,
+        adr_role_ids: Optional[List[str]] = None,
+        ops_role_ids: Optional[List[str]] = None,
+    ) -> Dict:
+        """Assign Publisher (instance identity) and Subscriber (ADR namespace identity) roles.
+
+        Idempotent — existing assignments are skipped. Scope is the EG namespace
+        (--ra-scope namespace, default) or the topic-space resource (--ra-scope topic-space).
+        """
+        resolved_ops_roles = ops_role_ids or [EG_TOPICSPACES_PUBLISHER_ROLE_ID]
+        resolved_adr_roles = adr_role_ids or [EG_TOPICSPACES_SUBSCRIBER_ROLE_ID]
+        scope = self._role_scope(eg_ctx, ra_scope, topic_space_name)
+        manager = self._permission_manager(eg_ctx)
+
+        assignments = [
+            ("instance", publisher_principal_id, resolved_ops_roles),
+            ("adrNamespace", subscriber_principal_id, resolved_adr_roles),
+        ]
+        result: Dict = {}
+        for result_key, principal_id, role_ids in assignments:
+            try:
+                for role_id in role_ids:
+                    role_def_id = ROLE_DEF_FORMAT_STR.format(
+                        subscription_id=eg_ctx.subscription_id, role_id=role_id
+                    )
+                    manager.apply_role_assignment(
+                        scope=scope,
+                        principal_id=principal_id,
+                        role_def_id=role_def_id,
+                        principal_type=PrincipalType.SERVICE_PRINCIPAL.value,
+                    )
+            except HttpResponseError as e:
+                raise ValidationError(
+                    f"Failed to assign role(s) for principal '{principal_id}' "
+                    f"on Event Grid namespace '{eg_ctx.namespace_name}'.\n"
+                    f"Error: {e.message}\n"
+                    f"  Scope: {scope}\n  Principal ID: {principal_id}\n  Role IDs: {', '.join(role_ids)}"
+                )
+            result[result_key] = {"principalId": principal_id, "roles": list(role_ids)}
+        return result

--- a/azext_edge/edge/providers/orchestration/live_data.py
+++ b/azext_edge/edge/providers/orchestration/live_data.py
@@ -472,10 +472,11 @@ class LiveData(EventGridProviderBase):
     ) -> None:
         """Disable Live Data for an IoT Operations instance.
 
-        Removes this instance's observability endpoint entry first (per-instance disable),
-        then tears down the dedicated dataflow profile, EG dataflow endpoint, and topic
-        space. Namespace-scoped role assignments are preserved; topic-space-scoped roles
-        are removed together with the topic space.
+        Tears down the dedicated dataflow profile, EG dataflow endpoint, and topic space,
+        then removes this instance's observability endpoint entry from the Device Registry
+        namespace last so an interrupted disable can be safely re-run. Namespace-scoped
+        role assignments are preserved; topic-space-scoped roles are removed together with
+        the topic space.
         """
         analyzing_cats = {"Analyzing": ["Instance & ADR namespace", "Resource probing"]}
         with WorkflowDisplay(
@@ -608,7 +609,7 @@ class LiveData(EventGridProviderBase):
         no_progress: Optional[bool] = None,
         **kwargs,
     ) -> None:
-        """Execute the teardown of disable(): remove endpoint entry first, then resources."""
+        """Execute the teardown of disable(): delete resources first, then remove the endpoint entry last."""
         eg_ns_label = f"Event Grid Namespace ({eg_ctx.namespace_name})" if eg_ctx else "Event Grid Namespace"
         cat_adr = f"Device Registry Namespace ({adr_namespace_name})"
         cat_aio = f"IoT Operations Instance ({name})"

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -5,9 +5,9 @@
 # ----------------------------------------------------------------------------------------------
 
 import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
-from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
+from azure.cli.core.azclierror import ValidationError
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from knack.log import get_logger
 from rich.console import Console
@@ -21,14 +21,10 @@ from ...util.az_client import (
 from ...util.common import should_continue_prompt
 from ...util.cloud_config import CloudConfig
 from ...util.id_tools import parse_resource_id as parse_resource_id_dict
-from ...util.queryable import Queryable
 from ...util.workflow_display import StepState, WorkflowDisplay, render_summary
 from .common import (
-    CUSTOM_LOCATIONS_API_VERSION,
     EG_TOPICSPACES_PUBLISHER_ROLE_ID,
     EG_TOPICSPACES_SUBSCRIBER_ROLE_ID,
-    EXTENSION_TYPE_OPS,
-    MANAGED_IDENTITY_API_VERSION,
     MGMT_ACTIONS_ADR_ENDPOINT_TYPE,
     MGMT_ACTIONS_DEFAULT_DATAFLOW_PROFILE,
     MGMT_ACTIONS_DEFAULT_EG_CLIENT_GROUP,
@@ -41,9 +37,8 @@ from .common import (
     MGMT_ACTIONS_RESPONSE_TOPIC_TEMPLATE,
     MIN_EG_CLIENT_SESSIONS_PER_AUTH_NAME,
     MIN_INSTANCE_VERSION_MGMT_ACTIONS,
-    MQTT_ENDPOINT_TYPE,
 )
-from .connected_cluster import ConnectedCluster
+from .eg_provider_base import EgNamespaceContext, EventGridProviderBase, graceful_delete as _graceful_delete
 from .permissions import ROLE_DEF_FORMAT_STR, PermissionManager, PrincipalType
 
 if TYPE_CHECKING:
@@ -99,16 +94,6 @@ def _build_graph_rules_config(topic_prefix_regex: str) -> List[Dict]:
             "value": json.dumps(rules_value),
         },
     ]
-
-
-def _graceful_delete(begin_delete_fn: Callable, resource_desc: str, **kwargs) -> None:
-    """Execute a begin_delete LRO, catching ResourceNotFoundError for idempotent teardown."""
-    try:
-        poller = begin_delete_fn()
-        wait_for_terminal_state(poller, **kwargs)
-        logger.info("Deleted %s.", resource_desc)
-    except ResourceNotFoundError:
-        logger.info("%s already deleted — skipping.", resource_desc.capitalize())
 
 
 def _build_adr_put_payload(adr_namespace: Dict, endpoint_key_to_remove: str) -> Dict:
@@ -207,21 +192,7 @@ def _log_disable_summary(
             logger.info("  %s: %s", label, get_mgmt_actions_resource_name(purpose, instance_resource_id))
 
 
-class EgNamespaceContext(NamedTuple):
-    """Validated Event Grid namespace context, produced by _validate_eg_namespace().
-
-    Set once during validation, then shared read-only across all subsequent setup
-    methods. Immutable NamedTuple ensures thread safety if concurrency is added later.
-    """
-
-    resource_id: str
-    subscription_id: str
-    resource_group_name: str
-    namespace_name: str
-    mqtt_hostname: str
-
-
-class MgmtActions(Queryable):
+class MgmtActions(EventGridProviderBase):
     """Provider for management actions enable/disable/show operations."""
 
     def __init__(self, cmd, subscription_id: Optional[str] = None):
@@ -1013,16 +984,6 @@ class MgmtActions(Queryable):
                 ep_exists=ep_exists,
                 **kwargs,
             )
-            self._teardown_adr_endpoint(
-                display=display,
-                category=cat_adr,
-                adr_namespace=adr_namespace,
-                adr_resource_group=adr_resource_group,
-                adr_namespace_name=adr_namespace_name,
-                custom_location_id=custom_location_id,
-                existing_endpoints=existing_endpoints,
-                **kwargs,
-            )
             self._teardown_eg_resources(
                 display=display,
                 category=eg_ns_label,
@@ -1033,6 +994,18 @@ class MgmtActions(Queryable):
                 sub_exists=sub_exists,
                 ts_name=ts_name,
                 ts_exists=ts_exists,
+                **kwargs,
+            )
+            # Remove the ADR endpoint entry last: it holds the EG resourceId used to discover
+            # the EG namespace, so keeping it until the end keeps an interrupted disable re-run-safe.
+            self._teardown_adr_endpoint(
+                display=display,
+                category=cat_adr,
+                adr_namespace=adr_namespace,
+                adr_resource_group=adr_resource_group,
+                adr_namespace_name=adr_namespace_name,
+                custom_location_id=custom_location_id,
+                existing_endpoints=existing_endpoints,
                 **kwargs,
             )
 
@@ -1309,138 +1282,11 @@ class MgmtActions(Queryable):
 
         return None
 
-    def _discover_eg_context(self, mgmt_endpoint: Optional[Dict]) -> Optional[EgNamespaceContext]:
-        """Extract EG namespace context from an ADR management endpoint entry.
-
-        Parses the resourceId from the endpoint, validates required fields, and creates
-        a cross-subscription EG client when the namespace is in a different subscription.
-        Returns None if the endpoint is missing or has incomplete EG reference data.
-        """
-        if not mgmt_endpoint:
-            return None
-
-        eg_resource_id = mgmt_endpoint.get("resourceId", "")
-        if not eg_resource_id:
-            return None
-
-        parsed_eg = parse_resource_id_dict(eg_resource_id)
-        eg_namespace_name = parsed_eg.get("name", "")
-        eg_resource_group = parsed_eg.get("resource_group", "")
-        eg_subscription_id = parsed_eg.get("subscription", "")
-        mqtt_hostname = mgmt_endpoint.get("address", "")
-
-        if not (eg_namespace_name and eg_resource_group and eg_subscription_id):
-            return None
-
-        eg_ctx = EgNamespaceContext(
-            resource_id=eg_resource_id,
-            subscription_id=eg_subscription_id,
-            resource_group_name=eg_resource_group,
-            namespace_name=eg_namespace_name,
-            mqtt_hostname=mqtt_hostname,
-        )
-
-        # Handle cross-subscription EG namespace
-        if eg_subscription_id.lower() != self.default_subscription_id.lower():
-            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
-                **self._get_client_kwargs(subscription_id=eg_subscription_id)
-            )
-
-        return eg_ctx
-
     def _validate_eg_namespace(self, eg_resource_id: str) -> EgNamespaceContext:
-        """Parse, fetch, and validate an Event Grid namespace for mgmt-actions use.
-
-        Validates that the resource ID is a well-formed Microsoft.EventGrid/namespaces ID,
-        the namespace exists, and MQTT broker (topic spaces) is enabled. When the namespace
-        resides in a different subscription, a cross-subscription EG client is created and
-        stored as self.eventgrid_mgmt_client for use by subsequent EG setup methods.
-        """
-        parsed = parse_resource_id_dict(eg_resource_id)
-
-        # Validate resource type
-        eg_namespace = parsed.get("namespace", "")
-        eg_type = parsed.get("type", "")
-        if eg_namespace.lower() != "microsoft.eventgrid" or eg_type.lower() != "namespaces":
-            raise InvalidArgumentValueError(
-                f"--eg-resource-id must reference a Microsoft.EventGrid/namespaces resource.\n"
-                f"Got: {eg_namespace}/{eg_type}\n"
-                f"Expected format: /subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroup}}"
-                f"/providers/Microsoft.EventGrid/namespaces/{{namespaceName}}"
-            )
-
-        eg_subscription_id = parsed.get("subscription", "")
-        eg_resource_group = parsed.get("resource_group", "")
-        eg_name = parsed.get("name", "")
-
-        if not all([eg_subscription_id, eg_resource_group, eg_name]):
-            raise InvalidArgumentValueError(
-                f"Malformed resource Id '{eg_resource_id}'. Could not extract subscription, "
-                f"resource group, or namespace name."
-            )
-
-        # Handle cross-subscription: create a new EG client if needed
-        if eg_subscription_id.lower() != self.default_subscription_id.lower():
-            logger.info(
-                "Event Grid namespace is in subscription '%s' (instance subscription: '%s'). "
-                "Creating cross-subscription client.",
-                eg_subscription_id,
-                self.default_subscription_id,
-            )
-            self.eventgrid_mgmt_client = get_eventgrid_mgmt_client(
-                **self._get_client_kwargs(subscription_id=eg_subscription_id)
-            )
-
-        # Fetch the namespace
-        try:
-            namespace_resource = self.eventgrid_mgmt_client.namespaces.get(
-                resource_group_name=eg_resource_group,
-                namespace_name=eg_name,
-            )
-        except ResourceNotFoundError:
-            raise InvalidArgumentValueError(
-                f"Event Grid namespace '{eg_name}' not found in resource group '{eg_resource_group}' "
-                f"(subscription: {eg_subscription_id}).\n"
-                f"Verify the --eg-resource-id value and ensure the namespace exists."
-            )
-
-        # Validate topic spaces enabled
-        topic_spaces_config = namespace_resource.get("properties", {}).get("topicSpacesConfiguration", {})
-        topic_spaces_state = topic_spaces_config.get("state", "")
-        if topic_spaces_state != "Enabled":
-            state_detail = (
-                f"Current state: '{topic_spaces_state}'."
-                if topic_spaces_state
-                else "MQTT broker has not been configured."
-            )
-            raise ValidationError(
-                f"Event Grid namespace '{eg_name}' does not have MQTT broker (topic spaces) enabled.\n"
-                f"{state_detail} "
-                f"Enable topic spaces on the namespace before running mgmt-actions enable."
-            )
-
-        mqtt_hostname = topic_spaces_config.get("hostname", "")
-        if not mqtt_hostname:
-            raise ValidationError(
-                f"Event Grid namespace '{eg_name}' has topic spaces enabled but no MQTT hostname. "
-                f"This may indicate the namespace is still provisioning."
-            )
-
-        max_client_sessions = topic_spaces_config.get("maximumClientSessionsPerAuthenticationName", 0)
-        if max_client_sessions < MIN_EG_CLIENT_SESSIONS_PER_AUTH_NAME:
-            raise ValidationError(
-                f"Event Grid namespace '{eg_name}' has maximumClientSessionsPerAuthenticationName "
-                f"set to {max_client_sessions}. Management actions requires at least "
-                f"{MIN_EG_CLIENT_SESSIONS_PER_AUTH_NAME} concurrent client sessions per authentication name "
-                f"to support reliable dataflow connectivity."
-            )
-
-        return EgNamespaceContext(
-            resource_id=eg_resource_id,
-            subscription_id=eg_subscription_id,
-            resource_group_name=eg_resource_group,
-            namespace_name=eg_name,
-            mqtt_hostname=mqtt_hostname,
+        """Validate the Event Grid namespace, additionally enforcing the minimum client-session
+        requirement management actions relies on."""
+        return super()._validate_eg_namespace(
+            eg_resource_id, min_client_sessions=MIN_EG_CLIENT_SESSIONS_PER_AUTH_NAME
         )
 
     def _setup_eg_topic_space(
@@ -1581,114 +1427,17 @@ class MgmtActions(Queryable):
         mi_resource: Optional[Dict] = None,
         **kwargs,
     ) -> Dict:
-        """Create or update the EG MQTT dataflow endpoint on the AIO instance.
-
-        Uses GET-then-PUT to report accurate status. The endpoint connects to the EG
-        namespace's MQTT broker using managed identity authentication. Defaults to
-        SystemAssigned MI; when mi_resource is provided, a UserAssigned MI is
-        configured instead using clientId and tenantId from the resolved UAMI resource.
-
-        When the endpoint already exists, compares host, authentication, and
-        clientIdPrefix against the desired state. If any differ (e.g., re-enabling with
-        a different EG namespace, switching between SAMI/UAMI, or a stale/missing
-        clientIdPrefix), the endpoint is updated via PUT.
-        """
+        """Create or update the mgmt-actions EG MQTT dataflow endpoint (hash-derived name)."""
         endpoint_name = get_mgmt_actions_resource_name("eg", instance_resource_id)
-
-        # Build desired authentication block
-        desired_authentication = self._build_eg_endpoint_auth(mi_resource)
-
-        # Check if endpoint already exists
-        try:
-            existing = self.iotops_mgmt_client.dataflow_endpoint.get(
-                resource_group_name=resource_group_name,
-                instance_name=instance_name,
-                dataflow_endpoint_name=endpoint_name,
-            )
-            existing_mqtt = existing.get("properties", {}).get("mqttSettings", {})
-            existing_host = existing_mqtt.get("host", "")
-            existing_auth = existing_mqtt.get("authentication", {})
-            existing_client_id_prefix = existing_mqtt.get("clientIdPrefix", "")
-
-            # Compare host, auth, and clientIdPrefix — update if any differ
-            host_matches = existing_host == eg_ctx.mqtt_hostname
-            auth_matches = existing_auth == desired_authentication
-            client_id_prefix_matches = existing_client_id_prefix == instance_name
-            if host_matches and auth_matches and client_id_prefix_matches:
-                logger.info(
-                    "Dataflow endpoint '%s' already exists on instance '%s' with matching configuration.",
-                    endpoint_name,
-                    instance_name,
-                )
-                return {"name": endpoint_name, "authentication": existing_auth, "exists": True}
-
-            logger.info(
-                "Dataflow endpoint '%s' exists but configuration differs "
-                "(host_match=%s, auth_match=%s, client_id_prefix_match=%s). Updating.",
-                endpoint_name,
-                host_matches,
-                auth_matches,
-                client_id_prefix_matches,
-            )
-        except ResourceNotFoundError:
-            existing = None
-
-        resource = {
-            "extendedLocation": extended_location,
-            "properties": {
-                "endpointType": MQTT_ENDPOINT_TYPE,
-                "mqttSettings": {
-                    "host": eg_ctx.mqtt_hostname,
-                    "clientIdPrefix": instance_name,
-                    "authentication": desired_authentication,
-                    "tls": {
-                        "mode": "Enabled",
-                    },
-                },
-            },
-        }
-
-        poller = self.iotops_mgmt_client.dataflow_endpoint.begin_create_or_update(
-            resource_group_name=resource_group_name,
+        return super()._setup_eg_dataflow_endpoint(
+            eg_ctx=eg_ctx,
             instance_name=instance_name,
-            dataflow_endpoint_name=endpoint_name,
-            resource=resource,
+            resource_group_name=resource_group_name,
+            extended_location=extended_location,
+            endpoint_name=endpoint_name,
+            mi_resource=mi_resource,
+            **kwargs,
         )
-        wait_for_terminal_state(poller, **kwargs)
-
-        if existing:
-            logger.info(
-                "Updated dataflow endpoint '%s' on instance '%s'.",
-                endpoint_name,
-                instance_name,
-            )
-            return {"name": endpoint_name, "authentication": desired_authentication, "exists": True, "updated": True}
-
-        logger.info(
-            "Created dataflow endpoint '%s' on instance '%s'.",
-            endpoint_name,
-            instance_name,
-        )
-        return {"name": endpoint_name, "authentication": desired_authentication, "exists": False}
-
-    def _build_eg_endpoint_auth(self, mi_resource: Optional[Dict] = None) -> Dict:
-        """Build the authentication block for the EG MQTT dataflow endpoint."""
-        eg_audience = CloudConfig(self.cmd).eventgrid_audience
-        if mi_resource:
-            return {
-                "method": "UserAssignedManagedIdentity",
-                "userAssignedManagedIdentitySettings": {
-                    "clientId": mi_resource["properties"]["clientId"],
-                    "tenantId": mi_resource["properties"]["tenantId"],
-                    "scope": f"{eg_audience}/.default",
-                },
-            }
-        return {
-            "method": "SystemAssignedManagedIdentity",
-            "systemAssignedManagedIdentitySettings": {
-                "audience": eg_audience,
-            },
-        }
 
     def _setup_adr_management_endpoint(
         self,
@@ -2002,99 +1751,9 @@ class MgmtActions(Queryable):
 
         return {"name": dataflow_name, "exists": False}
 
-    def _resolve_user_assigned_mi(self, mi_resource_id: str) -> Dict:
-        """Fetch a user-assigned managed identity resource to extract clientId and tenantId.
-
-        Uses the base Queryable resource_client for same-subscription lookups. When the
-        UAMI is in a different subscription, creates a cross-subscription client.
-        """
-        parsed = parse_resource_id_dict(mi_resource_id)
-        mi_subscription = parsed.get("subscription", self.default_subscription_id)
-
-        if mi_subscription.lower() != self.default_subscription_id.lower():
-            from ...util.az_client import get_resource_client
-
-            client = get_resource_client(**self._get_client_kwargs(subscription_id=mi_subscription))
-        else:
-            client = self.resource_client
-
-        try:
-            return client.resources.get_by_id(
-                resource_id=mi_resource_id,
-                api_version=MANAGED_IDENTITY_API_VERSION,
-            )
-        except ResourceNotFoundError:
-            raise InvalidArgumentValueError(
-                f"User-assigned managed identity '{mi_resource_id}' not found.\n"
-                f"Verify the --mi-user-assigned value and ensure the identity exists."
-            )
-
-    def _resolve_dataflow_auth_identity(
-        self,
-        instance: Dict,
-        mi_resource: Optional[Dict] = None,
-    ) -> str:
-        """Resolve the principal ID of the identity that authenticates the dataflow endpoint.
-
-        When a UAMI is provided, its principalId is used directly. Otherwise, resolves the
-        AIO extension's system MI by traversing: instance → custom location → connected
-        cluster → extensions. The resolved principal ID is used for EG role assignments.
-        """
-        if mi_resource:
-            principal_id = mi_resource.get("properties", {}).get("principalId")
-            if not principal_id:
-                raise ValidationError(
-                    "User-assigned managed identity is missing 'principalId'.\n"
-                    "Verify the identity resource has been fully provisioned."
-                )
-            return principal_id
-
-        # Resolve AIO extension system MI via custom location → connected cluster
-        cl_id = instance.get("extendedLocation", {}).get("name")
-        if not cl_id:
-            raise ValidationError(
-                "Instance is missing 'extendedLocation.name' (custom location ID).\n"
-                "The instance may not be fully provisioned."
-            )
-
-        custom_location = self.resource_client.resources.get_by_id(
-            resource_id=cl_id,
-            api_version=CUSTOM_LOCATIONS_API_VERSION,
-        )
-
-        host_resource_id = custom_location.get("properties", {}).get("hostResourceId")
-        if not host_resource_id:
-            raise ValidationError(
-                f"Custom location '{cl_id}' is missing 'hostResourceId'.\n"
-                "Unable to resolve the connected cluster for extension identity."
-            )
-
-        cluster_parts = parse_resource_id_dict(host_resource_id)
-        connected_cluster = ConnectedCluster(
-            cmd=self.cmd,
-            subscription_id=cluster_parts.get("subscription", self.default_subscription_id),
-            cluster_name=cluster_parts["name"],
-            resource_group_name=cluster_parts["resource_group"],
-        )
-
-        ext_map = connected_cluster.get_extensions_by_type(EXTENSION_TYPE_OPS)
-        ops_ext = ext_map.get(EXTENSION_TYPE_OPS)
-        if not ops_ext:
-            raise ValidationError(
-                "IoT Operations extension not found on the connected cluster.\n"
-                "Cannot resolve the extension identity for EG role assignments.\n"
-                "Ensure 'az iot ops create' has been run successfully."
-            )
-
-        principal_id = ops_ext.get("identity", {}).get("principalId")
-        if not principal_id:
-            raise ValidationError(
-                "IoT Operations extension is missing 'identity.principalId'.\n"
-                "Cannot assign EG roles without the extension identity.\n"
-                "Please re-deploy via 'az iot ops create'."
-            )
-
-        return principal_id
+    def _resolve_dataflow_auth_identity(self, instance: Dict, mi_resource: Optional[Dict] = None) -> str:
+        """Resolve the principal ID used for EG role assignments (AIO extension MI or UAMI)."""
+        return self._resolve_ops_extension_identity(instance, mi_resource)
 
     def _setup_role_assignments(
         self,

--- a/azext_edge/edge/providers/orchestration/mgmt_actions.py
+++ b/azext_edge/edge/providers/orchestration/mgmt_actions.py
@@ -1417,7 +1417,7 @@ class MgmtActions(EventGridProviderBase):
         result["exists"] = all_exists
         return result
 
-    def _setup_eg_dataflow_endpoint(
+    def _setup_eg_dataflow_endpoint(  # pylint: disable=arguments-renamed
         self,
         eg_ctx: EgNamespaceContext,
         instance_name: str,

--- a/azext_edge/edge/util/az_client.py
+++ b/azext_edge/edge/util/az_client.py
@@ -171,6 +171,7 @@ def get_eventgrid_mgmt_client(
 
 
 class DeviceRegistryMgmtApiVersion(Enum):
+    V20261102_preview = "2026-11-02-preview"
     V20260401 = "2026-04-01"
     V20260201_preview = "2026-02-01-preview"
     V20251001 = "2025-10-01"

--- a/azext_edge/tests/conftest.py
+++ b/azext_edge/tests/conftest.py
@@ -33,6 +33,7 @@ MARKERS = [
     MarkerDefinition("rpsaas", "mark tests that are cloud-side", True),
     MarkerDefinition("upgrade", "mark tests that will run az iot ops upgrade", True),
     MarkerDefinition("mgmtactions", "mark tests that exercise az iot ops mgmt-actions end to end", True),
+    MarkerDefinition("livedata", "mark tests that exercise az iot ops live-data end to end", True),
     MarkerDefinition("init_scenario_test", "mark tests that will run az iot ops init", True),
     MarkerDefinition("require_wlif_setup", "mark tests that require workload identity trust setup", True),
     MarkerDefinition("long_running", "mark tests that take a long time to run", False),

--- a/azext_edge/tests/edge/orchestration/test_live_data_int.py
+++ b/azext_edge/tests/edge/orchestration/test_live_data_int.py
@@ -1,0 +1,353 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+"""Integration coverage for the `az iot ops live-data` command group.
+
+Exercises the full lifecycle against live Azure: enable, show, and disable,
+including idempotency on both mutating commands and role-assignment landing at
+the selected scope.
+
+The lifecycle runs once per outbound identity mode, system-assigned and
+user-assigned, because the two differ in which principal the Event Grid role
+assignments target and in the ADR namespace outbound identity written, not only
+in a config field. Unlike mgmt-actions there is no CLI `execute` equivalent —
+per-session data flow is owned by DOE — so the assertions cover the ARM
+resources the CLI provisions and the role assignments it grants.
+"""
+
+from typing import Dict, List
+from uuid import uuid4
+
+import pytest
+from knack.log import get_logger
+
+from azext_edge.edge.providers.orchestration.common import (
+    EG_TOPICSPACES_PUBLISHER_ROLE_ID,
+    EG_TOPICSPACES_SUBSCRIBER_ROLE_ID,
+)
+from azext_edge.edge.util.az_client import DEFAULT_EVENTGRID_MGMT_API_VERSION
+
+from ...helpers import assert_role_assignment, run
+
+logger = get_logger(__name__)
+
+
+def _describe_existing_state(show_result: Dict) -> List[str]:
+    """Name every Live Data sub-resource that already exists.
+
+    `show` reports `enabled` as the conjunction of every sub-resource, so a
+    partially configured instance reports False. Enabling on top of that and
+    disabling afterwards would delete resources the run did not create, so the
+    fixture refuses on any trace rather than on `enabled` alone.
+    """
+    found: List[str] = []
+
+    instance_section = show_result.get("instance") or {}
+    for key in ("dataflowProfile", "dataflowEndpoint"):
+        if (instance_section.get(key) or {}).get("exists"):
+            found.append(f"instance.{key}")
+
+    eg_section = show_result.get("eventGrid")
+    if eg_section and (eg_section.get("topicSpace") or {}).get("exists"):
+        found.append("eventGrid.topicSpace")
+
+    adr_section = show_result.get("deviceRegistryNamespace") or {}
+    if adr_section.get("observabilityEndpoint"):
+        found.append("deviceRegistryNamespace.observabilityEndpoint")
+
+    return found
+
+
+def _assert_sub_resources_exist(show_result: Dict) -> None:
+    """Every sub-resource `show` reports should exist once enable has completed."""
+    assert show_result["enabled"] is True, f"show reported disabled after enable: {show_result}"
+
+    instance_section = show_result["instance"]
+    assert instance_section["dataflowProfile"]["exists"] is True
+    assert instance_section["dataflowEndpoint"]["exists"] is True
+
+    eg_section = show_result["eventGrid"]
+    assert eg_section is not None, "eventGrid section was null, the observability endpoint was not discoverable"
+    assert eg_section["topicSpace"]["exists"] is True
+
+    adr_section = show_result["deviceRegistryNamespace"]
+    assert adr_section is not None
+    assert adr_section["observabilityEndpoint"] is not None, "ADR observability endpoint entry missing"
+    assert adr_section["observabilityEndpoint"]["address"]
+
+
+def _list_topic_space_names(eg_resource_id: str) -> List[str]:
+    """Every topic space on the namespace, following pagination."""
+    url = (
+        f"https://management.azure.com{eg_resource_id}/topicSpaces"
+        f"?api-version={DEFAULT_EVENTGRID_MGMT_API_VERSION.value}"
+    )
+    names: List[str] = []
+    while url:
+        page = run(f'az rest --method get --url "{url}"')
+        names.extend(space["name"] for space in page.get("value", []))
+        url = page.get("nextLink")
+    return names
+
+
+def _ensure_eg_namespace(request, settings, resource_group: str, location: str) -> str:
+    """Resolve the Event Grid namespace, creating a throwaway when none is supplied."""
+    eg_resource_id = settings.env.azext_edge_eg_resource_id
+    if eg_resource_id:
+        return eg_resource_id
+
+    created_eg_name = f"livedata{uuid4().hex[:10]}"
+
+    def _delete_eg_namespace() -> None:
+        try:
+            run(f"az eventgrid namespace delete -n {created_eg_name} -g {resource_group} -y")
+        except Exception:
+            logger.error(f"Failed to delete Event Grid namespace {created_eg_name}.")
+
+    request.addfinalizer(_delete_eg_namespace)
+    run("az extension add --upgrade -n eventgrid -y")
+    run(
+        f"az eventgrid namespace create -n {created_eg_name} -g {resource_group} -l {location} "
+        '--topic-spaces-configuration \'{"state":"Enabled","maximumClientSessionsPerAuthenticationName":8}\' '
+        '--sku \'{"name":"Standard","capacity":1}\''
+    )
+    return run(f"az eventgrid namespace show -n {created_eg_name} -g {resource_group}")["id"]
+
+
+@pytest.fixture(scope="module")
+def user_assigned_mi(request, settings) -> str:
+    """A user-assigned managed identity, assigned to the instance for dataflow use.
+
+    Reuses a caller-supplied identity when configured, otherwise creates a
+    throwaway. Named with uuid4 rather than the seeded generate_random_string,
+    which repeats across runs against the shared test resource group.
+    """
+    from ...settings import EnvironmentVariables
+
+    settings.add_to_config(EnvironmentVariables.user_assigned_mi_id.value)
+    resource_group = settings.env.azext_edge_rg
+    instance_name = settings.env.azext_edge_instance
+
+    mi_id = settings.env.azext_edge_user_assigned_mi_id
+    if not mi_id:
+        mi_name = f"livedata-mi-{uuid4().hex[:8]}"
+
+        def _delete_mi() -> None:
+            try:
+                run(f"az identity delete -n {mi_name} -g {resource_group}")
+            except Exception:
+                logger.error(f"Failed to delete managed identity {mi_name}.")
+
+        request.addfinalizer(_delete_mi)
+        mi_id = run(f"az identity create -n {mi_name} -g {resource_group}")["id"]
+
+        def _remove_identity() -> None:
+            try:
+                run(
+                    f"az iot ops identity remove -n {instance_name} -g {resource_group} "
+                    f'--mi-user-assigned "{mi_id}"'
+                )
+            except Exception:
+                logger.error(f"Failed to remove user-assigned identity {mi_id} from {instance_name}.")
+
+        request.addfinalizer(_remove_identity)
+
+    run(f'az iot ops identity assign -n {instance_name} -g {resource_group} --mi-user-assigned "{mi_id}"')
+    return mi_id
+
+
+@pytest.fixture(scope="module")
+def live_data_setup(request, settings):
+    """Resolve prerequisites and guarantee a clean baseline for the lifecycle.
+
+    Requires an existing IoT Operations instance backed by an ADR namespace.
+    Creates an Event Grid namespace when one is not supplied.
+    """
+    from ...settings import EnvironmentVariables
+
+    for var in (
+        EnvironmentVariables.rg,
+        EnvironmentVariables.instance,
+        EnvironmentVariables.eg_resource_id,
+    ):
+        settings.add_to_config(var.value)
+
+    instance_name = settings.env.azext_edge_instance
+    resource_group = settings.env.azext_edge_rg
+    if not all([instance_name, resource_group]):
+        raise AssertionError(
+            "Cannot run live-data tests without an instance and resource group. "
+            f"Current settings:\n {settings}"
+        )
+
+    instance = run(f"az iot ops show -n {instance_name} -g {resource_group}")
+    ns_id = instance.get("properties", {}).get("adrNamespaceRef", {}).get("resourceId")
+    if not ns_id:
+        raise AssertionError(
+            f"Instance '{instance_name}' has no ADR namespace reference, which Live Data requires."
+        )
+
+    location = run(f'az resource show --ids "{ns_id}"')["location"]
+
+    # A pre-existing enablement cannot be faithfully restored, so refuse rather
+    # than run on top of it. `enabled` alone is insufficient, since a half
+    # configured instance reports False; refuse on any trace.
+    initial_state = run(f"az iot ops live-data show -i {instance_name} -g {resource_group}")
+    existing = _describe_existing_state(initial_state)
+    if existing:
+        raise AssertionError(
+            f"Instance '{instance_name}' already has Live Data traces: {existing}. "
+            "Refusing to run so the test does not delete resources it did not create."
+        )
+
+    eg_resource_id = _ensure_eg_namespace(
+        request=request, settings=settings, resource_group=resource_group, location=location
+    )
+    common = f"-i {instance_name} -g {resource_group}"
+
+    yield {
+        "instanceName": instance_name,
+        "resourceGroup": resource_group,
+        "egResourceId": eg_resource_id,
+    }
+
+    try:
+        run(f"az iot ops live-data disable {common} -y")
+    except Exception:
+        logger.error("Failed to disable live-data during teardown.")
+
+
+@pytest.mark.livedata
+@pytest.mark.serial
+@pytest.mark.parametrize("auth_mode", ["systemAssigned", "userAssigned"])
+def test_live_data_lifecycle(request, live_data_setup, auth_mode: str) -> None:
+    """enable -> show -> disable, plus idempotency on both mutating commands.
+
+    Runs once per outbound identity mode. A user-assigned identity changes both
+    the dataflow endpoint auth block and the ADR namespace outbound identity, and
+    which principal receives the Event Grid role assignments.
+    """
+    instance_name = live_data_setup["instanceName"]
+    resource_group = live_data_setup["resourceGroup"]
+    eg_resource_id = live_data_setup["egResourceId"]
+    common = f"-i {instance_name} -g {resource_group}"
+
+    mi_id = request.getfixturevalue("user_assigned_mi") if auth_mode == "userAssigned" else None
+    enable_command = f'az iot ops live-data enable {common} --eg-resource-id "{eg_resource_id}"'
+    if mi_id:
+        enable_command += f' --mi-user-assigned "{mi_id}"'
+
+    # --- Baseline ---
+    before = run(f"az iot ops live-data show {common}")
+    assert before["enabled"] is False, "expected a clean baseline, live-data reported enabled"
+
+    def _ensure_disabled() -> None:
+        try:
+            run(f"az iot ops live-data disable {common} -y")
+        except Exception:
+            logger.error(f"Failed to disable live-data after the {auth_mode} lifecycle test.")
+
+    request.addfinalizer(_ensure_disabled)
+
+    # --- Enable ---
+    enable_result = run(enable_command)
+    topic_space_name = enable_result["eventGrid"]["topicSpace"]["name"]
+    assert topic_space_name
+    assert enable_result["instance"]["dataflowProfile"]["name"]
+    assert enable_result["instance"]["dataflowEndpoint"]["name"]
+
+    expected_method = "UserAssignedManagedIdentity" if mi_id else "SystemAssignedManagedIdentity"
+    endpoint_auth = enable_result["instance"]["dataflowEndpoint"]["authentication"]
+    assert endpoint_auth["method"] == expected_method, f"unexpected endpoint auth: {endpoint_auth}"
+
+    expected_outbound = "UserAssigned" if mi_id else "SystemAssigned"
+    outbound_identity = enable_result["deviceRegistryNamespace"]["outboundIdentity"]
+    assert outbound_identity["type"] == expected_outbound, f"unexpected outbound identity: {outbound_identity}"
+
+    # --- Role assignments landed at Event Grid namespace scope (default) ---
+    assert enable_result["roleAssignmentScope"] == "namespace"
+    role_assignments = enable_result["roleAssignments"]
+    instance_grant = role_assignments["instance"]
+    adr_grant = role_assignments["adrNamespace"]
+    assert instance_grant["roles"] == [EG_TOPICSPACES_PUBLISHER_ROLE_ID]
+    assert adr_grant["roles"] == [EG_TOPICSPACES_SUBSCRIBER_ROLE_ID]
+    assert_role_assignment(
+        scope=eg_resource_id,
+        assignee=instance_grant["principalId"],
+        expected_role_ids=instance_grant["roles"],
+    )
+    assert_role_assignment(
+        scope=eg_resource_id,
+        assignee=adr_grant["principalId"],
+        expected_role_ids=adr_grant["roles"],
+    )
+
+    # --- Show reflects reality ---
+    _assert_sub_resources_exist(run(f"az iot ops live-data show {common}"))
+
+    # --- Enable is idempotent ---
+    run(enable_command)
+    _assert_sub_resources_exist(run(f"az iot ops live-data show {common}"))
+
+    # --- Disable tears down every sub-resource ---
+    run(f"az iot ops live-data disable {common} -y")
+    after_disable = run(f"az iot ops live-data show {common}")
+    assert after_disable["enabled"] is False
+    assert after_disable["instance"]["dataflowProfile"]["exists"] is False
+    assert after_disable["instance"]["dataflowEndpoint"]["exists"] is False
+
+    # show discovers Event Grid through the ADR observability endpoint, so removing that
+    # entry takes the whole eventGrid section with it. Assert the endpoint is gone, then
+    # check the Event Grid side directly since show can no longer reach it.
+    assert after_disable["deviceRegistryNamespace"]["observabilityEndpoint"] is None
+    assert after_disable["eventGrid"] is None
+    assert topic_space_name not in _list_topic_space_names(eg_resource_id)
+
+    # --- Disable is idempotent ---
+    run(f"az iot ops live-data disable {common} -y")
+
+
+@pytest.mark.livedata
+@pytest.mark.serial
+def test_live_data_ra_scope_topic_space(request, live_data_setup) -> None:
+    """--ra-scope topic-space grants roles at the topic-space resource and removes them on disable."""
+    instance_name = live_data_setup["instanceName"]
+    resource_group = live_data_setup["resourceGroup"]
+    eg_resource_id = live_data_setup["egResourceId"]
+    common = f"-i {instance_name} -g {resource_group}"
+
+    before = run(f"az iot ops live-data show {common}")
+    assert before["enabled"] is False, "expected a clean baseline, live-data reported enabled"
+
+    def _ensure_disabled() -> None:
+        try:
+            run(f"az iot ops live-data disable {common} -y")
+        except Exception:
+            logger.error("Failed to disable live-data after the topic-space scope test.")
+
+    request.addfinalizer(_ensure_disabled)
+
+    enable_result = run(
+        f'az iot ops live-data enable {common} --eg-resource-id "{eg_resource_id}" --ra-scope topic-space'
+    )
+    assert enable_result["roleAssignmentScope"] == "topic-space"
+    topic_space_name = enable_result["eventGrid"]["topicSpace"]["name"]
+    ts_scope = f"{eg_resource_id}/topicSpaces/{topic_space_name}"
+
+    role_assignments = enable_result["roleAssignments"]
+    for key in ("instance", "adrNamespace"):
+        grant = role_assignments[key]
+        assert grant["principalId"], f"{key} has no principal after enable"
+        assert_role_assignment(
+            scope=ts_scope,
+            assignee=grant["principalId"],
+            expected_role_ids=grant["roles"],
+        )
+
+    # Disable removes the topic space, which takes the topic-space-scoped role
+    # assignments with it — nothing left orphaned.
+    run(f"az iot ops live-data disable {common} -y")
+    assert topic_space_name not in _list_topic_space_names(eg_resource_id)

--- a/azext_edge/tests/edge/orchestration/test_live_data_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_live_data_unit.py
@@ -603,6 +603,7 @@ class TestSetupAdrObservability:
             json=_build_adr_namespace_response(
                 adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid",
                 observability_endpoints={cl_id: desired},
+                outbound_identity={"type": "SystemAssigned"},
             ),
             status=200,
         )

--- a/azext_edge/tests/edge/orchestration/test_live_data_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_live_data_unit.py
@@ -1,0 +1,1270 @@
+# coding=utf-8
+# ----------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License file in the project root for license information.
+# ----------------------------------------------------------------------------------------------
+
+import json
+from typing import Optional
+
+import pytest
+import responses
+from azure.cli.core.azclierror import ValidationError
+
+from azext_edge.edge.providers.orchestration.common import (
+    EG_TOPICSPACES_PUBLISHER_ROLE_ID,
+    EG_TOPICSPACES_SUBSCRIBER_ROLE_ID,
+    LIVE_DATA_ADR_ENDPOINT_TYPE,
+    LIVE_DATA_ENDPOINT_NAME,
+    LIVE_DATA_PROFILE_NAME,
+    LIVE_DATA_TOPIC_TEMPLATE,
+    LIVE_DATA_TOPICSPACE_PREFIX,
+    LiveDataRoleScope,
+)
+from azext_edge.edge.providers.orchestration.eg_provider_base import EgNamespaceContext
+from azext_edge.edge.providers.orchestration.live_data import (
+    LiveData,
+    _build_adr_observability_put_payload,
+    get_live_data_topic_space_name,
+)
+
+from ...generators import BASE_URL, generate_random_string, generate_resource_id, get_zeroed_subscription
+
+ZEROED_SUBSCRIPTION = get_zeroed_subscription()
+DEVICEREGISTRY_RP = "Microsoft.DeviceRegistry"
+DEVICEREGISTRY_API_VERSION = "2026-11-02-preview"
+EVENTGRID_RP = "Microsoft.EventGrid"
+EVENTGRID_API_VERSION = "2025-02-15"
+IOTOPS_RP = "Microsoft.IoTOperations"
+IOTOPS_API_VERSION = "2026-07-01"
+
+MOCK_EXTENDED_LOCATION: dict = {
+    "name": (
+        f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/test-rg"
+        f"/providers/Microsoft.ExtendedLocation/customLocations/my-cl"
+    ),
+    "type": "CustomLocation",
+}
+
+
+@pytest.fixture(autouse=True)
+def suppress_workflow_display(mocker):
+    """Prevent WorkflowDisplay and render_summary from writing to stderr during tests."""
+    mocker.patch("azext_edge.edge.providers.orchestration.live_data.WorkflowDisplay")
+    mocker.patch("azext_edge.edge.providers.orchestration.live_data.render_summary")
+    mocker.patch("azext_edge.edge.providers.orchestration.live_data.console")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_eg_resource_id(
+    namespace_name: str,
+    resource_group_name: str,
+    subscription_id: Optional[str] = None,
+) -> str:
+    return generate_resource_id(
+        resource_group_name=resource_group_name,
+        resource_provider=EVENTGRID_RP,
+        resource_path=f"/namespaces/{namespace_name}",
+        resource_subscription=subscription_id,
+    )
+
+
+def _build_eg_endpoint(
+    namespace_name: str,
+    resource_group_name: str,
+    subscription_id: Optional[str] = None,
+    sub_resource: Optional[str] = None,
+) -> str:
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    url = (
+        f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+        f"/providers/{EVENTGRID_RP}/namespaces/{namespace_name}"
+    )
+    if sub_resource:
+        url += sub_resource
+    url += f"?api-version={EVENTGRID_API_VERSION}"
+    return url
+
+
+def _build_iotops_endpoint(
+    instance_name: str,
+    resource_group_name: str,
+    sub_resource: Optional[str] = None,
+) -> str:
+    url = (
+        f"{BASE_URL}/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{resource_group_name}"
+        f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+    )
+    if sub_resource:
+        url += sub_resource
+    url += f"?api-version={IOTOPS_API_VERSION}"
+    return url
+
+
+def _build_adr_namespace_resource_id(
+    namespace_name: str,
+    resource_group_name: str,
+    subscription_id: Optional[str] = None,
+) -> str:
+    return generate_resource_id(
+        resource_group_name=resource_group_name,
+        resource_provider=DEVICEREGISTRY_RP,
+        resource_path=f"/namespaces/{namespace_name}",
+        resource_subscription=subscription_id,
+    )
+
+
+def _build_adr_endpoint(
+    namespace_name: str,
+    resource_group_name: str,
+    subscription_id: Optional[str] = None,
+) -> str:
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    return (
+        f"{BASE_URL}/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+        f"/providers/{DEVICEREGISTRY_RP}/namespaces/{namespace_name}"
+        f"?api-version={DEVICEREGISTRY_API_VERSION}"
+    )
+
+
+def _build_eg_namespace_response(
+    namespace_name: str,
+    resource_group_name: str,
+    topic_spaces_state: str = "Enabled",
+    mqtt_hostname: str = "test-ns.eastus-1.ts.eventgrid.azure.net",
+    subscription_id: Optional[str] = None,
+) -> dict:
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    return {
+        "id": (
+            f"/subscriptions/{sub_id}/resourceGroups/{resource_group_name}"
+            f"/providers/{EVENTGRID_RP}/namespaces/{namespace_name}"
+        ),
+        "name": namespace_name,
+        "location": "eastus",
+        "properties": {
+            "provisioningState": "Succeeded",
+            "topicSpacesConfiguration": {
+                "state": topic_spaces_state,
+                "hostname": mqtt_hostname,
+            },
+        },
+    }
+
+
+def _build_adr_namespace_response(
+    namespace_name: str,
+    resource_group_name: str,
+    identity_type: str = "None",
+    principal_id: Optional[str] = None,
+    observability_endpoints: Optional[dict] = None,
+    outbound_identity: Optional[dict] = None,
+    subscription_id: Optional[str] = None,
+) -> dict:
+    sub_id = subscription_id or ZEROED_SUBSCRIPTION
+    identity: dict = {"type": identity_type}
+    if principal_id:
+        identity["principalId"] = principal_id
+    properties: dict = {"provisioningState": "Succeeded"}
+    if observability_endpoints is not None:
+        properties["observability"] = {"endpoints": observability_endpoints}
+    if outbound_identity is not None:
+        properties["outboundIdentity"] = outbound_identity
+    return {
+        "id": _build_adr_namespace_resource_id(namespace_name, resource_group_name, sub_id),
+        "name": namespace_name,
+        "location": "eastus",
+        "identity": identity,
+        "properties": properties,
+    }
+
+
+def _build_instance_response(
+    instance_name: str,
+    resource_group_name: str,
+    adr_namespace_name: Optional[str] = None,
+    include_adr_ref: bool = True,
+) -> dict:
+    properties: dict = {"provisioningState": "Succeeded"}
+    if include_adr_ref:
+        adr_ns_name = adr_namespace_name or f"{instance_name}-adr-ns"
+        properties["adrNamespaceRef"] = {
+            "resourceId": _build_adr_namespace_resource_id(adr_ns_name, resource_group_name)
+        }
+    return {
+        "id": (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{resource_group_name}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        ),
+        "name": instance_name,
+        "location": "eastus",
+        "extendedLocation": MOCK_EXTENDED_LOCATION,
+        "properties": properties,
+    }
+
+
+def _make_eg_ctx(
+    namespace_name: Optional[str] = None,
+    resource_group_name: Optional[str] = None,
+    mqtt_hostname: Optional[str] = None,
+) -> EgNamespaceContext:
+    ns = namespace_name or "test-ns"
+    rg = resource_group_name or "test-rg"
+    return EgNamespaceContext(
+        resource_id=_build_eg_resource_id(ns, rg),
+        subscription_id=ZEROED_SUBSCRIPTION,
+        resource_group_name=rg,
+        namespace_name=ns,
+        mqtt_hostname=mqtt_hostname or "test-ns.eastus-1.ts.eventgrid.azure.net",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic naming
+# ---------------------------------------------------------------------------
+
+
+class TestTopicSpaceName:
+    def test_deterministic_and_prefixed(self):
+        rid = _build_adr_namespace_resource_id("ns", "rg")
+        name1 = get_live_data_topic_space_name(rid)
+        name2 = get_live_data_topic_space_name(rid)
+        assert name1 == name2
+        assert name1.startswith(f"{LIVE_DATA_TOPICSPACE_PREFIX}-")
+        # prefix + hyphen + 8 hex chars
+        assert len(name1) == len(LIVE_DATA_TOPICSPACE_PREFIX) + 1 + 8
+
+    def test_distinct_instances_distinct_names(self):
+        a = get_live_data_topic_space_name(_build_adr_namespace_resource_id("nsA", "rg"))
+        b = get_live_data_topic_space_name(_build_adr_namespace_resource_id("nsB", "rg"))
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# _build_adr_observability_put_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildObservabilityPutPayload:
+    def test_removes_target_preserves_others(self):
+        cl_key = "cl-1"
+        other_key = "cl-2"
+        other_entry = {"endpointType": LIVE_DATA_ADR_ENDPOINT_TYPE, "address": "other"}
+        adr_namespace = {
+            "location": "eastus",
+            "identity": {"type": "SystemAssigned", "principalId": "pid"},
+            "tags": {"env": "test"},
+            "properties": {
+                "observability": {"endpoints": {cl_key: {"address": "mine"}, other_key: other_entry}},
+                "outboundIdentity": {"type": "SystemAssigned"},
+                "management": {"endpoints": {"cl-x": {"address": "mgmt"}}},
+                "messaging": {"endpoints": {}},
+            },
+        }
+        payload = _build_adr_observability_put_payload(adr_namespace, cl_key)
+
+        endpoints = payload["properties"]["observability"]["endpoints"]
+        assert cl_key not in endpoints
+        assert endpoints[other_key] == other_entry
+        assert payload["identity"] == {"type": "SystemAssigned", "principalId": "pid"}
+        assert payload["tags"] == {"env": "test"}
+        assert payload["properties"]["outboundIdentity"] == {"type": "SystemAssigned"}
+        assert payload["properties"]["management"] == {"endpoints": {"cl-x": {"address": "mgmt"}}}
+        assert payload["properties"]["messaging"] == {"endpoints": {}}
+        assert payload["location"] == "eastus"
+
+    def test_optional_fields_absent(self):
+        adr_namespace = {
+            "location": "eastus",
+            "properties": {"observability": {"endpoints": {"cl-1": {"address": "mine"}}}},
+        }
+        payload = _build_adr_observability_put_payload(adr_namespace, "cl-1")
+        assert payload["properties"]["observability"]["endpoints"] == {}
+        assert "identity" not in payload
+        assert "tags" not in payload
+        assert "outboundIdentity" not in payload["properties"]
+        assert "management" not in payload["properties"]
+        assert "messaging" not in payload["properties"]
+
+
+# ---------------------------------------------------------------------------
+# _setup_topic_space
+# ---------------------------------------------------------------------------
+
+
+class TestSetupTopicSpace:
+    def test_create_new(self, mocked_cmd, mocked_responses: responses):
+        ns, rg = generate_random_string(), generate_random_string()
+        instance_name = generate_random_string()
+        instance_rid = _build_adr_namespace_resource_id(instance_name, rg)
+        eg_ctx = _make_eg_ctx(namespace_name=ns, resource_group_name=rg)
+        ts_name = get_live_data_topic_space_name(instance_rid)
+
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_eg_endpoint(ns, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            json={"error": {"code": "ResourceNotFound"}},
+            status=404,
+        )
+        mocked_responses.add(
+            method=responses.PUT,
+            url=_build_eg_endpoint(ns, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            json={"id": f"/fake/topicSpaces/{ts_name}", "name": ts_name},
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_topic_space(
+            eg_ctx=eg_ctx, instance_name=instance_name, instance_resource_id=instance_rid, wait_sec=0
+        )
+
+        assert result["name"] == ts_name
+        assert result["exists"] is False
+        put_body = json.loads(mocked_responses.calls[1].request.body)
+        assert put_body["properties"]["topicTemplates"] == [LIVE_DATA_TOPIC_TEMPLATE.format(scope_id=instance_name)]
+
+    def test_existing_topic_space(self, mocked_cmd, mocked_responses: responses):
+        ns, rg = generate_random_string(), generate_random_string()
+        instance_rid = _build_adr_namespace_resource_id(generate_random_string(), rg)
+        eg_ctx = _make_eg_ctx(namespace_name=ns, resource_group_name=rg)
+        ts_name = get_live_data_topic_space_name(instance_rid)
+
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_eg_endpoint(ns, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            json={"id": f"/fake/topicSpaces/{ts_name}", "name": ts_name},
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_topic_space(
+            eg_ctx=eg_ctx, instance_name="inst", instance_resource_id=instance_rid, wait_sec=0
+        )
+        assert result["exists"] is True
+        assert len(mocked_responses.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _setup_dataflow_profile
+# ---------------------------------------------------------------------------
+
+
+class TestSetupDataflowProfile:
+    def test_create_new_instance_count_one(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}},
+            status=404,
+        )
+        mocked_responses.add(
+            method=responses.PUT,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_PROFILE_NAME},
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_dataflow_profile(
+            instance_name=instance_name,
+            resource_group_name=rg,
+            extended_location=MOCK_EXTENDED_LOCATION,
+            wait_sec=0,
+        )
+        assert result["name"] == LIVE_DATA_PROFILE_NAME
+        assert result["exists"] is False
+        put_body = json.loads(mocked_responses.calls[1].request.body)
+        assert put_body["properties"]["instanceCount"] == 1
+        assert put_body["extendedLocation"] == MOCK_EXTENDED_LOCATION
+
+    def test_existing_profile(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_PROFILE_NAME},
+            status=200,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_dataflow_profile(
+            instance_name=instance_name,
+            resource_group_name=rg,
+            extended_location=MOCK_EXTENDED_LOCATION,
+            wait_sec=0,
+        )
+        assert result["exists"] is True
+        assert len(mocked_responses.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _role_scope
+# ---------------------------------------------------------------------------
+
+
+class TestRoleScope:
+    def test_namespace_scope(self, mocked_cmd):
+        eg_ctx = _make_eg_ctx()
+        provider = LiveData(cmd=mocked_cmd)
+        scope = provider._role_scope(eg_ctx, LiveDataRoleScope.NAMESPACE, "live-data-ts-abc12345")
+        assert scope == eg_ctx.resource_id
+
+    def test_topic_space_scope(self, mocked_cmd):
+        eg_ctx = _make_eg_ctx()
+        provider = LiveData(cmd=mocked_cmd)
+        scope = provider._role_scope(eg_ctx, LiveDataRoleScope.TOPIC_SPACE, "live-data-ts-abc12345")
+        assert scope == f"{eg_ctx.resource_id}/topicSpaces/live-data-ts-abc12345"
+
+
+# ---------------------------------------------------------------------------
+# _setup_role_assignments
+# ---------------------------------------------------------------------------
+
+
+class TestSetupRoleAssignments:
+    def test_publisher_and_subscriber(self, mocked_cmd, mocker):
+        eg_ctx = _make_eg_ctx()
+        mock_pm = mocker.MagicMock()
+        mocker.patch(
+            "azext_edge.edge.providers.orchestration.live_data.PermissionManager",
+            return_value=mock_pm,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        provider.permission_manager = mock_pm
+
+        result = provider._setup_role_assignments(
+            eg_ctx=eg_ctx,
+            ra_scope=LiveDataRoleScope.NAMESPACE,
+            topic_space_name="live-data-ts-abc12345",
+            publisher_principal_id="pub-pid",
+            subscriber_principal_id="sub-pid",
+        )
+
+        assert result["instance"]["principalId"] == "pub-pid"
+        assert result["instance"]["roles"] == [EG_TOPICSPACES_PUBLISHER_ROLE_ID]
+        assert result["adrNamespace"]["principalId"] == "sub-pid"
+        assert result["adrNamespace"]["roles"] == [EG_TOPICSPACES_SUBSCRIBER_ROLE_ID]
+        # publisher + subscriber, one role each
+        assert mock_pm.apply_role_assignment.call_count == 2
+        for call in mock_pm.apply_role_assignment.call_args_list:
+            assert call.kwargs["scope"] == eg_ctx.resource_id
+
+
+# ---------------------------------------------------------------------------
+# _setup_adr_observability
+# ---------------------------------------------------------------------------
+
+
+class TestSetupAdrObservability:
+    def test_single_write_existing_sami(self, mocked_cmd, mocked_responses: responses):
+        """Existing system-assigned identity: single PATCH writes outboundIdentity + endpoint."""
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        instance = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns)
+        eg_ctx = _make_eg_ctx(resource_group_name=rg)
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+
+        # ADR GET: SAMI already enabled, no observability endpoints yet
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid", observability_endpoints={}
+            ),
+            status=200,
+        )
+        # PATCH (begin_update) returns updated namespace
+        mocked_responses.add(
+            method=responses.PATCH,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid", observability_endpoints={}
+            ),
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_adr_observability(
+            instance=instance,
+            eg_ctx=eg_ctx,
+            custom_location_id=cl_id,
+            mi_resource=None,
+            ra_scope=LiveDataRoleScope.NAMESPACE,
+            topic_space_name="live-data-ts-abc12345",
+            adr_role_ids=None,
+            skip_role_assignments=False,
+            wait_sec=0,
+        )
+
+        assert result["identity_exists"] is True
+        assert result["endpoint_exists"] is False
+        assert result["outboundIdentity"] == {"type": "SystemAssigned"}
+        assert result["identity"]["principalId"] == "adr-pid"
+        # GET + PATCH
+        assert len(mocked_responses.calls) == 2
+        patch_body = json.loads(mocked_responses.calls[1].request.body)
+        endpoints = patch_body["properties"]["observability"]["endpoints"]
+        assert cl_id in endpoints
+        assert endpoints[cl_id]["endpointType"] == LIVE_DATA_ADR_ENDPOINT_TYPE
+        assert endpoints[cl_id]["scopeId"] == instance_name
+
+    def test_staged_new_sami_grants_role_between_writes(self, mocked_cmd, mocked_responses: responses, mocker):
+        """New system-assigned identity: staged flow — identity PATCH, grant Subscriber, endpoint PATCH."""
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        instance = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns)
+        eg_ctx = _make_eg_ctx(resource_group_name=rg)
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+
+        mock_pm = mocker.MagicMock()
+        mocker.patch(
+            "azext_edge.edge.providers.orchestration.live_data.PermissionManager",
+            return_value=mock_pm,
+        )
+
+        # ADR GET: identity None (no SAMI yet)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, identity_type="None", observability_endpoints={}),
+            status=200,
+        )
+        # PATCH #1 (enable identity) returns SAMI principalId
+        mocked_responses.add(
+            method=responses.PATCH,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="new-adr-pid", observability_endpoints={}
+            ),
+            status=200,
+        )
+        # PATCH #2 (write endpoint entry)
+        mocked_responses.add(
+            method=responses.PATCH,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="new-adr-pid", observability_endpoints={}
+            ),
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        provider.permission_manager = mock_pm
+        result = provider._setup_adr_observability(
+            instance=instance,
+            eg_ctx=eg_ctx,
+            custom_location_id=cl_id,
+            mi_resource=None,
+            ra_scope=LiveDataRoleScope.NAMESPACE,
+            topic_space_name="live-data-ts-abc12345",
+            adr_role_ids=None,
+            skip_role_assignments=False,
+            wait_sec=0,
+        )
+
+        assert result["identity"]["principalId"] == "new-adr-pid"
+        # GET + PATCH1 + PATCH2
+        assert len(mocked_responses.calls) == 3
+        # Subscriber role granted between the two PATCHes
+        assert mock_pm.apply_role_assignment.call_count == 1
+        assert mock_pm.apply_role_assignment.call_args.kwargs["principal_id"] == "new-adr-pid"
+        # First PATCH has no endpoint entry; second PATCH writes it
+        patch1 = json.loads(mocked_responses.calls[1].request.body)
+        assert "observability" not in patch1["properties"]
+        patch2 = json.loads(mocked_responses.calls[2].request.body)
+        assert cl_id in patch2["properties"]["observability"]["endpoints"]
+
+    def test_already_configured_early_return(self, mocked_cmd, mocked_responses: responses):
+        """Existing SAMI and identical endpoint entry: no PATCH, early return."""
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        instance = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns)
+        eg_ctx = _make_eg_ctx(resource_group_name=rg)
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+        desired = {
+            "endpointType": LIVE_DATA_ADR_ENDPOINT_TYPE,
+            "address": eg_ctx.mqtt_hostname,
+            "scopeId": instance_name,
+            "resourceId": eg_ctx.resource_id,
+        }
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid",
+                observability_endpoints={cl_id: desired},
+            ),
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_adr_observability(
+            instance=instance, eg_ctx=eg_ctx, custom_location_id=cl_id, mi_resource=None,
+            ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="live-data-ts-abc12345",
+            adr_role_ids=None, skip_role_assignments=False, wait_sec=0,
+        )
+        assert result["identity_exists"] is True
+        assert result["endpoint_exists"] is True
+        assert len(mocked_responses.calls) == 1  # GET only, no PATCH
+
+    def test_uami_single_write(self, mocked_cmd, mocked_responses: responses):
+        """A user-assigned identity uses a single write with UserAssigned outboundIdentity."""
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        instance = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns)
+        eg_ctx = _make_eg_ctx(resource_group_name=rg)
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+        uami_rid = _build_uami_resource_id(generate_random_string(), rg)
+        mi_resource = _build_uami_response(uami_rid, "cid", "tid", "uami-pid")
+
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, identity_type="None", observability_endpoints={}),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.PATCH,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, identity_type="None", observability_endpoints={}),
+            status=200,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider._setup_adr_observability(
+            instance=instance, eg_ctx=eg_ctx, custom_location_id=cl_id, mi_resource=mi_resource,
+            ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="live-data-ts-abc12345",
+            adr_role_ids=None, skip_role_assignments=False, wait_sec=0,
+        )
+        assert result["outboundIdentity"] == {"type": "UserAssigned", "userAssignedIdentity": uami_rid}
+        assert result["identity"]["principalId"] == "uami-pid"
+        patch_body = json.loads(mocked_responses.calls[1].request.body)
+        assert patch_body["properties"]["outboundIdentity"]["type"] == "UserAssigned"
+
+    def test_no_adr_ref_raises(self, mocked_cmd):
+        instance = _build_instance_response(generate_random_string(), generate_random_string(), include_adr_ref=False)
+        provider = LiveData(cmd=mocked_cmd)
+        with pytest.raises(ValidationError, match="ADR namespace reference"):
+            provider._setup_adr_observability(
+                instance=instance, eg_ctx=_make_eg_ctx(), custom_location_id="cl",
+                mi_resource=None, ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="ts",
+                adr_role_ids=None, skip_role_assignments=False, wait_sec=0,
+            )
+
+    def test_staged_missing_principal_raises(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        instance = _build_instance_response(instance_name, rg, adr_namespace_name=adr_ns)
+        mocker.patch("azext_edge.edge.providers.orchestration.live_data.PermissionManager")
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, identity_type="None", observability_endpoints={}),
+            status=200,
+        )
+        # PATCH #1 returns SystemAssigned but WITHOUT principalId
+        mocked_responses.add(
+            method=responses.PATCH,
+            url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, identity_type="SystemAssigned", observability_endpoints={}),
+            status=200,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        with pytest.raises(ValidationError, match="no principalId"):
+            provider._setup_adr_observability(
+                instance=instance, eg_ctx=_make_eg_ctx(resource_group_name=rg), custom_location_id="cl",
+                mi_resource=None, ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="ts",
+                adr_role_ids=None, skip_role_assignments=False, wait_sec=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# _build_outbound_identity / _resolve_outbound_principal
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundIdentity:
+    def test_build_system_assigned(self, mocked_cmd):
+        provider = LiveData(cmd=mocked_cmd)
+        assert provider._build_outbound_identity(None) == {"type": "SystemAssigned"}
+
+    def test_build_user_assigned(self, mocked_cmd):
+        provider = LiveData(cmd=mocked_cmd)
+        mi = {"id": "/uami/rid", "properties": {"principalId": "pid"}}
+        assert provider._build_outbound_identity(mi) == {"type": "UserAssigned", "userAssignedIdentity": "/uami/rid"}
+
+    def test_resolve_principal_uami(self, mocked_cmd):
+        provider = LiveData(cmd=mocked_cmd)
+        assert provider._resolve_outbound_principal({"properties": {"principalId": "pid"}}, {}) == "pid"
+
+    def test_resolve_principal_sami(self, mocked_cmd):
+        provider = LiveData(cmd=mocked_cmd)
+        assert provider._resolve_outbound_principal(None, {"principalId": "sami-pid"}) == "sami-pid"
+
+    def test_resolve_principal_missing_raises(self, mocked_cmd):
+        provider = LiveData(cmd=mocked_cmd)
+        with pytest.raises(ValidationError, match="outbound identity principal"):
+            provider._resolve_outbound_principal(None, {})
+
+
+# ---------------------------------------------------------------------------
+# Role-assignment error paths
+# ---------------------------------------------------------------------------
+
+
+class TestRoleAssignmentErrors:
+    def test_setup_role_assignments_http_error(self, mocked_cmd, mocker):
+        from azure.core.exceptions import HttpResponseError
+
+        eg_ctx = _make_eg_ctx()
+        mock_pm = mocker.MagicMock()
+        mock_pm.apply_role_assignment.side_effect = HttpResponseError(message="denied")
+        mocker.patch(
+            "azext_edge.edge.providers.orchestration.live_data.PermissionManager", return_value=mock_pm
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        provider.permission_manager = mock_pm
+        with pytest.raises(ValidationError, match="Failed to assign role"):
+            provider._setup_role_assignments(
+                eg_ctx=eg_ctx, ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="ts",
+                publisher_principal_id="pub", subscriber_principal_id="sub",
+            )
+
+    def test_assign_subscriber_role_http_error(self, mocked_cmd, mocker):
+        from azure.core.exceptions import HttpResponseError
+
+        eg_ctx = _make_eg_ctx()
+        mock_pm = mocker.MagicMock()
+        mock_pm.apply_role_assignment.side_effect = HttpResponseError(message="denied")
+        mocker.patch(
+            "azext_edge.edge.providers.orchestration.live_data.PermissionManager", return_value=mock_pm
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        provider.permission_manager = mock_pm
+        with pytest.raises(ValidationError, match="Failed to assign Subscriber role"):
+            provider._assign_subscriber_role(
+                eg_ctx=eg_ctx, ra_scope=LiveDataRoleScope.NAMESPACE, topic_space_name="ts",
+                principal_id="sub", adr_role_ids=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# enable()
+# ---------------------------------------------------------------------------
+
+
+def _register_enable_mocks(
+    mocked_responses: responses,
+    instance_name: str,
+    rg: str,
+    ns_name: str,
+    adr_ns: str,
+    eg_rid: str,
+    hostname: str,
+    instance_rid: str,
+    *,
+    mi_response: Optional[dict] = None,
+) -> None:
+    ts_name = get_live_data_topic_space_name(instance_rid)
+    # 1. instance GET
+    mocked_responses.add(
+        method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+        json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+    )
+    # 2. EG namespace GET (validation)
+    mocked_responses.add(
+        method=responses.GET, url=_build_eg_endpoint(ns_name, rg),
+        json=_build_eg_namespace_response(ns_name, rg, mqtt_hostname=hostname), status=200,
+    )
+    # 3. (optional) UAMI GET
+    if mi_response is not None:
+        mocked_responses.add(
+            method=responses.GET, url=_build_uami_endpoint(mi_response["id"]), json=mi_response, status=200,
+        )
+    # topic space GET 404 + PUT
+    mocked_responses.add(
+        method=responses.GET, url=_build_eg_endpoint(ns_name, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+        json={"error": {"code": "ResourceNotFound"}}, status=404,
+    )
+    mocked_responses.add(
+        method=responses.PUT, url=_build_eg_endpoint(ns_name, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+        json={"id": "/fake", "name": ts_name}, status=200,
+    )
+    # dataflow profile GET 404 + PUT
+    mocked_responses.add(
+        method=responses.GET,
+        url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+        json={"error": {"code": "ResourceNotFound"}}, status=404,
+    )
+    mocked_responses.add(
+        method=responses.PUT,
+        url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+        json={"id": "/fake", "name": LIVE_DATA_PROFILE_NAME}, status=200,
+    )
+    # dataflow endpoint GET 404 + PUT
+    mocked_responses.add(
+        method=responses.GET,
+        url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+        json={"error": {"code": "ResourceNotFound"}}, status=404,
+    )
+    mocked_responses.add(
+        method=responses.PUT,
+        url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+        json={"id": "/fake", "name": LIVE_DATA_ENDPOINT_NAME}, status=200,
+    )
+    # ADR GET (SAMI enabled) + PATCH
+    mocked_responses.add(
+        method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+        json=_build_adr_namespace_response(
+            adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid", observability_endpoints={}
+        ),
+        status=200,
+    )
+    mocked_responses.add(
+        method=responses.PATCH, url=_build_adr_endpoint(adr_ns, rg),
+        json=_build_adr_namespace_response(
+            adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid", observability_endpoints={}
+        ),
+        status=200,
+    )
+
+
+class TestEnable:
+    def test_happy_path_sami(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        mocker.patch.object(LiveData, "_resolve_ops_extension_identity", return_value="pub-pid")
+        mocker.patch.object(
+            LiveData, "_setup_role_assignments",
+            return_value={"instance": {"principalId": "pub-pid"}, "adrNamespace": {"principalId": "adr-pid"}},
+        )
+        _register_enable_mocks(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, instance_rid)
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.enable(
+            name=instance_name, resource_group_name=rg, eg_resource_id=eg_rid, wait_sec=0,
+        )
+
+        assert set(result.keys()) == {
+            "instance", "eventGrid", "deviceRegistryNamespace", "roleAssignmentScope", "roleAssignments"
+        }
+        assert result["roleAssignmentScope"] == "namespace"
+        assert result["instance"]["dataflowProfile"]["name"] == LIVE_DATA_PROFILE_NAME
+        assert result["instance"]["dataflowEndpoint"]["name"] == LIVE_DATA_ENDPOINT_NAME
+        assert result["eventGrid"]["namespace"]["name"] == ns_name
+        assert result["deviceRegistryNamespace"]["outboundIdentity"] == {"type": "SystemAssigned"}
+
+    def test_cloud_gate_blocks(self, mocked_cmd, mocker):
+        cloud = mocker.MagicMock()
+        cloud.supports_eventgrid_mqtt = False
+        mocker.patch("azext_edge.edge.providers.orchestration.live_data.CloudConfig", return_value=cloud)
+        provider = LiveData(cmd=mocked_cmd)
+        with pytest.raises(ValidationError, match="not available in this cloud"):
+            provider.enable(name="i", resource_group_name="rg", eg_resource_id="eg", wait_sec=0)
+
+    def test_skip_role_assignments(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        setup_ra = mocker.patch.object(LiveData, "_setup_role_assignments")
+        _register_enable_mocks(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, instance_rid)
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.enable(
+            name=instance_name, resource_group_name=rg, eg_resource_id=eg_rid,
+            skip_role_assignments=True, wait_sec=0,
+        )
+        assert "roleAssignments" not in result
+        setup_ra.assert_not_called()
+
+    def test_ra_scope_topic_space(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        mocker.patch.object(LiveData, "_resolve_ops_extension_identity", return_value="pub-pid")
+        mocker.patch.object(LiveData, "_setup_role_assignments", return_value={})
+        _register_enable_mocks(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, instance_rid)
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.enable(
+            name=instance_name, resource_group_name=rg, eg_resource_id=eg_rid,
+            ra_scope="topic-space", wait_sec=0,
+        )
+        assert result["roleAssignmentScope"] == "topic-space"
+
+
+# ---------------------------------------------------------------------------
+# show()
+# ---------------------------------------------------------------------------
+
+
+class TestShow:
+    def _register_show_mocks(self, mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, ts_name):
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+        obs_endpoint = {
+            "endpointType": LIVE_DATA_ADR_ENDPOINT_TYPE, "address": hostname,
+            "scopeId": instance_name, "resourceId": eg_rid,
+        }
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid",
+                observability_endpoints={cl_id: obs_endpoint}, outbound_identity={"type": "SystemAssigned"},
+            ),
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_eg_endpoint(ns_name, rg),
+            json=_build_eg_namespace_response(ns_name, rg, mqtt_hostname=hostname), status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_eg_endpoint(ns_name, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            json={
+                "id": "/fake", "name": ts_name,
+                "properties": {"topicTemplates": [LIVE_DATA_TOPIC_TEMPLATE.format(scope_id=instance_name)]},
+            },
+            status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_PROFILE_NAME}, status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_ENDPOINT_NAME}, status=200,
+        )
+
+    def test_enabled_all_present(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        ts_name = get_live_data_topic_space_name(instance_rid)
+        self._register_show_mocks(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, ts_name)
+
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.show(name=instance_name, resource_group_name=rg)
+        assert result["enabled"] is True
+        assert result["deviceRegistryNamespace"]["name"] == adr_ns
+        assert result["eventGrid"]["topicSpace"]["exists"] is True
+        assert result["instance"]["dataflowProfile"]["exists"] is True
+
+    def test_no_adr_ref(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, include_adr_ref=False), status=200,
+        )
+        # show() always probes the dedicated dataflow profile + endpoint (absent here)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.show(name=instance_name, resource_group_name=rg)
+        assert result["enabled"] is False
+        assert result["deviceRegistryNamespace"] is None
+
+    def test_adr_not_found(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.show(name=instance_name, resource_group_name=rg)
+        assert result["enabled"] is False
+        assert result["deviceRegistryNamespace"] is None
+
+    def test_disabled_endpoint_absent(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+        )
+        # ADR present but no observability endpoints
+        mocked_responses.add(
+            method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid", observability_endpoints={}
+            ),
+            status=200,
+        )
+        # No EG context (obs endpoint absent) → EG skipped; dataflow profile + endpoint probed (absent)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        result = provider.show(name=instance_name, resource_group_name=rg)
+        assert result["enabled"] is False
+        assert result["eventGrid"] is None
+
+
+# ---------------------------------------------------------------------------
+# disable()
+# ---------------------------------------------------------------------------
+
+
+PROMPT_TARGET = "azext_edge.edge.providers.orchestration.live_data.should_continue_prompt"
+
+
+class TestDisable:
+    def _register_discovery(self, mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, ts_name):
+        cl_id = MOCK_EXTENDED_LOCATION["name"]
+        obs_endpoint = {
+            "endpointType": LIVE_DATA_ADR_ENDPOINT_TYPE, "address": hostname,
+            "scopeId": instance_name, "resourceId": eg_rid,
+        }
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(
+                adr_ns, rg, identity_type="SystemAssigned", principal_id="adr-pid",
+                observability_endpoints={cl_id: obs_endpoint},
+            ),
+            status=200,
+        )
+        # probe: profile, endpoint, topic space (all present)
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_PROFILE_NAME}, status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            json={"id": "/fake", "name": LIVE_DATA_ENDPOINT_NAME}, status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_eg_endpoint(ns_name, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            json={"id": "/fake", "name": ts_name}, status=200,
+        )
+
+    def test_full_teardown(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        ts_name = get_live_data_topic_space_name(instance_rid)
+        mocker.patch(PROMPT_TARGET, return_value=True)
+        self._register_discovery(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, ts_name)
+        # teardown: ADR PUT (remove endpoint), profile DELETE, endpoint DELETE, topic space DELETE
+        mocked_responses.add(
+            method=responses.PUT, url=_build_adr_endpoint(adr_ns, rg),
+            json=_build_adr_namespace_response(adr_ns, rg, observability_endpoints={}), status=200,
+        )
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowProfiles/{LIVE_DATA_PROFILE_NAME}"),
+            status=204,
+        )
+        mocked_responses.add(
+            method=responses.DELETE,
+            url=_build_iotops_endpoint(instance_name, rg, sub_resource=f"/dataflowEndpoints/{LIVE_DATA_ENDPOINT_NAME}"),
+            status=204,
+        )
+        mocked_responses.add(
+            method=responses.DELETE, url=_build_eg_endpoint(ns_name, rg, sub_resource=f"/topicSpaces/{ts_name}"),
+            status=204,
+        )
+
+        provider = LiveData(cmd=mocked_cmd)
+        provider.disable(name=instance_name, resource_group_name=rg, confirm_yes=True, wait_sec=0)
+        methods = [c.request.method for c in mocked_responses.calls]
+        assert methods.count("DELETE") == 3
+        assert "PUT" in methods  # endpoint entry removed via begin_create_or_replace
+
+    def test_no_adr_ref_early_return(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, include_adr_ref=False), status=200,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        provider.disable(name=instance_name, resource_group_name=rg, confirm_yes=True, wait_sec=0)
+        assert len(mocked_responses.calls) == 1
+
+    def test_adr_not_found_early_return(self, mocked_cmd, mocked_responses: responses):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        mocked_responses.add(
+            method=responses.GET, url=_build_iotops_endpoint(instance_name, rg),
+            json=_build_instance_response(instance_name, rg, adr_namespace_name=adr_ns), status=200,
+        )
+        mocked_responses.add(
+            method=responses.GET, url=_build_adr_endpoint(adr_ns, rg),
+            json={"error": {"code": "ResourceNotFound"}}, status=404,
+        )
+        provider = LiveData(cmd=mocked_cmd)
+        provider.disable(name=instance_name, resource_group_name=rg, confirm_yes=True, wait_sec=0)
+        assert len(mocked_responses.calls) == 2
+
+    def test_prompt_declined(self, mocked_cmd, mocked_responses: responses, mocker):
+        rg = generate_random_string()
+        instance_name = generate_random_string()
+        ns_name = generate_random_string()
+        adr_ns = f"{instance_name}-adr-ns"
+        eg_rid = _build_eg_resource_id(ns_name, rg)
+        hostname = f"{ns_name}.eastus-1.ts.eventgrid.azure.net"
+        instance_rid = (
+            f"/subscriptions/{ZEROED_SUBSCRIPTION}/resourceGroups/{rg}"
+            f"/providers/{IOTOPS_RP}/instances/{instance_name}"
+        )
+        ts_name = get_live_data_topic_space_name(instance_rid)
+        mocker.patch(PROMPT_TARGET, return_value=False)
+        self._register_discovery(mocked_responses, instance_name, rg, ns_name, adr_ns, eg_rid, hostname, ts_name)
+
+        provider = LiveData(cmd=mocked_cmd)
+        provider.disable(name=instance_name, resource_group_name=rg, wait_sec=0)
+        methods = [c.request.method for c in mocked_responses.calls]
+        assert "DELETE" not in methods
+        assert "PUT" not in methods
+
+
+# ---------------------------------------------------------------------------
+# Command adapters
+# ---------------------------------------------------------------------------
+
+
+class TestCommandAdapters:
+    def test_enable_delegates(self, mocker):
+        from azext_edge.edge import commands_live_data
+
+        mock_provider = mocker.MagicMock()
+        mocker.patch.object(commands_live_data, "LiveData", return_value=mock_provider)
+        commands_live_data.live_data_enable(
+            cmd=mocker.MagicMock(), instance_name="i", resource_group_name="rg", eg_resource_id="eg",
+        )
+        mock_provider.enable.assert_called_once()
+        assert mock_provider.enable.call_args.kwargs["name"] == "i"
+
+    def test_show_delegates(self, mocker):
+        from azext_edge.edge import commands_live_data
+
+        mock_provider = mocker.MagicMock()
+        mocker.patch.object(commands_live_data, "LiveData", return_value=mock_provider)
+        commands_live_data.live_data_show(cmd=mocker.MagicMock(), instance_name="i", resource_group_name="rg")
+        mock_provider.show.assert_called_once()
+
+    def test_disable_delegates(self, mocker):
+        from azext_edge.edge import commands_live_data
+
+        mock_provider = mocker.MagicMock()
+        mocker.patch.object(commands_live_data, "LiveData", return_value=mock_provider)
+        commands_live_data.live_data_disable(cmd=mocker.MagicMock(), instance_name="i", resource_group_name="rg")
+        mock_provider.disable.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# UAMI helpers (module-level; resolved at test run time)
+# ---------------------------------------------------------------------------
+
+UAMI_API_VERSION = "2023-01-31"
+
+
+def _build_uami_resource_id(name: str, rg: str, subscription_id: Optional[str] = None) -> str:
+    sub = subscription_id or ZEROED_SUBSCRIPTION
+    return (
+        f"/subscriptions/{sub}/resourceGroups/{rg}"
+        f"/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}"
+    )
+
+
+def _build_uami_endpoint(mi_resource_id: str) -> str:
+    return f"{BASE_URL}{mi_resource_id}?api-version={UAMI_API_VERSION}"
+
+
+def _build_uami_response(mi_resource_id: str, client_id: str, tenant_id: str, principal_id: str) -> dict:
+    return {
+        "id": mi_resource_id,
+        "properties": {"clientId": client_id, "tenantId": tenant_id, "principalId": principal_id},
+    }

--- a/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_mgmt_actions_unit.py
@@ -3403,18 +3403,18 @@ class TestDisable:
 
         # instance GET + ADR GET + graph detect GET + ep detect GET +
         # EG ts GET + EG pub GET + EG sub GET +
-        # resp DELETE + graph DELETE + ep DELETE + ADR PUT +
-        # pub DELETE + sub DELETE + ts DELETE = 14
+        # resp DELETE + graph DELETE + ep DELETE +
+        # pub DELETE + sub DELETE + ts DELETE + ADR PUT = 14
         assert len(mocked_responses.calls) == 14
 
-        # Verify full call sequence: discovery GETs → AIO DELETEs → ADR PUT → EG DELETEs
+        # Verify full call sequence: discovery GETs → AIO DELETEs → EG DELETEs → ADR PUT
         call_methods = [c.request.method for c in mocked_responses.calls]
         assert call_methods == [
             "GET", "GET", "GET", "GET",     # instance, ADR, graph detect, ep detect
             "GET", "GET", "GET",             # EG ts, pub, sub existence
             "DELETE", "DELETE", "DELETE",    # resp dataflow, graph, endpoint
-            "PUT",                           # ADR namespace update (full replace)
             "DELETE", "DELETE", "DELETE",    # pub binding, sub binding, topic space
+            "PUT",                           # ADR namespace update (full replace) — removed last
         ]
 
         # Verify mutation calls target expected resources
@@ -3426,10 +3426,10 @@ class TestDisable:
         assert f"/dataflows/{f['resp_name']}" in mut_paths[0]
         assert f"/dataflowGraphs/{f['graph_name']}" in mut_paths[1]
         assert f"/dataflowEndpoints/{f['ep_name']}" in mut_paths[2]
-        assert f"/providers/{DEVICEREGISTRY_RP}/namespaces/{f['adr_ns_name']}" in mut_paths[3]
-        assert f"/permissionBindings/{f['pub_name']}" in mut_paths[4]
-        assert f"/permissionBindings/{f['sub_name']}" in mut_paths[5]
-        assert f"/topicSpaces/{f['ts_name']}" in mut_paths[6]
+        assert f"/permissionBindings/{f['pub_name']}" in mut_paths[3]
+        assert f"/permissionBindings/{f['sub_name']}" in mut_paths[4]
+        assert f"/topicSpaces/{f['ts_name']}" in mut_paths[5]
+        assert f"/providers/{DEVICEREGISTRY_RP}/namespaces/{f['adr_ns_name']}" in mut_paths[6]
 
     def test_confirmation_cancel(self, mocked_cmd, mocked_responses: responses, mocker):
         """Cancellation via should_continue_prompt stops all deletions."""

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ commands =
     --junitxml=junit/test-aziotops-ext-unit.xml {posargs}
 
 # integration tests
-[testenv:python-{init,e2e,rpsaas,upgrade,mgmtactions,long,wlif,edge,all}-int]
+[testenv:python-{init,e2e,rpsaas,upgrade,mgmtactions,livedata,long,wlif,edge,all}-int]
 skip_install = True
 description =
     {[base]description}
@@ -71,6 +71,7 @@ description =
     rpsaas: marked cloud
     upgrade: marked upgrade
     mgmtactions: marked mgmt-actions
+    livedata: marked live-data
     long: marked long-running
     edge: non-marked (default)
     all: all (except init, wlif)
@@ -94,6 +95,7 @@ setenv =
     edge: SCENARIO="edge"
     upgrade: SCENARIO="upgrade"
     mgmtactions: SCENARIO="mgmtactions"
+    livedata: SCENARIO="livedata"
     all: SCENARIO="not init_scenario_test and not require_wlif_setup"
 commands =
     python --version


### PR DESCRIPTION
- Adds the preview az iot ops live-data command group (`enable`,  `show`,  `disable`) to configure and inspect Live Data observability for an IoT Operations instance.

- Delivers a complete, idempotent lifecycle: enabling wires up the supporting Event Grid, Device Registry, and dataflow resources; `show` reports consolidated status; `disable` cleanly tears everything down.

- Extracts the shared Event Grid and identity setup into a common base so Live Data and Management Actions stay consistent and avoid duplicated behavior.

- Hardens the disable flow so an interrupted run can be safely re-run without leaving orphaned resources (applies to both Live Data and Management Actions).

- Includes full unit-test coverage and live integration tests for the new command group.

Enable:

<img width="2257" height="832" alt="image" src="https://github.com/user-attachments/assets/a68e52f5-ee57-445d-8803-dd0eae3ade9c" />

<img width="2257" height="1737" alt="image" src="https://github.com/user-attachments/assets/7b02ef5d-1099-4fd5-b4de-7a6936bfff0f" />

<img width="2263" height="495" alt="image" src="https://github.com/user-attachments/assets/2f94dee2-5278-437d-92f3-456c8b353989" />

Staged Enable:

<img width="2282" height="657" alt="image" src="https://github.com/user-attachments/assets/75a9b79f-d1d7-49b6-a0e9-ef678bf3b80f" />


Show:

<img width="2256" height="388" alt="image" src="https://github.com/user-attachments/assets/a3444b70-54ec-4a3d-bd6c-2b3617031b50" />


<img width="1503" height="1235" alt="image" src="https://github.com/user-attachments/assets/c2c1361b-e7b1-4cad-ad6a-3f08014e67ab" />


Disable:

<img width="2258" height="602" alt="image" src="https://github.com/user-attachments/assets/df087ec3-4876-4eaa-b7ef-bffccc9c1eca" />


<img width="2272" height="1215" alt="image" src="https://github.com/user-attachments/assets/236b57a2-0f51-4e6e-8ccc-c448ff675f5f" />

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
