### PR TITLE
fix: skip OPC UA connector template when opcua feature is disabled

### DIFF
--- a/.github/test-scenarios.yml
+++ b/.github/test-scenarios.yml
@@ -27,10 +27,6 @@ scenarios:
     description: "Cloud tests"
     tox_env: python-rpsaas-int
 
-  - name: opcuaoff
-    description: "Create with OPC UA disabled"
-    create_args: "--feature opcua.mode=Disabled"
-
   - name: upgrade
     description: "Upgrade tests"
     tox_env: python-upgrade-int
@@ -42,8 +38,9 @@ scenarios:
     parallel: false
 
   - name: redeploy
-    description: "Redeployment tests"
+    description: "Redeployment tests (OPC UA disabled)"
     test_redeploy: true
+    create_args: "--feature opcua.mode=Disabled"
 
   - name: trustbundle
     description: "Workload identity tests"

--- a/.github/test-scenarios.yml
+++ b/.github/test-scenarios.yml
@@ -27,6 +27,10 @@ scenarios:
     description: "Cloud tests"
     tox_env: python-rpsaas-int
 
+  - name: opcuaoff
+    description: "Create with OPC UA disabled"
+    create_args: "--feature opcua.mode=Disabled"
+
   - name: upgrade
     description: "Upgrade tests"
     tox_env: python-upgrade-int

--- a/azext_edge/constants.py
+++ b/azext_edge/constants.py
@@ -7,8 +7,8 @@
 
 import os
 
-VERSION = "2.9.0"
+VERSION = "2.10.0a1"
 EXTENSION_NAME = "azure-iot-ops"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 USER_AGENT = "IotOperationsCliExtension/{}".format(VERSION)
-AIO_RELEASE = "2608"
+AIO_RELEASE = "2609"

--- a/azext_edge/edge/providers/orchestration/common.py
+++ b/azext_edge/edge/providers/orchestration/common.py
@@ -444,7 +444,7 @@ OPCUA_CONNECTOR_METADATA_REF = "mcr.microsoft.com/azureiotoperations/aio-connect
 OPCUA_CONNECTOR_AIO_MIN_VERSION = "1.2.100"
 # Connectors component image tag stamped on the template (distinct from the AIO extension
 # version). Bump per release from the publishing capture step's connectors.image.tag.
-OPCUA_CONNECTOR_VERSION = "1.4.10"
+OPCUA_CONNECTOR_VERSION = "1.4.13"
 
 # Management Actions
 EG_TOPICSPACES_PUBLISHER_ROLE_ID = "a12b0b94-b317-4dcd-84a8-502ce99884c6"

--- a/azext_edge/edge/providers/orchestration/resources/connector_templates.py
+++ b/azext_edge/edge/providers/orchestration/resources/connector_templates.py
@@ -22,7 +22,7 @@ import tarfile
 import tempfile
 from contextlib import nullcontext
 import hashlib
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from azure.cli.core.azclierror import (
     InvalidArgumentValueError,
@@ -31,6 +31,7 @@ from azure.cli.core.azclierror import (
     ValidationError,
     CLIInternalError,
 )
+from azure.core.exceptions import HttpResponseError
 from knack.log import get_logger
 from rich.console import Console
 
@@ -289,6 +290,35 @@ class ConnectorTemplates(Queryable):
                 headers=headers or {},
             )
             return wait_for_terminal_state(poller=poller, logger=logger)
+
+    def check_default_opcua_template_needed(
+        self,
+        instance_name: str,
+        resource_group_name: str,
+    ) -> Tuple[bool, Optional[str]]:
+        """Return (needed, repair_name) for the default OPC UA connector template.
+
+        A prefix-matching template in a terminal ``Failed`` state is repaired in place by reusing
+        its name (``repair_name``); a ``Succeeded`` or transient template is left untouched so user
+        customizations and in-flight provisioning are preserved. If none exists, a new default is
+        needed. Shared by the upgrade backfill and the update re-enable path.
+        """
+        from ..common import OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX, PROVISIONING_STATE_FAILED
+
+        try:
+            existing_templates = self.list(instance_name=instance_name, resource_group_name=resource_group_name)
+            for template in existing_templates:
+                if not (template.get("name") or "").lower().startswith(OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX):
+                    continue
+                if (template.get("provisioningState") or "").lower() == PROVISIONING_STATE_FAILED.lower():
+                    logger.debug("Default OPC UA connector template exists but failed; will repair in place.")
+                    return True, template.get("name")
+                logger.debug("Default OPC UA connector template already exists.")
+                return False, None
+            return True, None
+        except HttpResponseError as e:
+            logger.debug(f"Error checking OPC UA connector template: {e}")
+            return False, None
 
     @staticmethod
     def default_opcua_template_name(instance_name: str) -> str:

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -273,11 +273,17 @@ class Instances(Queryable):
         if description:
             instance["properties"]["description"] = description
 
+        opcua_needs_backfill = False
         if features:
             desired_features = parse_feature_kvp_nargs(features, strict=True)
-            current_features: dict = instance["properties"].get("features", {})
+            current_features: dict = instance["properties"].get("features", {}) or {}
+            prior_opcua_mode = (current_features.get("opcua") or {}).get("mode")
             current_features.update(desired_features)
             instance["properties"]["features"] = current_features
+            new_opcua_mode = (current_features.get("opcua") or {}).get("mode")
+            # Enabling OPC UA from Disabled needs the default connector template the create path skips
+            # while disabled; without it the supervisor has nothing to reconcile.
+            opcua_needs_backfill = prior_opcua_mode == "Disabled" and new_opcua_mode not in (None, "Disabled")
 
         if adr_namespace_resource_id:
             instance["properties"]["adrNamespaceRef"] = {"resourceId": adr_namespace_resource_id}
@@ -296,7 +302,19 @@ class Instances(Queryable):
                 resource=instance,
                 **operation_kwargs,
             )
-            return wait_for_terminal_state(poller, **kwargs)
+            result = wait_for_terminal_state(poller, **kwargs)
+            if opcua_needs_backfill:
+                from .connector_templates import ConnectorTemplates
+                from ..common import OPCUA_CONNECTOR_VERSION
+
+                ConnectorTemplates(self.cmd).create_default_opcua_template(
+                    resource_group_name=resource_group_name,
+                    instance_name=name,
+                    connector_version=OPCUA_CONNECTOR_VERSION,
+                    headers=headers,
+                    no_status=no_status,
+                )
+            return result
 
     def remove_mi_user_assigned(
         self,

--- a/azext_edge/edge/providers/orchestration/resources/instances.py
+++ b/azext_edge/edge/providers/orchestration/resources/instances.py
@@ -273,17 +273,16 @@ class Instances(Queryable):
         if description:
             instance["properties"]["description"] = description
 
-        opcua_needs_backfill = False
+        opcua_backfill_requested = False
         if features:
             desired_features = parse_feature_kvp_nargs(features, strict=True)
             current_features: dict = instance["properties"].get("features", {}) or {}
-            prior_opcua_mode = (current_features.get("opcua") or {}).get("mode")
             current_features.update(desired_features)
             instance["properties"]["features"] = current_features
-            new_opcua_mode = (current_features.get("opcua") or {}).get("mode")
-            # Enabling OPC UA from Disabled needs the default connector template the create path skips
-            # while disabled; without it the supervisor has nothing to reconcile.
-            opcua_needs_backfill = prior_opcua_mode == "Disabled" and new_opcua_mode not in (None, "Disabled")
+            requested_opcua_mode = (desired_features.get("opcua") or {}).get("mode")
+            # Enabling OPC UA needs the default connector template the create path skips while
+            # disabled; running on any enable request also lets a repeat repair a partial attempt.
+            opcua_backfill_requested = requested_opcua_mode not in (None, "Disabled")
 
         if adr_namespace_resource_id:
             instance["properties"]["adrNamespaceRef"] = {"resourceId": adr_namespace_resource_id}
@@ -303,17 +302,23 @@ class Instances(Queryable):
                 **operation_kwargs,
             )
             result = wait_for_terminal_state(poller, **kwargs)
-            if opcua_needs_backfill:
+            if opcua_backfill_requested:
                 from .connector_templates import ConnectorTemplates
                 from ..common import OPCUA_CONNECTOR_VERSION
 
-                ConnectorTemplates(self.cmd).create_default_opcua_template(
-                    resource_group_name=resource_group_name,
-                    instance_name=name,
-                    connector_version=OPCUA_CONNECTOR_VERSION,
-                    headers=headers,
-                    no_status=no_status,
+                connector_templates = ConnectorTemplates(self.cmd)
+                needed, repair_name = connector_templates.check_default_opcua_template_needed(
+                    instance_name=name, resource_group_name=resource_group_name
                 )
+                if needed:
+                    connector_templates.create_default_opcua_template(
+                        resource_group_name=resource_group_name,
+                        instance_name=name,
+                        connector_version=OPCUA_CONNECTOR_VERSION,
+                        template_name=repair_name,
+                        headers=headers,
+                        no_status=no_status,
+                    )
             return result
 
     def remove_mi_user_assigned(

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -251,24 +251,19 @@ class InitTargets:
     ) -> Tuple[dict, dict]:
         if not cl_extension_ids:
             cl_extension_ids = []
-        param_to_target = {
-            "clusterName": self.cluster_name,
-            "clusterNamespace": self.cluster_namespace,
-            "clusterLocation": self.location,
-            "customLocationName": self.custom_location_name,
-            "clExtensionIds": cl_extension_ids,
-            "schemaRegistryId": self.schema_registry_resource_id,
-            "adrNamespaceId": self.adr_namespace_resource_id,
-            "defaultDataflowInstanceCount": self.dataflow_profile_instances,
-            "brokerConfig": self.broker_config,
-            "trustConfig": self.trust_config,
-        }
-        # Drive the template's OPC UA connector condition; the instance features are injected
-        # directly (not via the features parameter), so gate on the parameter the condition reads.
-        if self.instance_features and self.instance_features.get("opcua", {}).get("mode") == "Disabled":
-            param_to_target["disableOpcUaFeature"] = True
         template, parameters = self._handle_apply_targets(
-            param_to_target=param_to_target,
+            param_to_target={
+                "clusterName": self.cluster_name,
+                "clusterNamespace": self.cluster_namespace,
+                "clusterLocation": self.location,
+                "customLocationName": self.custom_location_name,
+                "clExtensionIds": cl_extension_ids,
+                "schemaRegistryId": self.schema_registry_resource_id,
+                "adrNamespaceId": self.adr_namespace_resource_id,
+                "defaultDataflowInstanceCount": self.dataflow_profile_instances,
+                "brokerConfig": self.broker_config,
+                "trustConfig": self.trust_config,
+            },
             template_blueprint=TEMPLATE_BLUEPRINT_INSTANCE,
         )
 
@@ -317,6 +312,10 @@ class InitTargets:
             )
 
         resources: Dict[str, Dict[str, dict]] = template.content.get("resources", {})
+        # OPC UA disabled: drop the connector template so it is never deployed; no supervisor
+        # reconciles it, so its provisioning would otherwise never reach a terminal state.
+        if self.instance_features and self.instance_features.get("opcua", {}).get("mode") == "Disabled":
+            resources.pop("opcUaConnectorTemplate", None)
         if phase == InstancePhase.EXT:
             del_if_not_in(resources, PHASE_KEY_MAP[InstancePhase.EXT])
             return template.content, parameters

--- a/azext_edge/edge/providers/orchestration/targets.py
+++ b/azext_edge/edge/providers/orchestration/targets.py
@@ -251,19 +251,24 @@ class InitTargets:
     ) -> Tuple[dict, dict]:
         if not cl_extension_ids:
             cl_extension_ids = []
+        param_to_target = {
+            "clusterName": self.cluster_name,
+            "clusterNamespace": self.cluster_namespace,
+            "clusterLocation": self.location,
+            "customLocationName": self.custom_location_name,
+            "clExtensionIds": cl_extension_ids,
+            "schemaRegistryId": self.schema_registry_resource_id,
+            "adrNamespaceId": self.adr_namespace_resource_id,
+            "defaultDataflowInstanceCount": self.dataflow_profile_instances,
+            "brokerConfig": self.broker_config,
+            "trustConfig": self.trust_config,
+        }
+        # Drive the template's OPC UA connector condition; the instance features are injected
+        # directly (not via the features parameter), so gate on the parameter the condition reads.
+        if self.instance_features and self.instance_features.get("opcua", {}).get("mode") == "Disabled":
+            param_to_target["disableOpcUaFeature"] = True
         template, parameters = self._handle_apply_targets(
-            param_to_target={
-                "clusterName": self.cluster_name,
-                "clusterNamespace": self.cluster_namespace,
-                "clusterLocation": self.location,
-                "customLocationName": self.custom_location_name,
-                "clExtensionIds": cl_extension_ids,
-                "schemaRegistryId": self.schema_registry_resource_id,
-                "adrNamespaceId": self.adr_namespace_resource_id,
-                "defaultDataflowInstanceCount": self.dataflow_profile_instances,
-                "brokerConfig": self.broker_config,
-                "trustConfig": self.trust_config,
-            },
+            param_to_target=param_to_target,
             template_blueprint=TEMPLATE_BLUEPRINT_INSTANCE,
         )
 

--- a/azext_edge/edge/providers/orchestration/template.py
+++ b/azext_edge/edge/providers/orchestration/template.py
@@ -49,12 +49,12 @@ class TemplateBlueprint(NamedTuple):
 
 
 TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
-    commit_id="51dff082e4e1fbdb156c650f79917774cb4c0062",
+    commit_id="f9e05bed5c435135403c5a32264afebf14a409ec",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
-        "metadata": {"_generator": {"name": "bicep", "version": "0.46.1.21595", "templateHash": "6829492317291626106"}},
+        "metadata": {"_generator": {"name": "bicep", "version": "0.46.1.21595", "templateHash": "8485265132777030182"}},
         "definitions": {
             "_1.AdvancedConfig": {
                 "type": "object",
@@ -689,7 +689,7 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"certManager": "1.0.0", "secretStore": "1.5.2"},
+            "VERSIONS": {"certManager": "1.1.2", "secretStore": "1.5.3"},
             "TRAINS": {"certManager": "stable", "secretStore": "stable"},
         },
         "resources": {
@@ -769,14 +769,12 @@ TEMPLATE_BLUEPRINT_ENABLEMENT = TemplateBlueprint(
 )
 
 TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
-    commit_id="4a3ede7ce58e52e8eafb780adce8238d7e34b8cb",
+    commit_id="b1074766f704b8c51d9ef869a0c40b047733c7f7",
     content={
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
         "languageVersion": "2.0",
         "contentVersion": "1.0.0.0",
-        "metadata": {
-            "_generator": {"name": "bicep", "version": "0.46.1.21595", "templateHash": "17709006562362117864"}
-        },
+        "metadata": {"_generator": {"name": "bicep", "version": "0.46.1.21595", "templateHash": "6793523398905367306"}},
         "definitions": {
             "_1.AdvancedConfig": {
                 "type": "object",
@@ -1472,11 +1470,12 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "brokerConfig": {"$ref": "#/definitions/_1.BrokerConfig", "nullable": True},
             "trustConfig": {"$ref": "#/definitions/_1.TrustConfig", "defaultValue": {"source": "SelfSigned"}},
             "defaultDataflowInstanceCount": {"type": "int", "defaultValue": 1},
+            "disableOpcUaFeature": {"type": "bool", "defaultValue": False},
             "advancedConfig": {"$ref": "#/definitions/_1.AdvancedConfig", "defaultValue": {}},
         },
         "variables": {
-            "VERSIONS": {"iotOperations": "1.4.73"},
-            "TRAINS": {"iotOperations": "stable"},
+            "VERSIONS": {"iotOperations": "1.4.105"},
+            "TRAINS": {"iotOperations": "integration"},
             "HASH": "[coalesce(tryGet(parameters('advancedConfig'), 'resourceSuffix'), take(uniqueString(resourceGroup().id, parameters('clusterName'), parameters('clusterNamespace')), 5))]",
             "AIO_EXTENSION_SUFFIX": "[take(uniqueString(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName'))), 5)]",
             "CUSTOM_LOCATION_NAMESPACE": "[parameters('clusterNamespace')]",
@@ -1485,7 +1484,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
             "ISSUER_NAME": "[if(variables('customerManagedTrust'), parameters('trustConfig').settings.issuerName, format('{0}-aio-certificate-issuer', parameters('clusterNamespace')))]",
             "TRUST_CONFIG_MAP": "[if(variables('customerManagedTrust'), parameters('trustConfig').settings.configMapName, format('{0}-aio-ca-trust-bundle', parameters('clusterNamespace')))]",
             "TRUST_CONFIG_MAP_KEY": "[if(variables('customerManagedTrust'), parameters('trustConfig').settings.configMapKey, 'ca.crt')]",
-            "OPCUA_CONNECTOR_VERSION": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'connectors'), 'version'), '1.4.10')]",
+            "OPCUA_CONNECTOR_VERSION": "[coalesce(tryGet(tryGet(parameters('advancedConfig'), 'connectors'), 'version'), '1.4.13')]",
             "MQTT_SETTINGS": {
                 "brokerListenerServiceName": "aio-broker",
                 "brokerListenerPort": 18883,
@@ -1528,7 +1527,10 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
                 "name": "[resourceId('Microsoft.ExtendedLocation/customLocations', coalesce(parameters('customLocationName'), format('location-{0}', variables('HASH'))))]",
                 "type": "CustomLocation",
             },
+            "effectiveFeatures": "[if(parameters('disableOpcUaFeature'), union(coalesce(parameters('features'), createObject()), createObject('opcua', createObject('mode', 'Disabled', 'settings', createObject()))), parameters('features'))]",
             "opcUaConnectorTemplateName": "[format('azureiotoperationsconnectorforopcua-{0}', substring(uniqueString(resourceId('Microsoft.IoTOperations/instances', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))))), 0, 4))]",
+            "opcUaFeature": "[coalesce(coalesce(tryGet(parameters('features'), 'opcua'), tryGet(parameters('features'), 'connectors')), createObject())]",
+            "opcUaFeatureMode": "[if(parameters('disableOpcUaFeature'), 'Disabled', coalesce(tryGet(variables('opcUaFeature'), 'mode'), 'Stable'))]",
         },
         "resources": {
             "cluster": {
@@ -1575,7 +1577,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
                 "properties": {
                     "description": "An AIO instance.",
                     "schemaRegistryRef": {"resourceId": "[parameters('schemaRegistryId')]"},
-                    "features": "[parameters('features')]",
+                    "features": "[variables('effectiveFeatures')]",
                     "adrNamespaceRef": "[if(not(empty(parameters('adrNamespaceId'))), createObject('resourceId', parameters('adrNamespaceId')), null())]",
                 },
                 "dependsOn": ["customLocation"],
@@ -1691,6 +1693,7 @@ TEMPLATE_BLUEPRINT_INSTANCE = TemplateBlueprint(
                 "dependsOn": ["aioInstance", "customLocation"],
             },
             "opcUaConnectorTemplate": {
+                "condition": "[not(equals(variables('opcUaFeatureMode'), 'Disabled'))]",
                 "type": "Microsoft.IoTOperations/instances/akriConnectorTemplates",
                 "apiVersion": "2026-07-01",
                 "name": "[format('{0}/{1}', coalesce(parameters('aioInstanceName'), format('aio-{0}', variables('HASH'))), variables('opcUaConnectorTemplateName'))]",

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -209,6 +209,12 @@ class UpgradeManager:
         in-flight provisioning.
         """
         self._opcua_template_name_to_repair = None
+        opcua_mode = (
+            (self.instance_record.get("properties") or {}).get("features", {}).get("opcua", {}).get("mode")
+        )
+        # Disabled: no supervisor reconciles the template, so its PUT never reaches a terminal state.
+        if opcua_mode == "Disabled":
+            return False, None
         try:
             existing_templates = self.connector_templates.list(
                 instance_name=self.instance_name, resource_group_name=self.resource_group_name

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -209,9 +209,9 @@ class UpgradeManager:
         in-flight provisioning.
         """
         self._opcua_template_name_to_repair = None
-        opcua_mode = (
-            (self.instance_record.get("properties") or {}).get("features", {}).get("opcua", {}).get("mode")
-        )
+        # features (and its nested objects) may be absent or explicitly null on the record.
+        features = (self.instance_record.get("properties") or {}).get("features") or {}
+        opcua_mode = (features.get("opcua") or {}).get("mode")
         # Disabled: no supervisor reconciles the template, so its PUT never reaches a terminal state.
         if opcua_mode == "Disabled":
             return False, None

--- a/azext_edge/edge/providers/orchestration/upgrade2.py
+++ b/azext_edge/edge/providers/orchestration/upgrade2.py
@@ -38,9 +38,7 @@ from .common import (
     MIN_INSTANCE_VERSION_V1_FOR_V2_UPGRADE,
     MIN_INSTANCE_VERSION_V2,
     OPCUA_CONNECTOR_ENDPOINT_TYPE,
-    OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX,
     OPCUA_CONNECTOR_VERSION,
-    PROVISIONING_STATE_FAILED,
     PROVISIONING_STATE_SUCCESS,
     ConfigSyncModeType,
 )
@@ -212,11 +210,8 @@ class UpgradeManager:
     def _check_opcua_connector_template_needed(self) -> Tuple[bool, Optional[str]]:
         """Return (needed, repair_name) for the default OPC UA connector template.
 
-        The OPC UA supervisor requires a default ``akriConnectorTemplates`` resource (2608+) that
-        no CLI install path created historically. A prefix-matching template that exists but is in
-        a terminal ``Failed`` state is repaired in place by reusing its name (``repair_name``);
-        transient states (e.g. Accepted/Updating/Deleting) are left alone to avoid racing an
-        in-flight provisioning.
+        Skips entirely when OPC UA is disabled on the instance; otherwise delegates the prefix and
+        provisioning-state decision to the shared ConnectorTemplates helper.
         """
         self._opcua_template_name_to_repair = None
         # features (and its nested objects) may be absent or explicitly null on the record.
@@ -225,25 +220,11 @@ class UpgradeManager:
         # Disabled: no supervisor reconciles the template, so its PUT never reaches a terminal state.
         if opcua_mode == "Disabled":
             return False, None
-        try:
-            existing_templates = self.connector_templates.list(
-                instance_name=self.instance_name, resource_group_name=self.resource_group_name
-            )
-            for template in existing_templates:
-                if not (template.get("name") or "").lower().startswith(OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX):
-                    continue
-                if (template.get("provisioningState") or "").lower() == PROVISIONING_STATE_FAILED.lower():
-                    # Repair the existing resource in place by reusing its name.
-                    self._opcua_template_name_to_repair = template.get("name")
-                    logger.debug("Default OPC UA connector template exists but failed; will repair in place.")
-                    return True, self._opcua_template_name_to_repair
-                # Succeeded or a transient state: leave it alone.
-                logger.debug("Default OPC UA connector template already exists.")
-                return False, None
-            return True, None
-        except HttpResponseError as e:
-            logger.debug(f"Error checking OPC UA connector template: {e}")
-            return False, None
+        needed, repair_name = self.connector_templates.check_default_opcua_template_needed(
+            instance_name=self.instance_name, resource_group_name=self.resource_group_name
+        )
+        self._opcua_template_name_to_repair = repair_name
+        return needed, repair_name
 
     def _create_default_opcua_connector_template(self, headers: dict) -> dict:
         return self.connector_templates.create_default_opcua_template(

--- a/azext_edge/tests/edge/init/int/test_init_int.py
+++ b/azext_edge/tests/edge/init/int/test_init_int.py
@@ -19,6 +19,7 @@ from azext_edge.edge.providers.orchestration.common import (
     EXTENSION_TYPE_CM,
     EXTENSION_TYPE_OPS,
     EXTENSION_TYPE_SSC,
+    OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX,
 )
 
 from ....generators import generate_random_string
@@ -220,6 +221,7 @@ def assert_aio_instance(
     location: Optional[str] = None,
     tags: Optional[str] = None,
     trust_settings: Optional[dict] = None,
+    feature: Optional[str] = None,
     **_,
 ):
     # check extensions installed
@@ -281,6 +283,18 @@ def assert_aio_instance(
     assert expected_custom_location in tree
     if not trust_settings:
         assert "cert-manager" in tree
+
+    # OPC UA disabled: the instance must reflect it and no default connector template should exist.
+    if feature and "opcua.mode=disabled" in str(feature).lower():
+        assert instance_props.get("features", {}).get("opcua", {}).get("mode") == "Disabled"
+        templates = run(f"az iot ops connector template list -g {resource_group} --instance {instance_name}") or []
+        default_templates = [
+            t for t in templates if str(t.get("name", "")).startswith(OPCUA_CONNECTOR_TEMPLATE_NAME_PREFIX)
+        ]
+        assert not default_templates, (
+            "Expected no default OPC UA connector template while OPC UA is disabled, found: "
+            f"{[t.get('name') for t in default_templates]}"
+        )
 
 
 def assert_broker_args(

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -631,6 +631,23 @@ def test_instance_update_opcua_mode(
         content_type="application/json",
     )
 
+    prior_opcua_mode = (initial_feat_state or {}).get("opcua", {}).get("mode")
+    new_opcua_mode = features_scenario["expected"].get("opcua", {}).get("mode")
+    expects_backfill = prior_opcua_mode == "Disabled" and new_opcua_mode not in (None, "Disabled")
+    if expects_backfill:
+        # Re-enabling OPC UA backfills the default connector template that create omitted while disabled.
+        connector_put_re = re.compile(re.escape(instance_endpoint.split("?")[0]) + r"/akriConnectorTemplates/[^/?]+")
+        mocked_responses.add(
+            method=responses.PUT,
+            url=connector_put_re,
+            json={
+                "name": "azureiotoperationsconnectorforopcua-abcd",
+                "properties": {"provisioningState": "Succeeded"},
+            },
+            status=200,
+            content_type="application/json",
+        )
+
     result = update_instance(
         cmd=mocked_cmd,
         instance_name=instance_name,
@@ -638,11 +655,16 @@ def test_instance_update_opcua_mode(
         instance_features=features_scenario["inputs"],
         wait_sec=0,
     )
-    assert len(mocked_responses.calls) == 2
 
     update_request = json.loads(mocked_responses.calls[1].request.body)
     assert update_request["properties"]["features"] == features_scenario["expected"]
     assert result == updated_record
+
+    if expects_backfill:
+        put_paths = [c.request.url for c in mocked_responses.calls if c.request.method == "PUT"]
+        assert any("/akriConnectorTemplates/" in p for p in put_paths), "expected connector template backfill PUT"
+    else:
+        assert len(mocked_responses.calls) == 2
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
+++ b/azext_edge/tests/edge/orchestration/resources/test_instances_unit.py
@@ -631,15 +631,23 @@ def test_instance_update_opcua_mode(
         content_type="application/json",
     )
 
-    prior_opcua_mode = (initial_feat_state or {}).get("opcua", {}).get("mode")
+    # Enabling OPC UA triggers a backfill: list existing templates, create the default if absent.
     new_opcua_mode = features_scenario["expected"].get("opcua", {}).get("mode")
-    expects_backfill = prior_opcua_mode == "Disabled" and new_opcua_mode not in (None, "Disabled")
+    expects_backfill = new_opcua_mode not in (None, "Disabled")
     if expects_backfill:
-        # Re-enabling OPC UA backfills the default connector template that create omitted while disabled.
-        connector_put_re = re.compile(re.escape(instance_endpoint.split("?")[0]) + r"/akriConnectorTemplates/[^/?]+")
+        base_url = instance_endpoint.split("?")[0]
+        list_re = re.compile(re.escape(base_url) + r"/akriConnectorTemplates(\?|$)")
+        mocked_responses.add(
+            method=responses.GET,
+            url=list_re,
+            json={"value": []},
+            status=200,
+            content_type="application/json",
+        )
+        create_re = re.compile(re.escape(base_url) + r"/akriConnectorTemplates/[^/?]+")
         mocked_responses.add(
             method=responses.PUT,
-            url=connector_put_re,
+            url=create_re,
             json={
                 "name": "azureiotoperationsconnectorforopcua-abcd",
                 "properties": {"provisioningState": "Succeeded"},

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -501,11 +501,9 @@ def test_init_targets_opcua_mode(target_scenario: dict):
     ],
 )
 def test_init_targets_opcua_disabled_omits_connector_template(instance_features):
-    """When opcua.mode=Disabled, the OPC UA akriConnectorTemplates resource must not be deployed
-    unconditionally. With the feature off the OPC UA supervisor is never deployed, so the
-    akriConnectorTemplates resource never reaches a terminal provisioning state and hangs
-    `az iot ops create`. A correct template either omits the resource or gates it with an ARM
-    condition.
+    """When opcua.mode=Disabled, the OPC UA akriConnectorTemplates resource must be omitted from
+    the full and RESOURCES templates. With the feature off the OPC UA supervisor is never deployed,
+    so the resource would never reach a terminal provisioning state and would hang `az iot ops create`.
     """
     targets = InitTargets(
         cluster_name=generate_random_string(),
@@ -518,19 +516,9 @@ def test_init_targets_opcua_disabled_omits_connector_template(instance_features)
     extension_ids = [generate_random_string()]
 
     for phase in (None, InstancePhase.RESOURCES):
-        template, parameters = targets.get_ops_instance_template(extension_ids, phase=phase)
-        connector_template = template["resources"].get("opcUaConnectorTemplate")
-        not_deployed = connector_template is None
-        # If the resource is still present, its ARM condition must be driven off by a supplied
-        # parameter; otherwise the condition defaults to enabled and the template still deploys.
-        gated = bool(
-            connector_template
-            and connector_template.get("condition")
-            and parameters.get("disableOpcUaFeature", {}).get("value") is True
-        )
-        assert not_deployed or gated, (
-            f"Phase {phase}: opcUaConnectorTemplate is deployed unconditionally while "
-            "opcua.mode=Disabled; expected it to be omitted or gated by a driven ARM condition."
+        template, _ = targets.get_ops_instance_template(extension_ids, phase=phase)
+        assert "opcUaConnectorTemplate" not in template["resources"], (
+            f"Phase {phase}: opcUaConnectorTemplate must be omitted when opcua.mode=Disabled."
         )
 
 
@@ -553,8 +541,13 @@ def test_init_targets_opcua_enabled_keeps_connector_template(instance_features):
         instance_name=generate_random_string(),
         instance_features=instance_features,
     )
-    template, _ = targets.get_ops_instance_template([generate_random_string()], phase=InstancePhase.RESOURCES)
-    assert "opcUaConnectorTemplate" in template["resources"]
+    extension_ids = [generate_random_string()]
+
+    for phase in (None, InstancePhase.RESOURCES):
+        template, _ = targets.get_ops_instance_template(extension_ids, phase=phase)
+        assert "opcUaConnectorTemplate" in template["resources"], (
+            f"Phase {phase}: opcUaConnectorTemplate must be present when opcua is enabled."
+        )
 
 
 @pytest.mark.parametrize(

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -518,13 +518,19 @@ def test_init_targets_opcua_disabled_omits_connector_template(instance_features)
     extension_ids = [generate_random_string()]
 
     for phase in (None, InstancePhase.RESOURCES):
-        template, _ = targets.get_ops_instance_template(extension_ids, phase=phase)
+        template, parameters = targets.get_ops_instance_template(extension_ids, phase=phase)
         connector_template = template["resources"].get("opcUaConnectorTemplate")
         not_deployed = connector_template is None
-        gated = bool(connector_template and connector_template.get("condition"))
+        # If the resource is still present, its ARM condition must be driven off by a supplied
+        # parameter; otherwise the condition defaults to enabled and the template still deploys.
+        gated = bool(
+            connector_template
+            and connector_template.get("condition")
+            and parameters.get("disableOpcUaFeature", {}).get("value") is True
+        )
         assert not_deployed or gated, (
             f"Phase {phase}: opcUaConnectorTemplate is deployed unconditionally while "
-            "opcua.mode=Disabled; expected it to be omitted or gated by an ARM condition."
+            "opcua.mode=Disabled; expected it to be omitted or gated by a driven ARM condition."
         )
 
 

--- a/azext_edge/tests/edge/orchestration/test_targets_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_targets_unit.py
@@ -495,6 +495,63 @@ def test_init_targets_opcua_mode(target_scenario: dict):
 
 
 @pytest.mark.parametrize(
+    "instance_features",
+    [
+        ["opcua.mode=Disabled"],
+    ],
+)
+def test_init_targets_opcua_disabled_omits_connector_template(instance_features):
+    """When opcua.mode=Disabled, the OPC UA akriConnectorTemplates resource must not be deployed
+    unconditionally. With the feature off the OPC UA supervisor is never deployed, so the
+    akriConnectorTemplates resource never reaches a terminal provisioning state and hangs
+    `az iot ops create`. A correct template either omits the resource or gates it with an ARM
+    condition.
+    """
+    targets = InitTargets(
+        cluster_name=generate_random_string(),
+        resource_group_name=generate_random_string(),
+        schema_registry_resource_id=get_schema_registry_id(),
+        adr_namespace_resource_id=get_ns_resource_id(),
+        instance_name=generate_random_string(),
+        instance_features=instance_features,
+    )
+    extension_ids = [generate_random_string()]
+
+    for phase in (None, InstancePhase.RESOURCES):
+        template, _ = targets.get_ops_instance_template(extension_ids, phase=phase)
+        connector_template = template["resources"].get("opcUaConnectorTemplate")
+        not_deployed = connector_template is None
+        gated = bool(connector_template and connector_template.get("condition"))
+        assert not_deployed or gated, (
+            f"Phase {phase}: opcUaConnectorTemplate is deployed unconditionally while "
+            "opcua.mode=Disabled; expected it to be omitted or gated by an ARM condition."
+        )
+
+
+@pytest.mark.parametrize(
+    "instance_features",
+    [
+        None,
+        ["opcua.mode=Stable"],
+    ],
+)
+def test_init_targets_opcua_enabled_keeps_connector_template(instance_features):
+    """OPC UA enabled (default or Stable) must still deploy the connector template; the disabled
+    guard must not over-remove it.
+    """
+    targets = InitTargets(
+        cluster_name=generate_random_string(),
+        resource_group_name=generate_random_string(),
+        schema_registry_resource_id=get_schema_registry_id(),
+        adr_namespace_resource_id=get_ns_resource_id(),
+        instance_name=generate_random_string(),
+        instance_features=instance_features,
+    )
+    template, _ = targets.get_ops_instance_template([generate_random_string()], phase=InstancePhase.RESOURCES)
+    assert "opcUaConnectorTemplate" in template["resources"]
+
+
+@pytest.mark.parametrize(
     "cm_config, expected_config",
     [
         (None, get_default_cm_config()),

--- a/azext_edge/tests/edge/orchestration/test_template_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_template_unit.py
@@ -151,11 +151,11 @@ def test_template_blueprint(content: dict):
 
 EXTENSION_CONFIGS = {
     "enablement": [
-        (EXTENSION_TYPE_CM, "1.0.0", "stable"),
-        (EXTENSION_TYPE_SSC, "1.5.2", "stable"),
+        (EXTENSION_TYPE_CM, "1.1.2", "stable"),
+        (EXTENSION_TYPE_SSC, "1.5.3", "stable"),
     ],
     "instance": [
-        (EXTENSION_TYPE_OPS, "1.4.73", "stable"),
+        (EXTENSION_TYPE_OPS, "1.4.105", "integration"),
     ],
 }
 

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -2827,6 +2827,8 @@ def test_check_opcua_connector_template_needed_disabled():
 
     assert needed is False
     assert repair_name is None
+
+
 def build_ext_upgrade_state(
     ext_type: str = EXTENSION_TYPE_CM,
     current_version: Optional[str] = "1.4.73",

--- a/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
+++ b/azext_edge/tests/edge/orchestration/test_upgrade2_unit.py
@@ -2800,3 +2800,24 @@ def test_opcua_connector_version_matches_template_tag():
         f"tag stamped by the instance template ({template_tag}); update the constant during the "
         "release bump so create and upgrade stamp the same tag."
     )
+
+
+def test_check_opcua_connector_template_needed_disabled():
+    """Upgrade must not create the default OPC UA connector template when the instance has
+    opcua.mode=Disabled. With the feature off the OPC UA supervisor is not deployed, so the
+    akriConnectorTemplates PUT never reaches a terminal state and hangs the upgrade.
+    """
+    from azext_edge.edge.providers.orchestration.upgrade2 import UpgradeManager
+
+    manager = UpgradeManager.__new__(UpgradeManager)
+    manager.instance_name = generate_random_string()
+    manager.resource_group_name = generate_random_string()
+    manager._opcua_template_name_to_repair = None
+    manager.instance_record = {"properties": {"features": {"opcua": {"mode": "Disabled"}}}}
+    manager.connector_templates = Mock()
+    manager.connector_templates.list.return_value = []
+
+    needed, repair_name = manager._check_opcua_connector_template_needed()
+
+    assert needed is False
+    assert repair_name is None


### PR DESCRIPTION
## Overview

- Fixes an issue where creating or upgrading an Azure IoT Operations instance with the OPC UA feature disabled could hang until the operation timed out.
- Updates the bundled Azure IoT Operations deployment templates to the 2609 release.
- Adds automated test coverage for the OPC UA disabled scenario.
