### PR TITLE
fix(support): handle consolidated Arc telemetry agent

### DIFF
--- a/azext_edge/edge/providers/support/arcagents.py
+++ b/azext_edge/edge/providers/support/arcagents.py
@@ -21,6 +21,7 @@ from .base import (
 logger = get_logger(__name__)
 
 MONIKER = "arcagents"
+ARC_TELEMETRY_AGENTS = ("metrics-agent", "telemetry-agent")
 ARC_AGENTS = [
     ("cluster-identity-operator", False),  # (component, has_services)
     ("clusterconnect-agent", False),
@@ -30,6 +31,7 @@ ARC_AGENTS = [
     ("kube-aad-proxy", True),
     ("cluster-metadata-operator", False),
     ("metrics-agent", False),
+    ("telemetry-agent", False),
     ("resource-sync-agent", False),
 ]
 

--- a/azext_edge/tests/edge/support/create_bundle_int/helpers.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/helpers.py
@@ -12,7 +12,7 @@ import pytest
 from azure.cli.core.azclierror import CLIInternalError
 from azext_edge.edge.common import OpsServiceType
 from azext_edge.edge.providers.edge_api.base import EdgeApiManager, EdgeResourceApi
-from azext_edge.edge.providers.support.arcagents import ARC_AGENTS
+from azext_edge.edge.providers.support.arcagents import ARC_AGENTS, ARC_TELEMETRY_AGENTS
 from ....helpers import (
     PLURAL_KEY,
     find_extra_or_missing_names,
@@ -487,7 +487,7 @@ def get_file_map(  # noqa: C901
     file_map = {"__namespaces__": {}}
 
     # by default, there will be arc agents, meta and meso in every bundle
-    num_additional_services = len(ARC_AGENTS)
+    num_additional_services = 0
     meta_path = path.join(BASE_ZIP_PATH, aio_namespace, "meta")
     meso_path = path.join(BASE_ZIP_PATH, aio_namespace, "meso")
     if meta_path in walk_result:
@@ -500,7 +500,9 @@ def get_file_map(  # noqa: C901
         file_map["__namespaces__"]["arc"] = arc_namespace
         for agent, _ in ARC_AGENTS:
             agent_path = path.join(BASE_ZIP_PATH, arc_namespace, "arcagents", agent)
-            file_map["arc"][agent] = convert_file_names(walk_result[agent_path]["files"])
+            if agent_path in walk_result:
+                file_map["arc"][agent] = convert_file_names(walk_result[agent_path]["files"])
+        num_additional_services += len(file_map["arc"])
 
     # TODO: explain the magic numbers (1, 2 better). Might need some refactoring too
     if mq_traces and path.join(ops_path, "traces") in walk_result:
@@ -875,7 +877,14 @@ def _clean_up_folders(
         assert not level_2["files"]
     if arc_namespace:
         level_2 = walk_result.pop(path.join(BASE_ZIP_PATH, arc_namespace, "arcagents"))
-        assert level_2["folders"] == [agent[0] for agent in ARC_AGENTS], f"Mismatch; folders: [{level_2['folders']}]"
+        actual_agents = set(level_2["folders"])
+        expected_agents = {agent[0] for agent in ARC_AGENTS}
+        required_agents = expected_agents - set(ARC_TELEMETRY_AGENTS)
+        assert required_agents.issubset(actual_agents), f"Mismatch; folders: [{level_2['folders']}]"
+        assert actual_agents.issubset(expected_agents), f"Unexpected folders: [{level_2['folders']}]"
+        assert actual_agents.intersection(ARC_TELEMETRY_AGENTS), (
+            f"Expected one of {ARC_TELEMETRY_AGENTS}; folders: [{level_2['folders']}]"
+        )
         assert not level_2["files"]
 
 

--- a/azext_edge/tests/edge/support/create_bundle_int/test_arcagents_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_arcagents_int.py
@@ -7,7 +7,7 @@
 import pytest
 from knack.log import get_logger
 from azext_edge.edge.common import OpsServiceType
-from azext_edge.edge.providers.support.arcagents import ARC_AGENTS
+from azext_edge.edge.providers.support.arcagents import ARC_AGENTS, ARC_TELEMETRY_AGENTS
 from ....helpers import get_multi_kubectl_workload_items
 from .helpers import (
     check_workload_resource_files,
@@ -27,6 +27,7 @@ AGENT_RESOURCE_PREFIXES = {
     "kube-aad-proxy": "kube-aad-proxy",
     "cluster-metadata-operator": "cluster-metadata-operator",
     "metrics-agent": "metrics-agent",
+    "telemetry-agent": "telemetry-agent",
     "resource-sync-agent": "resource-sync-agent"
 }
 AGENT_WORKLOAD_TYPES = ["deployment", "pod", "replicaset"]
@@ -47,9 +48,11 @@ def test_create_bundle_arcagents(cluster_connection, tracked_files):
     walk_result, bundle_path = run_bundle_command(command=command, tracked_files=tracked_files)
     files = get_file_map(walk_result=walk_result, ops_service=ops_service)
     agents_file_map = files["arc"]
+    assert set(agents_file_map).intersection(ARC_TELEMETRY_AGENTS)
 
-    for agent, has_service in ARC_AGENTS:
-        file_map = agents_file_map[agent]
+    service_by_agent = dict(ARC_AGENTS)
+    for agent, file_map in agents_file_map.items():
+        has_service = service_by_agent[agent]
 
         assert set(file_map.keys()).issubset(
             set(AGENT_SERVICE_WORKLOAD_TYPES if has_service else AGENT_WORKLOAD_TYPES)

--- a/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
+++ b/azext_edge/tests/edge/support/create_bundle_int/test_auto_int.py
@@ -9,7 +9,6 @@ from os import mkdir, path
 from knack.log import get_logger
 from typing import Dict, List, Optional, Tuple
 from azext_edge.edge.common import OpsServiceType
-from azext_edge.edge.providers.support.arcagents import ARC_AGENTS
 from .helpers import (
     assert_file_names,
     process_top_levels,
@@ -113,7 +112,14 @@ def test_create_bundle(cluster_connection, ops_service, bundle_dir, mq_traces, t
 
     # Level 2 and 3 - bottom
     is_billing_included = OpsServiceType.billing.value in expected_services
-    actual_walk_result = len(expected_services) + int(is_billing_included) + len(ARC_AGENTS)
+    arc_agent_count = 0
+    if arc_namespace:
+        arc_agent_path = path.join(BASE_ZIP_PATH, arc_namespace, "arcagents")
+        arc_agent_count = sum(
+            directory.startswith(f"{arc_agent_path}{path.sep}")
+            for directory in walk_result
+        )
+    actual_walk_result = len(expected_services) + int(is_billing_included) + arc_agent_count
 
     assert len(walk_result) == actual_walk_result
 


### PR DESCRIPTION
• Restore integration-test compatibility with the latest Azure Arc agent release.
• Preserve support-bundle behavior across both previous and current Arc deployments.


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
